### PR TITLE
gh-152907: Restore cooked output flags around the input hook in the new REPL

### DIFF
--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -735,13 +735,9 @@ class UnixConsole(Console):
             return self.__run_input_hook
 
     def __run_input_hook(self):
-        # Input-hook callbacks (GUI toolkit event loops, and any warning,
-        # traceback or print they emit) expect normal cooked-mode output, but
-        # pyrepl runs with OPOST disabled so it can drive the cursor itself.
-        # Temporarily restore the terminal's saved output flags around the
-        # hook so that '\n' is translated to '\r\n' as it was under the
-        # readline REPL, then re-enter raw mode.  Only oflag is toggled --
-        # re-enabling ECHO/ICANON at the prompt would be wrong.  See gh-152907.
+        # gh-152907: input hooks expect cooked output, but pyrepl runs with
+        # OPOST disabled.  Restore the saved output flags around the hook
+        # (only oflag; input must stay raw at the prompt).
         cooked = self.__rawtermstate.copy()
         cooked.oflag = self.__svtermstate.oflag
         self.__input_fd_set(cooked)

--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -491,6 +491,7 @@ class UnixConsole(Console):
         raw.cc[termios.VMIN] = b"\x01"
         raw.cc[termios.VTIME] = b"\x00"
         self.__input_fd_set(raw)
+        self.__rawtermstate = raw
 
         # Apple Terminal will re-wrap lines for us unless we preempt the
         # damage.
@@ -731,7 +732,23 @@ class UnixConsole(Console):
         # avoid inline imports here so the repl doesn't get flooded
         # with import logging from -X importtime=2
         if posix is not None and posix._is_inputhook_installed():
-            return posix._inputhook
+            return self.__run_input_hook
+
+    def __run_input_hook(self):
+        # Input-hook callbacks (GUI toolkit event loops, and any warning,
+        # traceback or print they emit) expect normal cooked-mode output, but
+        # pyrepl runs with OPOST disabled so it can drive the cursor itself.
+        # Temporarily restore the terminal's saved output flags around the
+        # hook so that '\n' is translated to '\r\n' as it was under the
+        # readline REPL, then re-enter raw mode.  Only oflag is toggled --
+        # re-enabling ECHO/ICANON at the prompt would be wrong.  See gh-152907.
+        cooked = self.__rawtermstate.copy()
+        cooked.oflag = self.__svtermstate.oflag
+        self.__input_fd_set(cooked)
+        try:
+            posix._inputhook()
+        finally:
+            self.__input_fd_set(self.__rawtermstate)
 
     def __enable_bracketed_paste(self) -> None:
         os.write(self.output_fd, b"\x1b[?2004h")

--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -746,7 +746,7 @@ class UnixConsole(Console):
         cooked.oflag = self.__svtermstate.oflag
         self.__input_fd_set(cooked)
         try:
-            posix._inputhook()
+            return posix._inputhook()
         finally:
             self.__input_fd_set(self.__rawtermstate)
 

--- a/Lib/test/test_pyrepl/test_unix_console.py
+++ b/Lib/test/test_pyrepl/test_unix_console.py
@@ -5,7 +5,6 @@ import select
 import signal
 import sys
 import threading
-import time
 import unittest
 from functools import partial
 from _colorize import ANSIColors
@@ -450,9 +449,11 @@ class TestUnixConsoleInputHook(TestCase):
     def test_input_hook_output_is_cooked(self):
         master_fd, slave_fd = pty.openpty()
 
-        # Continuously drain the master side, like a real terminal.  This is
-        # required because pyrepl switches the terminal mode with TCSADRAIN,
-        # which blocks until queued output has been consumed.
+        # Drain the master side continuously, like a real terminal would.
+        # This cannot be deferred until after the hook call: pyrepl switches
+        # the terminal mode with TCSADRAIN, which on some platforms (e.g.
+        # macOS) blocks until the queued output has actually been read from
+        # the master side, so an undrained pty deadlocks the mode switch.
         chunks = []
         reading = True
 
@@ -502,7 +503,7 @@ class TestUnixConsoleInputHook(TestCase):
                 mock_posix._inputhook.side_effect = fake_hook
                 hook = console.input_hook
                 self.assertIsNotNone(hook)
-                hook()
+                self.assertEqual(hook(), 0)
 
             # The hook ran with cooked output (OPOST on)...
             self.assertTrue(observed["oflag"] & _termios.OPOST)
@@ -512,8 +513,20 @@ class TestUnixConsoleInputHook(TestCase):
             console.restore()
             os.close(slave_fd)
 
-        # Give the reader a moment to drain the hook's output.
-        time.sleep(0.2)
+        # No sleep needed: the TCSADRAIN switch back to raw mode did not
+        # return until the hook's output was drained, so after joining the
+        # reader and emptying the master nothing is left in flight.
+        reading = False
+        reader_thread.join()
+        while select.select([master_fd], [], [], 0)[0]:
+            try:
+                extra = os.read(master_fd, 4096)
+            except OSError:
+                break
+            if not extra:
+                break
+            chunks.append(extra)
+
         data = b"".join(chunks)
         # The tty translated the hook's bare '\n' into '\r\n'.
         self.assertIn(b"line1\r\nline2\r\n", data)

--- a/Lib/test/test_pyrepl/test_unix_console.py
+++ b/Lib/test/test_pyrepl/test_unix_console.py
@@ -445,34 +445,21 @@ class TestUnixConsoleInputHook(TestCase):
 
     def test_input_hook_output_is_cooked(self):
         master_fd, slave_fd = pty.openpty()
+        self.addCleanup(os.close, master_fd)
 
-        # Drain the master continuously: on some platforms (e.g. macOS)
-        # tcsetattr(TCSADRAIN) blocks until the master side is read, so an
-        # undrained pty would deadlock the mode switch.
-        chunks = []
-        reading = True
-
-        def reader():
-            while reading:
-                r, _, _ = select.select([master_fd], [], [], 0.1)
-                if master_fd in r:
-                    try:
-                        data = os.read(master_fd, 4096)
-                    except OSError:
-                        break
-                    if not data:
-                        break
-                    chunks.append(data)
-
-        reader_thread = threading.Thread(target=reader)
-        reader_thread.start()
-
-        def cleanup():
-            nonlocal reading
-            reading = False
-            reader_thread.join()
-            os.close(master_fd)
-        self.addCleanup(cleanup)
+        # tcsetattr(TCSADRAIN) blocks on some platforms (e.g. macOS) while the
+        # master still holds unread output, so empty it before each mode switch.
+        def drain():
+            out = b""
+            while select.select([master_fd], [], [], 0)[0]:
+                try:
+                    data = os.read(master_fd, 4096)
+                except OSError:
+                    break
+                if not data:
+                    break
+                out += data
+            return out
 
         # Start from a cooked terminal so there are saved flags to restore.
         attr = _termios.tcgetattr(slave_fd)
@@ -482,6 +469,7 @@ class TestUnixConsoleInputHook(TestCase):
         console = UnixConsole(slave_fd, slave_fd, term="xterm")
         console.prepare()
         try:
+            drain()  # discard prepare()'s own setup sequences
             # pyrepl's own rendering runs with OPOST cleared.
             self.assertFalse(_termios.tcgetattr(slave_fd)[1] & _termios.OPOST)
 
@@ -490,6 +478,7 @@ class TestUnixConsoleInputHook(TestCase):
             def fake_hook():
                 observed["oflag"] = _termios.tcgetattr(slave_fd)[1]
                 os.write(slave_fd, b"line1\nline2\n")
+                observed["output"] = drain()
                 return 0
 
             with patch("_pyrepl.unix_console.posix") as mock_posix:
@@ -503,24 +492,27 @@ class TestUnixConsoleInputHook(TestCase):
             self.assertTrue(observed["oflag"] & _termios.OPOST)
             # ...and raw mode was restored afterwards.
             self.assertFalse(_termios.tcgetattr(slave_fd)[1] & _termios.OPOST)
+            # The tty translated the hook's bare '\n' into '\r\n'.
+            self.assertEqual(observed["output"], b"line1\r\nline2\r\n")
         finally:
-            console.restore()
-            os.close(slave_fd)
+            # restore() writes and only then switches modes, so there is no
+            # point left to drain from here; keep the master empty elsewhere.
+            stop = threading.Event()
 
-        # The switch back to raw mode already drained the hook's output, so
-        # joining the reader is enough -- no sleep needed.
-        reading = False
-        reader_thread.join()
-        while select.select([master_fd], [], [], 0)[0]:
+            def pump():
+                while not stop.is_set():
+                    if select.select([master_fd], [], [], 0.05)[0]:
+                        try:
+                            if not os.read(master_fd, 4096):
+                                break
+                        except OSError:
+                            break
+
+            pump_thread = threading.Thread(target=pump)
+            pump_thread.start()
             try:
-                extra = os.read(master_fd, 4096)
-            except OSError:
-                break
-            if not extra:
-                break
-            chunks.append(extra)
-
-        data = b"".join(chunks)
-        # The tty translated the hook's bare '\n' into '\r\n'.
-        self.assertIn(b"line1\r\nline2\r\n", data)
-        self.assertNotIn(b"line1\nline2\n", data)
+                console.restore()
+            finally:
+                stop.set()
+                pump_thread.join()
+                os.close(slave_fd)

--- a/Lib/test/test_pyrepl/test_unix_console.py
+++ b/Lib/test/test_pyrepl/test_unix_console.py
@@ -440,20 +440,15 @@ except ImportError:
 @unittest.skipIf(is_android or is_apple_mobile or is_wasm32,
                  "pty is not available on this platform")
 class TestUnixConsoleInputHook(TestCase):
-    # gh-152907: pyrepl runs with OPOST disabled so it can drive the cursor
-    # itself, but input-hook callbacks (GUI event loops, and any warning,
-    # traceback or print they emit) expect normal cooked-mode output.  The
-    # console must restore cooked output around the hook call so that '\n' is
-    # translated back to '\r\n', then re-enter raw mode.
+    # gh-152907: the console must restore cooked output (OPOST) around
+    # input-hook calls, then re-enter raw mode.
 
     def test_input_hook_output_is_cooked(self):
         master_fd, slave_fd = pty.openpty()
 
-        # Drain the master side continuously, like a real terminal would.
-        # This cannot be deferred until after the hook call: pyrepl switches
-        # the terminal mode with TCSADRAIN, which on some platforms (e.g.
-        # macOS) blocks until the queued output has actually been read from
-        # the master side, so an undrained pty deadlocks the mode switch.
+        # Drain the master continuously: on some platforms (e.g. macOS)
+        # tcsetattr(TCSADRAIN) blocks until the master side is read, so an
+        # undrained pty would deadlock the mode switch.
         chunks = []
         reading = True
 
@@ -479,8 +474,7 @@ class TestUnixConsoleInputHook(TestCase):
             os.close(master_fd)
         self.addCleanup(cleanup)
 
-        # Establish a normal cooked terminal as the saved state so the fix has
-        # something to restore around the hook call.
+        # Start from a cooked terminal so there are saved flags to restore.
         attr = _termios.tcgetattr(slave_fd)
         attr[1] |= _termios.OPOST | _termios.ONLCR
         _termios.tcsetattr(slave_fd, _termios.TCSANOW, attr)
@@ -513,9 +507,8 @@ class TestUnixConsoleInputHook(TestCase):
             console.restore()
             os.close(slave_fd)
 
-        # No sleep needed: the TCSADRAIN switch back to raw mode did not
-        # return until the hook's output was drained, so after joining the
-        # reader and emptying the master nothing is left in flight.
+        # The switch back to raw mode already drained the hook's output, so
+        # joining the reader is enough -- no sleep needed.
         reading = False
         reader_thread.join()
         while select.select([master_fd], [], [], 0)[0]:

--- a/Lib/test/test_pyrepl/test_unix_console.py
+++ b/Lib/test/test_pyrepl/test_unix_console.py
@@ -10,6 +10,7 @@ import unittest
 from functools import partial
 from _colorize import ANSIColors
 from test.support import force_color, os_helper, force_not_colorized_test_class
+from test.support import is_android, is_apple_mobile, is_wasm32
 from test.support import threading_helper
 
 from unittest import TestCase
@@ -437,6 +438,8 @@ except ImportError:
 
 @unittest.skipIf(sys.platform == "win32", "No Unix console on Windows")
 @unittest.skipUnless(pty, "requires pty")
+@unittest.skipIf(is_android or is_apple_mobile or is_wasm32,
+                 "pty is not available on this platform")
 class TestUnixConsoleInputHook(TestCase):
     # gh-152907: pyrepl runs with OPOST disabled so it can drive the cursor
     # itself, but input-hook callbacks (GUI event loops, and any warning,

--- a/Lib/test/test_pyrepl/test_unix_console.py
+++ b/Lib/test/test_pyrepl/test_unix_console.py
@@ -1,9 +1,11 @@
 import errno
 import itertools
 import os
+import select
 import signal
 import sys
 import threading
+import time
 import unittest
 from functools import partial
 from _colorize import ANSIColors
@@ -424,3 +426,92 @@ class TestUnixConsoleEIOHandling(TestCase):
 
         # EIO error should be handled gracefully in restore()
         console.restore()
+
+
+try:
+    import pty
+    import termios as _termios
+except ImportError:
+    pty = None
+
+
+@unittest.skipIf(sys.platform == "win32", "No Unix console on Windows")
+@unittest.skipUnless(pty, "requires pty")
+class TestUnixConsoleInputHook(TestCase):
+    # gh-152907: pyrepl runs with OPOST disabled so it can drive the cursor
+    # itself, but input-hook callbacks (GUI event loops, and any warning,
+    # traceback or print they emit) expect normal cooked-mode output.  The
+    # console must restore cooked output around the hook call so that '\n' is
+    # translated back to '\r\n', then re-enter raw mode.
+
+    def test_input_hook_output_is_cooked(self):
+        master_fd, slave_fd = pty.openpty()
+
+        # Continuously drain the master side, like a real terminal.  This is
+        # required because pyrepl switches the terminal mode with TCSADRAIN,
+        # which blocks until queued output has been consumed.
+        chunks = []
+        reading = True
+
+        def reader():
+            while reading:
+                r, _, _ = select.select([master_fd], [], [], 0.1)
+                if master_fd in r:
+                    try:
+                        data = os.read(master_fd, 4096)
+                    except OSError:
+                        break
+                    if not data:
+                        break
+                    chunks.append(data)
+
+        reader_thread = threading.Thread(target=reader)
+        reader_thread.start()
+
+        def cleanup():
+            nonlocal reading
+            reading = False
+            reader_thread.join()
+            os.close(master_fd)
+        self.addCleanup(cleanup)
+
+        # Establish a normal cooked terminal as the saved state so the fix has
+        # something to restore around the hook call.
+        attr = _termios.tcgetattr(slave_fd)
+        attr[1] |= _termios.OPOST | _termios.ONLCR
+        _termios.tcsetattr(slave_fd, _termios.TCSANOW, attr)
+
+        console = UnixConsole(slave_fd, slave_fd, term="xterm")
+        console.prepare()
+        try:
+            # pyrepl's own rendering runs with OPOST cleared.
+            self.assertFalse(_termios.tcgetattr(slave_fd)[1] & _termios.OPOST)
+
+            observed = {}
+
+            def fake_hook():
+                observed["oflag"] = _termios.tcgetattr(slave_fd)[1]
+                os.write(slave_fd, b"line1\nline2\n")
+                return 0
+
+            with patch("_pyrepl.unix_console.posix") as mock_posix:
+                mock_posix._is_inputhook_installed.return_value = True
+                mock_posix._inputhook.side_effect = fake_hook
+                hook = console.input_hook
+                self.assertIsNotNone(hook)
+                hook()
+
+            # The hook ran with cooked output (OPOST on)...
+            self.assertTrue(observed["oflag"] & _termios.OPOST)
+            # ...and raw mode was restored afterwards.
+            self.assertFalse(_termios.tcgetattr(slave_fd)[1] & _termios.OPOST)
+        finally:
+            console.restore()
+            os.close(slave_fd)
+
+        # Give the reader a moment to drain the hook's output.
+        time.sleep(0.2)
+        data = b"".join(chunks)
+        # The tty translated the hook's bare '\n' into '\r\n'.
+        self.assertIn(b"line1\r\nline2\r\n", data)
+        self.assertNotIn(b"line1\nline2\n", data)

--- a/Misc/NEWS.d/next/Library/2026-07-08-23-20-00.gh-issue-152907.oyPV9Y.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-08-23-20-00.gh-issue-152907.oyPV9Y.rst
@@ -1,0 +1,4 @@
+Restore cooked-mode terminal output flags around :c:data:`PyOS_InputHook`
+callbacks in the new :term:`REPL` (:mod:`!_pyrepl`), so that output written
+by an input hook (for example a GUI toolkit event loop) is no longer emitted
+with ``OPOST`` disabled and keeps its carriage returns.


### PR DESCRIPTION
**The problem:** While the new REPL waits for input, it puts the terminal in raw mode, which turns off the usual `\n` → `\r\n` translation. It also runs input hooks during that wait — these are what GUI toolkits (Tkinter, Qt, …) use to keep their event loops alive at the prompt. So when a hook prints something, each line starts where the previous one ended instead of at the left margin, and the text "staircases" down the screen. The old readline REPL didn't do this, and `PYTHON_BASIC_REPL=1` still works fine.

**The fix:** The REPL needs raw mode for drawing its own output, but the input hook runs at a moment when it isn't drawing. So this turns the newline translation back on just around the hook call, then returns to raw mode. Only the output flags are touched, so keystrokes are still not echoed at the prompt.

Checked with a pty that captures the exact bytes a hook writes:

```
before:  line1\nline2\nline3\n
after:   line1\r\nline2\r\nline3\r\n
```

There's a new test that fails without the fix, and `./python -m test test_pyrepl` passes.

I used AI assistance for this and have reviewed the change.

Refs #152907


<!-- gh-issue-number: gh-152907 -->
* Issue: gh-152907
<!-- /gh-issue-number -->
