### PR TITLE
gh-153392: Raise TOMLDecodeError for over-long integers in tomllib

### DIFF
--- a/Lib/test/test_tomllib/test_error.py
+++ b/Lib/test/test_tomllib/test_error.py
@@ -34,6 +34,16 @@ class TestError(unittest.TestCase):
             tomllib.loads("\n\nfwfw=")
         self.assertEqual(str(exc_info.exception), "Invalid value (at end of document)")
 
+    def test_overlong_integer(self):
+        # An integer with more digits than the int-to-str conversion limit
+        # must raise TOMLDecodeError, not the bare ValueError from int().
+        from test.support import adjust_int_max_str_digits
+        with adjust_int_max_str_digits(1000):
+            digits = "9" * 1001
+            for src in (f"x = {digits}", f"x = -{digits}"):
+                with self.assertRaises(tomllib.TOMLDecodeError):
+                    tomllib.loads(src)
+
     def test_invalid_char_quotes(self):
         with self.assertRaises(tomllib.TOMLDecodeError) as exc_info:
             tomllib.loads("v = '\n'")

--- a/Lib/tomllib/_parser.py
+++ b/Lib/tomllib/_parser.py
@@ -738,7 +738,11 @@ def parse_value(
     # char, so needs to be located after handling of dates and times.
     number_match = RE_NUMBER.match(src, pos)
     if number_match:
-        return number_match.end(), match_to_number(number_match, parse_float)
+        try:
+            number = match_to_number(number_match, parse_float)
+        except ValueError as e:
+            raise TOMLDecodeError("Invalid number", src, pos) from e
+        return number_match.end(), number
 
     # Special floats
     first_three = src[pos : pos + 3]

--- a/Lib/tomllib/_parser.py
+++ b/Lib/tomllib/_parser.py
@@ -741,6 +741,9 @@ def parse_value(
         try:
             number = match_to_number(number_match, parse_float)
         except ValueError as e:
+            if number_match.group("floatpart"):
+                # A failing parse_float raises its own error unchanged.
+                raise
             raise TOMLDecodeError("Invalid number", src, pos) from e
         return number_match.end(), number
 

--- a/Misc/NEWS.d/next/Library/2026-07-09-12-30-00.gh-issue-153392.Tm1Num.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-09-12-30-00.gh-issue-153392.Tm1Num.rst
@@ -1,0 +1,3 @@
+:func:`tomllib.loads` now raises :exc:`tomllib.TOMLDecodeError` instead of
+:exc:`ValueError` when a document contains an integer with more digits than the
+interpreter's integer string conversion limit.


### PR DESCRIPTION
The number branch of tomllib's value parser calls `match_to_number` without wrapping `ValueError`, so an integer with more digits than the interpreter's integer string conversion limit escapes `tomllib.loads` as a bare `ValueError` instead of `tomllib.TOMLDecodeError`. The sibling date and time branch already wraps `match_to_datetime`'s `ValueError` into `TOMLDecodeError`; this mirrors that for the number branch, so a malformed document raises only `TOMLDecodeError`, which is what the documentation promises.

Positive and negative decimal integers are both affected. Hexadecimal, octal, and binary literals are not, because they bypass the integer string conversion limit.

The wrap is scoped to the integer conversion only. A `parse_float` callback that raises `ValueError` still propagates unchanged, since that error belongs to the caller and is not a decode error; the existing `test_invalid_parse_float` contract is preserved.

The regression test in `test_error.py` forces a low `sys.set_int_max_str_digits` through `test.support.adjust_int_max_str_digits`, so it is deterministic and fast; it fails before the change and passes after.

`tomllib` is vendored from `tomli`; an upstream sync of the same wrapping is the maintainer's call.
