### PR TITLE
gh-153390: Document pathlib with_segments path duck typing

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -746,6 +746,14 @@ Pure paths provide the following methods and properties:
 
    .. versionadded:: 3.12
 
+   .. versionchanged:: 3.14
+
+      Some methods that accept path objects, such as :meth:`match` and
+      :meth:`~Path.rename`, check for a ``with_segments`` attribute to
+      determine whether the argument is already a path object. If present,
+      the argument is used directly; otherwise, it is converted using
+      ``with_segments()``.
+
 
 .. _concrete-paths:
 


### PR DESCRIPTION
This updates the `pathlib.PurePath.with_segments()` documentation to describe
the Python 3.14 behavior added in gh-128520 / GH-130199.

Some `pathlib` methods now use the presence of a `with_segments` attribute to
decide whether an argument is already a path object. If the attribute is
present, the argument is used directly; otherwise, it is converted through
`with_segments()`. This is relevant for authors of `pathlib` subclasses and
third-party path-like/path-adjacent objects.

Validation:

- `git diff --check`
- `env PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 make -C Doc check`
- `make -C Doc html SPHINXOPTS='-W --keep-going -q'`

Notes:

- No NEWS entry is included because this is a documentation-only change.
- Running `make -C Doc check` without `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`
  failed while building a pre-commit dependency (`regress`) because PyO3 0.26.0
  does not yet recognize Python 3.15.


<!-- gh-issue-number: gh-153390 -->
* Issue: gh-153390
<!-- /gh-issue-number -->
