### PR TITLE
gh-151914: Reorganize the curses entries in What's New in Python 3.16

### DIFF
--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -89,13 +89,6 @@ Improved modules
 curses
 ------
 
-* Add support for multiple terminals to the :mod:`curses` module:
-  the new functions :func:`curses.newterm`, :func:`curses.set_term`
-  and :func:`curses.new_prescr`,
-  the corresponding :ref:`screen <curses-screen-objects>` object,
-  and the :meth:`window.use() <curses.window.use>` method.
-  (Contributed by Serhiy Storchaka in :gh:`90092`.)
-
 * The :mod:`curses` character-cell window methods now accept a full character
   cell --- a spacing character optionally followed by combining characters ---
   in addition to a single integer or byte character.  This affects
@@ -115,40 +108,6 @@ curses
   without combining marks, representable as one byte in the window's encoding,
   and :meth:`~curses.window.in_wstr` returns its decoded text.
   (Contributed by Serhiy Storchaka in :gh:`151757`.)
-
-* The wide-character :mod:`curses` functions and methods
-  :meth:`~curses.window.get_wch`, :meth:`~curses.window.get_wstr`,
-  :func:`curses.unget_wch`, :func:`curses.erasewchar`,
-  :func:`curses.killwchar` and :func:`curses.wunctrl` now also work when Python
-  is not built against a wide-character-aware curses library, on an 8-bit
-  locale, where each character is a single byte in the relevant encoding.
-  :func:`curses.ungetch` now also accepts a one-character string, like
-  :func:`curses.unget_wch`; on a wide-character build it can be any character
-  (previously a multibyte character raised :exc:`OverflowError`).
-  (Contributed by Serhiy Storchaka in :gh:`152470`.)
-
-* Add :func:`curses.nofilter`, which undoes the effect of :func:`curses.filter`.
-  (Contributed by Serhiy Storchaka in :gh:`151744`.)
-
-* Add the :mod:`curses` functions :func:`curses.alloc_pair`,
-  :func:`curses.find_pair`, :func:`curses.free_pair` and
-  :func:`curses.reset_color_pairs` for dynamic color-pair management,
-  available when built against a wide-character ncurses with extended-color
-  support.
-  (Contributed by Serhiy Storchaka in :gh:`151774`.)
-
-* Add :mod:`curses` functions and window methods that report state which could
-  previously only be set, such as :meth:`curses.window.is_keypad`,
-  :meth:`curses.window.getparent` and :func:`curses.is_cbreak`,
-  available when built against an ncurses with ``NCURSES_EXT_FUNCS``.
-  (Contributed by Serhiy Storchaka in :gh:`151776`.)
-
-* Add the :mod:`curses` window methods :meth:`~curses.window.attr_get`,
-  :meth:`~curses.window.attr_set`, :meth:`~curses.window.attr_on`,
-  :meth:`~curses.window.attr_off` and :meth:`~curses.window.color_set`, which
-  pass the color pair as a separate argument instead of packing it into the
-  attribute value, and the corresponding ``WA_*`` attribute constants.
-  (Contributed by Serhiy Storchaka in :gh:`152219`.)
 
 * Add the :class:`curses.complexchar` type, representing a styled
   character cell (its text, attributes and color pair), and the window
@@ -173,14 +132,51 @@ curses
   library.
   (Contributed by Serhiy Storchaka in :gh:`152233`.)
 
-* Add the :mod:`curses` window method :meth:`~curses.window.dupwin`, which
-  returns a new window that is an independent duplicate of an existing one.
-  (Contributed by Serhiy Storchaka in :gh:`152258`.)
+* The wide-character :mod:`curses` functions and methods
+  :meth:`~curses.window.get_wch`, :meth:`~curses.window.get_wstr`,
+  :func:`curses.unget_wch`, :func:`curses.erasewchar`,
+  :func:`curses.killwchar` and :func:`curses.wunctrl` now also work when Python
+  is not built against a wide-character-aware curses library, on an 8-bit
+  locale, where each character is a single byte in the relevant encoding.
+  :func:`curses.ungetch` now also accepts a one-character string, like
+  :func:`curses.unget_wch`; on a wide-character build it can be any character
+  (previously a multibyte character raised :exc:`OverflowError`).
+  (Contributed by Serhiy Storchaka in :gh:`152470`.)
+
+* Add support for multiple terminals to the :mod:`curses` module:
+  the new functions :func:`curses.newterm`, :func:`curses.set_term`
+  and :func:`curses.new_prescr`,
+  the corresponding :ref:`screen <curses-screen-objects>` object,
+  and the :meth:`window.use() <curses.window.use>` method.
+  (Contributed by Serhiy Storchaka in :gh:`90092`.)
+
+* Add the :mod:`curses` window methods :meth:`~curses.window.attr_get`,
+  :meth:`~curses.window.attr_set`, :meth:`~curses.window.attr_on`,
+  :meth:`~curses.window.attr_off` and :meth:`~curses.window.color_set`, which
+  pass the color pair as a separate argument instead of packing it into the
+  attribute value, and the corresponding ``WA_*`` attribute constants.
+  (Contributed by Serhiy Storchaka in :gh:`152219`.)
+
+* Add the :func:`curses.term_attrs` function, which returns the supported
+  video attributes as :ref:`WA_* <curses-wa-constants>` values, the
+  counterpart of :func:`curses.termattrs`.
+  (Contributed by Serhiy Storchaka in :gh:`152332`.)
+
+* Add the :mod:`curses` functions :func:`curses.alloc_pair`,
+  :func:`curses.find_pair`, :func:`curses.free_pair` and
+  :func:`curses.reset_color_pairs` for dynamic color-pair management,
+  available when built against a wide-character ncurses with extended-color
+  support.
+  (Contributed by Serhiy Storchaka in :gh:`151774`.)
 
 * Add the :mod:`curses` functions :func:`~curses.scr_dump`,
   :func:`~curses.scr_restore`, :func:`~curses.scr_init` and
   :func:`~curses.scr_set`, which dump the whole screen to a file and restore it.
   (Contributed by Serhiy Storchaka in :gh:`152260`.)
+
+* Add the :mod:`curses` window method :meth:`~curses.window.dupwin`, which
+  returns a new window that is an independent duplicate of an existing one.
+  (Contributed by Serhiy Storchaka in :gh:`152258`.)
 
 * Add the soft-label-key functions to the :mod:`curses` module, which manage a
   row of labels along the bottom line of the screen:
@@ -194,11 +190,6 @@ curses
   :func:`~curses.slk_attr_set`, and :func:`~curses.slk_color`.
   (Contributed by Serhiy Storchaka in :gh:`152263`.)
 
-* Add the :func:`curses.term_attrs` function, which returns the supported
-  video attributes as :ref:`WA_* <curses-wa-constants>` values, the
-  counterpart of :func:`curses.termattrs`.
-  (Contributed by Serhiy Storchaka in :gh:`152332`.)
-
 * Add the :mod:`curses` key-management functions :func:`~curses.define_key`,
   :func:`~curses.key_defined` and :func:`~curses.keyok`, available when built
   against an ncurses with ``NCURSES_EXT_FUNCS``.
@@ -208,6 +199,15 @@ curses
   :meth:`curses.window.mouse_trafo` method, completing the :mod:`curses`
   mouse interface.
   (Contributed by Serhiy Storchaka in :gh:`152325`.)
+
+* Add :mod:`curses` functions and window methods that report state which could
+  previously only be set, such as :meth:`curses.window.is_keypad`,
+  :meth:`curses.window.getparent` and :func:`curses.is_cbreak`,
+  available when built against an ncurses with ``NCURSES_EXT_FUNCS``.
+  (Contributed by Serhiy Storchaka in :gh:`151776`.)
+
+* Add :func:`curses.nofilter`, which undoes the effect of :func:`curses.filter`.
+  (Contributed by Serhiy Storchaka in :gh:`151744`.)
 
 * :class:`curses.textpad.Textbox` now supports entering and reading back the
   full Unicode range, including combining characters, when curses is built with


### PR DESCRIPTION
Reorder the `curses` entries in "What's New in Python 3.16" from the most general and important to the more specialized, without changing their wording.
