### PR TITLE
[3.14] gh-151213: Remove 3.15+ asyncio tools flag from 3.14 docs (GH-151392)

### DIFF
--- a/Doc/library/asyncio-tools.rst
+++ b/Doc/library/asyncio-tools.rst
@@ -148,10 +148,3 @@ Command-line options
       18445801   0x10a2a38a0          Levitate             sleep -> play                                      TaskGroup._aexit -> TaskGroup.__aexit__ -> album   Sundowning      0x10a439f60
       18445801   0x10a2d7150          DYWTYLM              sleep -> play                                      TaskGroup._aexit -> TaskGroup.__aexit__ -> album   TMBTE           0x10a439d70
       18445801   0x10a6bdaa0          Aqua Regia           sleep -> play                                      TaskGroup._aexit -> TaskGroup.__aexit__ -> album   TMBTE           0x10a439d70
-
-.. option:: --retries N
-
-   Retry failed attempts to inspect the target process up to *N* times.  This
-   can help when the target process changes while its state is being read.
-
-   .. versionadded:: 3.15


### PR DESCRIPTION
This was a catch :-)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151213 -->
* Issue: gh-151213
<!-- /gh-issue-number -->
