### PR TITLE
gh-153404: Silently ignore non-decimal digits in robots.txt Crawl-delay and Request-rate

### DIFF
--- a/Lib/test/test_robotparser.py
+++ b/Lib/test/test_robotparser.py
@@ -246,23 +246,24 @@ Crawl-delay: pears
     bad = []
 
 
-class NonDecimalCrawlDelayTest(BaseRequestRateTest, unittest.TestCase):
+class NonDecimalDigitsTest(BaseRequestRateTest, unittest.TestCase):
     # Non-decimal Unicode digits pass str.isdigit() but int() rejects
     # them, so the directive must be silently ignored, not raise.
     robots_txt = """\
 User-Agent: *
-Disallow: /.
+Disallow: /tmp/
 Crawl-delay: ²
+Request-rate: ²/5
     """
     good = ['/foo.html']
-    bad = []
+    bad = ['/tmp/']
 
 
-class NonDecimalRequestRateTest(BaseRequestRateTest, unittest.TestCase):
+class NonDecimalDenominatorTest(BaseRequestRateTest, unittest.TestCase):
     robots_txt = """\
 User-agent: *
 Disallow: /tmp/
-Request-rate: ²/5
+Request-rate: 5/²
     """
     good = ['/foo.html']
     bad = ['/tmp/']

--- a/Lib/test/test_robotparser.py
+++ b/Lib/test/test_robotparser.py
@@ -246,6 +246,28 @@ Crawl-delay: pears
     bad = []
 
 
+class NonDecimalCrawlDelayTest(BaseRequestRateTest, unittest.TestCase):
+    # Non-decimal Unicode digits pass str.isdigit() but int() rejects
+    # them, so the directive must be silently ignored, not raise.
+    robots_txt = """\
+User-Agent: *
+Disallow: /.
+Crawl-delay: ²
+    """
+    good = ['/foo.html']
+    bad = []
+
+
+class NonDecimalRequestRateTest(BaseRequestRateTest, unittest.TestCase):
+    robots_txt = """\
+User-agent: *
+Disallow: /tmp/
+Request-rate: ²/5
+    """
+    good = ['/foo.html']
+    bad = ['/tmp/']
+
+
 class AnotherInvalidRequestRateTest(BaseRobotTest, unittest.TestCase):
     # also test that Allow and Diasallow works well with each other
     robots_txt = """\

--- a/Lib/test/test_robotparser.py
+++ b/Lib/test/test_robotparser.py
@@ -188,6 +188,8 @@ class BaseRequestRateTest(BaseRobotTest):
                         parsed_request_rate.seconds,
                         self.request_rate.seconds
                     )
+                else:
+                    self.assertIsNone(parsed_request_rate)
 
 
 class EmptyFileTest(BaseRequestRateTest, unittest.TestCase):
@@ -257,6 +259,8 @@ Request-rate: ²/5
     """
     good = ['/foo.html']
     bad = ['/tmp/']
+    crawl_delay = None
+    request_rate = None
 
 
 class NonDecimalDenominatorTest(BaseRequestRateTest, unittest.TestCase):
@@ -266,6 +270,7 @@ Disallow: /tmp/
 Request-rate: 5/²
     """
     good = ['/foo.html']
+    request_rate = None
     bad = ['/tmp/']
 
 

--- a/Lib/urllib/robotparser.py
+++ b/Lib/urllib/robotparser.py
@@ -148,15 +148,15 @@ class RobotFileParser:
                         # before trying to convert to int we need to make
                         # sure that robots.txt has valid syntax otherwise
                         # it will crash
-                        if line[1].strip().isdigit():
+                        if line[1].strip().isdecimal():
                             entry.delay = int(line[1])
                         state = 2
                 elif line[0] == "request-rate":
                     if state != 0:
                         numbers = line[1].split('/')
                         # check if all values are sane
-                        if (len(numbers) == 2 and numbers[0].strip().isdigit()
-                            and numbers[1].strip().isdigit()):
+                        if (len(numbers) == 2 and numbers[0].strip().isdecimal()
+                            and numbers[1].strip().isdecimal()):
                             entry.req_rate = RequestRate(int(numbers[0]), int(numbers[1]))
                         state = 2
                 elif line[0] == "sitemap":

--- a/Misc/NEWS.d/next/Library/2026-07-09-16-35-47.gh-issue-153404.daRkes.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-09-16-35-47.gh-issue-153404.daRkes.rst
@@ -1,0 +1,4 @@
+:class:`urllib.robotparser.RobotFileParser` now silently ignores a
+``Crawl-delay`` or ``Request-rate`` value written with non-decimal digits
+(such as ``U+00B2 SUPERSCRIPT TWO``) instead of raising :exc:`ValueError`
+and aborting the parse of the whole ``robots.txt`` file.


### PR DESCRIPTION
`str.isdigit()` returns True for non-decimal Unicode digits such as `U+00B2 SUPERSCRIPT TWO`, which `int()` then rejects with `ValueError`. In `RobotFileParser.parse()` this raised a raw `ValueError` that aborted parsing of the entire `robots.txt` file, even though every other malformed directive is silently ignored (`Allow` and `Disallow` already do `try/except ValueError: pass`, and invalid `Crawl-delay: pears` / `Request-rate: 9/banana` values are already dropped, with existing tests).

The `Crawl-delay` and `Request-rate` guards now use `str.isdecimal()`, the predicate for the decimal digits `int()` accepts, so a value written with non-decimal digits is ignored instead of raising.

Scope note: a control character that `str.strip()` removes but `int()` rejects (for example a byte in `U+001C..U+001F` inside a `Request-rate` token) still raises, because the `Request-rate` branch converts the unstripped token. That is a separate, pre-existing divergence, left out of this single-purpose change.


<!-- gh-issue-number: gh-153404 -->
* Issue: gh-153404
<!-- /gh-issue-number -->
