### PR TITLE
[3.15] gh-152785: Upgrade Ubuntu from 24.04 to 26.04 in GitHub Actions (#152717)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,12 @@
 config-variables: null
 
+# Pending release of actionlint > 1.7.12 for ubuntu-26.04* support:
+# https://github.com/rhysd/actionlint/pull/683
+self-hosted-runner:
+  labels:
+    - ubuntu-26.04
+    - ubuntu-26.04-arm
+
 paths:
   .github/workflows/**/*.yml:
      ignore:

--- a/.github/workflows/add-issue-header.yml
+++ b/.github/workflows/add-issue-header.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   add-header:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       issues: write
     timeout-minutes: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
     name: 'Check if Autoconf files are up to date'
     # Don't use ubuntu-latest but a specific version to make the job
     # reproducible: to get the same tools versions (autoconf, aclocal, ...)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     container:
       image: ghcr.io/python/autoconf:2025.01.02.12581854023
     timeout-minutes: 60
@@ -143,7 +143,7 @@ jobs:
     name: 'Check if generated files are up to date'
     # Don't use ubuntu-latest but a specific version to make the job
     # reproducible: to get the same tools versions (autoconf, aclocal, ...)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     needs: build-context
     if: needs.build-context.outputs.run-tests == 'true'
@@ -286,18 +286,18 @@ jobs:
         - false
         - true
         os:
-        - ubuntu-24.04
-        - ubuntu-24.04-arm
+        - ubuntu-26.04
+        - ubuntu-26.04-arm
         exclude:
         # Do not test BOLT with free-threading, to conserve resources
         - bolt: true
           free-threading: true
         # BOLT currently crashes during instrumentation on aarch64
-        - os: ubuntu-24.04-arm
+        - os: ubuntu-26.04-arm
           bolt: true
         include:
         # Enable CPU-intensive tests on ARM (default build only)
-        - os: ubuntu-24.04-arm
+        - os: ubuntu-26.04-arm
           bolt: false
           free-threading: false
           test-opts: '-u cpu'
@@ -317,7 +317,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-26.04]
         ssllib:
           # See Tools/ssl/make_ssl_data.py for notes on adding a new version
           ## OpenSSL
@@ -393,7 +393,7 @@ jobs:
           - arch: aarch64
             runs-on: macos-26
           - arch: x86_64
-            runs-on: ubuntu-24.04
+            runs-on: ubuntu-26.04
 
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -440,7 +440,7 @@ jobs:
 
   test-hypothesis:
     name: "Hypothesis tests on Ubuntu"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     needs: build-context
     if: needs.build-context.outputs.run-ubuntu == 'true'
@@ -551,7 +551,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-26.04]
     env:
       OPENSSL_VER: 3.5.7
       PYTHONSTRICTEXTENSIONBUILD: 1
@@ -625,7 +625,7 @@ jobs:
 
   cross-build-linux:
     name: Cross build Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     needs: build-context
     if: needs.build-context.outputs.run-ubuntu == 'true'

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   interpreter:
     name: Interpreter (Debug)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -145,9 +145,9 @@ jobs:
           - false
         include:
           - target: x86_64-unknown-linux-gnu/gcc
-            runner: ubuntu-24.04
+            runner: ubuntu-26.04
           - target: aarch64-unknown-linux-gnu/gcc
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-26.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -160,8 +160,7 @@ jobs:
           sudo ./.github/workflows/posix-deps-apt.sh
       - name: Build
         run: |
-          sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh ${{ env.LLVM_VERSION }}
-          export PATH="$(llvm-config-${{ env.LLVM_VERSION }} --bindir):$PATH"
+          # On ubuntu-26.04 image, clang is clang-21 by default
           ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '' }}
           make all --jobs 4
       - name: Test
@@ -171,7 +170,7 @@ jobs:
   linux-extras:
     name: ${{ matrix.name }}
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -202,8 +201,7 @@ jobs:
           sudo ./.github/workflows/posix-deps-apt.sh
       - name: Build
         run: |
-          sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh ${{ env.LLVM_VERSION }}
-          export PATH="$(llvm-config-${{ env.LLVM_VERSION }} --bindir):$PATH"
+          # On ubuntu-26.04 image, clang is clang-21 by default
           if [ "${{ matrix.use_clang }}" = "true" ]; then
             export CC=clang-${{ env.LLVM_VERSION }}
           fi

--- a/.github/workflows/new-bugs-announce-notifier.yml
+++ b/.github/workflows/new-bugs-announce-notifier.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   notify-new-bugs-announce:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       issues: read
     timeout-minutes: 10

--- a/.github/workflows/posix-deps-apt.sh
+++ b/.github/workflows/posix-deps-apt.sh
@@ -5,37 +5,23 @@ apt-get -yq --no-install-recommends install \
     build-essential \
     pkg-config \
     cmake \
+    curl \
     gdb \
     lcov \
     libb2-dev \
     libbz2-dev \
     libffi-dev \
-    libgdbm-dev \
     libgdbm-compat-dev \
+    libgdbm-dev \
     liblzma-dev \
+    libmpdec-dev \
     libncurses5-dev \
     libreadline6-dev \
     libsqlite3-dev \
     libssl-dev \
     libzstd-dev \
-    lzma \
-    lzma-dev \
     strace \
     tk-dev \
     uuid-dev \
     xvfb \
     zlib1g-dev
-
-# Workaround missing libmpdec-dev on ubuntu 24.04 by building mpdecimal
-# from source. ppa:ondrej/php (launchpad.net) are unreliable 
-# (https://status.canonical.com) so fetch the tarball directly
-# from the upstream host.
-# https://www.bytereef.org/mpdecimal/
-MPDECIMAL_VERSION=4.0.1
-curl -fsSL "https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-${MPDECIMAL_VERSION}.tar.gz" \
-    | tar -xz -C /tmp
-(cd "/tmp/mpdecimal-${MPDECIMAL_VERSION}" \
-    && ./configure --prefix=/usr/local \
-    && make -j"$(nproc)" \
-    && make install)
-ldconfig

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -11,7 +11,7 @@ jobs:
   label-dnm:
     name: DO-NOT-MERGE
     if: github.repository_owner == 'python'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       pull-requests: read
     timeout-minutes: 10
@@ -28,7 +28,7 @@ jobs:
   label-reviews:
     name: Unresolved review
     if: github.repository_owner == 'python'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       pull-requests: read
     timeout-minutes: 10

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -106,7 +106,7 @@ jobs:
   # Run "doctest" on HEAD as new syntax doesn't exist in the latest stable release
   doctest:
     name: 'Doctest'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-emscripten.yml
+++ b/.github/workflows/reusable-emscripten.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build-emscripten-reusable:
     name: 'build and test'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-san.yml
+++ b/.github/workflows/reusable-san.yml
@@ -27,7 +27,7 @@ jobs:
         && ' (free-threading)'
         || ''
       }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -38,14 +38,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo ./.github/workflows/posix-deps-apt.sh
-        # Install clang
-        wget https://apt.llvm.org/llvm.sh
-        chmod +x llvm.sh
-        sudo ./llvm.sh 21
-        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-21 100
-        sudo update-alternatives --set clang /usr/bin/clang-21
-        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-21 100
-        sudo update-alternatives --set clang++ /usr/bin/clang++-21
+        # On ubuntu-26.04 image, clang is clang-21 by default
         echo "CC=clang" >> "$GITHUB_ENV"
         echo "CXX=clang++" >> "$GITHUB_ENV"
     - name: TSan option setup

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Install Clang and BOLT
       if: ${{ fromJSON(inputs.bolt-optimizations) }}
       run: |
-        sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh 21
+        # On ubuntu-26.04 image, LLVM is LLVM-21 by default
         sudo apt-get install --no-install-recommends bolt-21
         echo PATH="$(llvm-config-21 --bindir):$PATH" >> $GITHUB_ENV
     - name: Configure OpenSSL env vars

--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build-wasi-reusable:
     name: 'build and test'
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-26.04-arm
     timeout-minutes: 60
     env:
       WASMTIME_VERSION: 38.0.3

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   stale:
     if: github.repository_owner == 'python'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       actions: write
       pull-requests: write

--- a/.github/workflows/tail-call.yml
+++ b/.github/workflows/tail-call.yml
@@ -66,13 +66,13 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu/gcc
-            runner: ubuntu-24.04
+            runner: ubuntu-26.04
             configure_flags: --with-pydebug
           - target: x86_64-unknown-linux-gnu/gcc-free-threading
-            runner: ubuntu-24.04
+            runner: ubuntu-26.04
             configure_flags: --disable-gil
           - target: aarch64-unknown-linux-gnu/gcc
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-26.04-arm
             configure_flags: --with-pydebug
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -83,8 +83,7 @@ jobs:
           python-version: '3.11'
       - name: Build
         run: |
-          sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ./llvm.sh ${{ env.LLVM_VERSION }}
-          export PATH="$(llvm-config-${{ env.LLVM_VERSION }} --bindir):$PATH"
+          # On ubuntu-26.04 image, clang is clang-21 by default
           CC=clang-${{ env.LLVM_VERSION }} ./configure --with-tail-call-interp ${{ matrix.configure_flags }}
           make all --jobs 4
       - name: Test

--- a/.github/workflows/verify-expat.yml
+++ b/.github/workflows/verify-expat.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
* Replace "ubuntu-24.04" with "ubuntu-26.04".
* Replace "ubuntu-latest" with "ubuntu-26.04" for Cross build Linux.
* Replace "ubuntu-latest" with "ubuntu-slim" for small workloads.
* Update ".github/actionlint.yaml" to allow "ubuntu-26.04" and "ubuntu-26.04-arm" images.
* Install Ubuntu libmpdec-dev package, rather than installing libmpdec from source (tarball).
* No longer run https://apt.llvm.org/llvm.sh, since ubuntu-26.04 provides clang-21 by default.


(cherry picked from commit 4c79929705eb31959a6f4071cc34583de0737a28)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152785 -->
* Issue: gh-152785
<!-- /gh-issue-number -->
