### PR TITLE
gh-90092: Fix test_curses when stdin is write-only (e.g. under nohup)

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -29,6 +29,9 @@ try:
 except ImportError:
     pass
 
+# Only reachable once curses imported, so the platform has fcntl too.
+import fcntl
+
 def requires_curses_func(name):
     return unittest.skipUnless(hasattr(curses, name),
                                'requires curses.%s' % name)
@@ -164,6 +167,10 @@ class TestCurses(unittest.TestCase):
             # ScreenTests run newterm()/set_term() in the same process.
             try:
                 infd = sys.__stdin__.fileno()
+                if fcntl.fcntl(infd, fcntl.F_GETFL) & os.O_ACCMODE == os.O_WRONLY:
+                    # newterm() needs a readable input fd; a write-only stdin
+                    # (as nohup leaves for a backgrounded run) fails with EINVAL.
+                    infd = stdout_fd
             except (AttributeError, ValueError, OSError):
                 infd = stdout_fd
             self.screen = curses.newterm(term, stdout_fd, infd)


### PR DESCRIPTION
`test_curses` fails in `setUp()` when the suite is run backgrounded under `nohup`:

```
OSError: [Errno 22] Invalid argument
```

`setUp()` derives the `newterm()` input fd from stdin, but `nohup` leaves stdin write-only when it backgrounds a run started from a terminal, and `newterm()` rejects a write-only input fd. Fall back to the output fd in that case, as is already done when stdin has no `fileno()`.

This only affects builds using the `newterm()` path (ncurses 6.5+); the previous `initscr()` path tolerated a write-only stdin.

Reported by @weixlu.


<!-- gh-issue-number: gh-90092 -->
* Issue: gh-90092
<!-- /gh-issue-number -->
