### PR TITLE
gh-153417: Fix BytesWarning in imaplib error messages for bytes arguments

### DIFF
--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -960,7 +960,7 @@ class IMAP4:
             if __debug__:
                 if self.debug >= 1:
                     self._dump_ur(self.untagged_responses)
-            raise self.readonly('%s is not writable' % mailbox)
+            raise self.readonly('%r is not writable' % (mailbox,))
         return typ, self.untagged_responses.get('EXISTS', [None])
 
 
@@ -1085,7 +1085,7 @@ class IMAP4:
         """
         command = command.upper()
         if not command in Commands:
-            raise self.error("Unknown IMAP4 UID command: %s" % command)
+            raise self.error("Unknown IMAP4 UID command: %r" % (command,))
         if self.state not in Commands[command]:
             raise self.error("command %s illegal in state %s, "
                              "only allowed in states %s" %

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -995,6 +995,32 @@ class NewIMAPTestsMixin:
         client.login('user', 'pass')
         self.assertIn('ENABLE', client.capabilities)
 
+    def test_readonly_error_reports_mailbox(self):
+        # The read-only error reports the mailbox via repr(), which also
+        # avoids BytesWarning for a bytes mailbox under -bb.
+        class ReadOnlyHandler(SimpleIMAPHandler):
+            def cmd_SELECT(self, tag, args):
+                self._send_line(b'* 2 EXISTS')
+                self._send_tagged(tag, 'OK', '[READ-ONLY] SELECT completed.')
+        client, _ = self._setup(ReadOnlyHandler)
+        client.login('user', 'pass')
+        for mailbox, expected in [('INBOX', "'INBOX'"), (b'INBOX', r"b'INBOX'")]:
+            with self.subTest(mailbox=mailbox):
+                with self.assertRaisesRegex(imaplib.IMAP4.readonly,
+                                            r"%s is not writable" % expected):
+                    client.select(mailbox)
+
+    def test_uid_unknown_command_reports_command(self):
+        # The unknown-UID-command error reports the command via repr(), which
+        # also avoids BytesWarning for a bytes command under -bb.
+        client, _ = self._setup(SimpleIMAPHandler)
+        for command, expected in [('BOGUS', "'BOGUS'"), (b'BOGUS', r"b'BOGUS'")]:
+            with self.subTest(command=command):
+                with self.assertRaisesRegex(
+                        imaplib.IMAP4.error,
+                        r"Unknown IMAP4 UID command: %s" % expected):
+                    client.uid(command, '1')
+
     def test_logout(self):
         client, _ = self._setup(SimpleIMAPHandler)
         typ, data = client.login('user', 'pass')

--- a/Misc/NEWS.d/next/Library/2026-07-09-14-00-00.gh-issue-153417.Bw7Rq2.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-09-14-00-00.gh-issue-153417.Bw7Rq2.rst
@@ -1,3 +1,3 @@
 Error messages from :meth:`imaplib.IMAP4.select` and :meth:`imaplib.IMAP4.uid`
-no longer raise :exc:`BytesWarning` under :option:`-bb`
+no longer raise :exc:`BytesWarning` under :option:`!-bb`
 when the mailbox or command argument is :class:`bytes`.

--- a/Misc/NEWS.d/next/Library/2026-07-09-14-00-00.gh-issue-153417.Bw7Rq2.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-09-14-00-00.gh-issue-153417.Bw7Rq2.rst
@@ -1,0 +1,3 @@
+Error messages from :meth:`imaplib.IMAP4.select` and :meth:`imaplib.IMAP4.uid`
+no longer raise :exc:`BytesWarning` under :option:`-bb`
+when the mailbox or command argument is :class:`bytes`.


### PR DESCRIPTION
`IMAP4.select()` and `IMAP4.uid()` formatted the mailbox and command argument with `%s` in their error messages.  Both arguments accept `bytes`, so under `-bb` formatting a `bytes` value raised `BytesWarning` and masked the real error.  This changes both to `%r`, which is safe for `bytes` and also quotes the value.

<!-- gh-issue-number: gh-153417 -->
* Issue: gh-153417
<!-- /gh-issue-number -->
