### PR TITLE
[3.15] gh-153422: Assert bool return type in tkinter tests (GH-153429)

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -2015,7 +2015,7 @@ Base and mixin classes
 
    .. method:: winfo_exists()
 
-      Return ``1`` if the widget exists, ``0`` otherwise.
+      Return true if the widget exists, false otherwise.
 
    .. method:: winfo_fpixels(number)
 
@@ -2054,7 +2054,7 @@ Base and mixin classes
 
    .. method:: winfo_ismapped()
 
-      Return ``1`` if the widget is currently mapped, ``0`` otherwise.
+      Return true if the widget is currently mapped, false otherwise.
 
    .. method:: winfo_manager()
 
@@ -2185,8 +2185,8 @@ Base and mixin classes
 
    .. method:: winfo_viewable()
 
-      Return ``1`` if the widget and all of its ancestors up through the
-      nearest toplevel window are mapped, ``0`` otherwise.
+      Return true if the widget and all of its ancestors up through the
+      nearest toplevel window are mapped, false otherwise.
 
    .. method:: winfo_visual()
 
@@ -5591,7 +5591,7 @@ Widget classes
    .. method:: edit_modified(arg=None)
 
       If *arg* is omitted, return the current state of the modified flag as
-      ``0`` or ``1``; the flag is set automatically whenever the text is
+      true or false; the flag is set automatically whenever the text is
       inserted or deleted.
       Otherwise set the flag to the boolean *arg*.
 

--- a/Lib/test/test_tkinter/test_images.py
+++ b/Lib/test/test_tkinter/test_images.py
@@ -655,12 +655,12 @@ class PhotoImageTest(BaseImageTest, AbstractTkTest, unittest.TestCase):
 
     def test_transparency(self):
         image = self.create()
-        self.assertEqual(image.transparency_get(0, 0), True)
-        self.assertEqual(image.transparency_get(4, 6), False)
+        self.assertIs(image.transparency_get(0, 0), True)
+        self.assertIs(image.transparency_get(4, 6), False)
         image.transparency_set(4, 6, True)
-        self.assertEqual(image.transparency_get(4, 6), True)
+        self.assertIs(image.transparency_get(4, 6), True)
         image.transparency_set(4, 6, False)
-        self.assertEqual(image.transparency_get(4, 6), False)
+        self.assertIs(image.transparency_get(4, 6), False)
         self.assertRaises(tkinter.TclError, image.transparency_get, -1, 0)
         self.assertRaises(tkinter.TclError, image.transparency_get, 16, 0)
         self.assertRaises(tkinter.TclError, image.transparency_set, -1, 0, True)

--- a/Lib/test/test_tkinter/test_text.py
+++ b/Lib/test/test_tkinter/test_text.py
@@ -18,10 +18,10 @@ class TextTest(AbstractTkTest, unittest.TestCase):
         text = self.text
         olddebug = text.debug()
         try:
-            text.debug(0)
-            self.assertEqual(text.debug(), 0)
-            text.debug(1)
-            self.assertEqual(text.debug(), 1)
+            text.debug(False)
+            self.assertIs(text.debug(), False)
+            text.debug(True)
+            self.assertIs(text.debug(), True)
         finally:
             text.debug(olddebug)
             self.assertEqual(text.debug(), olddebug)

--- a/Lib/test/test_ttk/test_widgets.py
+++ b/Lib/test/test_ttk/test_widgets.py
@@ -1685,9 +1685,9 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
         self.assertEqual(self.tv.get_children(item_id), ())
 
     def test_exists(self):
-        self.assertEqual(self.tv.exists('something'), False)
-        self.assertEqual(self.tv.exists(''), True)
-        self.assertEqual(self.tv.exists({}), False)
+        self.assertIs(self.tv.exists('something'), False)
+        self.assertIs(self.tv.exists(''), True)
+        self.assertIs(self.tv.exists({}), False)
 
         # the following will make a tk.call equivalent to
         # tk.call(treeview, "exists") which should result in an error

--- a/Lib/tkinter/ttk.py
+++ b/Lib/tkinter/ttk.py
@@ -1483,8 +1483,8 @@ class Treeview(Widget, tkinter.XView, tkinter.YView):
 
 
     def tag_has(self, tagname, item=None):
-        """If item is specified, returns 1 or 0 depending on whether the
-        specified item has the given tagname. Otherwise, returns a list of
+        """If item is specified, returns True if the specified item has the
+        given tagname, False otherwise. Otherwise, returns a list of
         all items which have the specified tag.
 
         * Availability: Tk 8.6"""


### PR DESCRIPTION
Partial backport of #153429 (gh-153422) to 3.15, without the behavior change: `winfo_exists()`, `winfo_ismapped()`, `winfo_viewable()` and `Text.edit_modified()` continue to return an integer on 3.15, so only the version-independent parts are backported.

The tests for `PhotoImage.transparency_get()`, `Text.debug()` and `Treeview.exists()` — which already return a `bool` on all versions — now assert the exact type with `assertIs`.

The documentation for the `winfo_*` methods and `Text.edit_modified()` uses general lowercase `true`/`false` instead of `1`/`0` (their return type is unchanged here), while `Treeview.tag_has()`'s docstring uses `True`/`False`, since it genuinely returns a `bool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-153422 -->
* Issue: gh-153422
<!-- /gh-issue-number -->
