### PR TITLE
gh-145633: Allow PyFloat_Pack8 & PyFloat_UnPack* to fail in future CPython versions

### DIFF
--- a/Doc/c-api/float.rst
+++ b/Doc/c-api/float.rst
@@ -233,9 +233,6 @@ most likely :exc:`OverflowError`).
 
    Pack a C double as the IEEE 754 binary64 double precision format.
 
-   .. impl-detail::
-      This function always succeeds in CPython.
-
 
 Unpack functions
 ^^^^^^^^^^^^^^^^
@@ -250,9 +247,6 @@ on little endian processor.
 Return value: The unpacked double.  On error, this is ``-1.0`` and
 :c:func:`PyErr_Occurred` is true (and an exception is set, most likely
 :exc:`OverflowError`).
-
-.. impl-detail::
-    These functions always succeed in CPython.
 
 .. c:function:: double PyFloat_Unpack2(const char *p, int le)
 

--- a/Misc/NEWS.d/next/C_API/2026-07-09-16-46-30.gh-issue-145633.jyNwAs.rst
+++ b/Misc/NEWS.d/next/C_API/2026-07-09-16-46-30.gh-issue-145633.jyNwAs.rst
@@ -1,0 +1,2 @@
+:c:func:`PyFloat_Pack8` and ``PyFloat_Unpack*`` functions are no longer
+guaranteed to always succeed on CPython.


### PR DESCRIPTION

See discussion in https://github.com/capi-workgroup/decisions/issues/107

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-145633 -->
* Issue: gh-145633
<!-- /gh-issue-number -->
