### PR TITLE
gh-153437: Make pegen output error detection checks after loop body for '*' rules.

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -604,6 +604,19 @@ except Exception:
 '''
         assert_python_ok('-c', script)
 
+    def test_memoryerror_during_concat_does_not_crash(self):
+        # gh-153182: Recursion/Memory errors parsing f-strings should be properly unwound
+        # and the parser should not attempt to continue parsing after the error. (In this case,
+        # a SyntaxWarning will subsequently be raised for the invalid escape, triggering a debug assert
+        # from the existing Exception)
+        script = r'''
+try:
+    compile('(x""f"\\{0}"<' * 1276, "<test>", "exec")
+except MemoryError:
+    pass
+'''
+        assert_python_ok('-c', script)
+
     def test_literal(self):
         self.assertEqual(f'', '')
         self.assertEqual(f'a', 'a')

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-09-15-39-19.gh-issue-153437.Dj2sRs.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-09-15-39-19.gh-issue-153437.Dj2sRs.rst
@@ -1,0 +1,2 @@
+Fix an issue where some grammar rules tried to continue parsing after an
+error

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -28710,6 +28710,11 @@ _loop0_1_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_1[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "NEWLINE"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -28857,6 +28862,11 @@ _loop0_3_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_3[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "';' simple_stmt"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -29484,6 +29494,11 @@ _loop0_13_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_13[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' NAME"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -29695,6 +29710,11 @@ _loop0_17_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_17[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "('.' | '...')"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -29842,6 +29862,11 @@ _loop0_19_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_19[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' import_from_as_name"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -30005,6 +30030,11 @@ _loop0_22_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_22[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' dotted_as_name"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -30281,6 +30311,11 @@ _loop0_27_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_27[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "param_no_default"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -30347,6 +30382,11 @@ _loop0_28_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_28[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "param_with_default"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -30559,6 +30599,11 @@ _loop0_31_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_31[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "param_maybe_default"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -30706,6 +30751,11 @@ _loop0_33_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_33[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' with_item"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -31116,6 +31166,11 @@ _loop0_39_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_39[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'|' closed_pattern"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -31442,6 +31497,11 @@ _loop0_44_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_44[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' maybe_star_pattern"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -31558,6 +31618,11 @@ _loop0_46_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_46[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' key_value_pattern"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -31733,6 +31798,11 @@ _loop0_49_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_49[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' pattern"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -31850,6 +31920,11 @@ _loop0_51_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_51[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' keyword_pattern"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -31966,6 +32041,11 @@ _loop0_53_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_53[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' type_param"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -32228,6 +32308,11 @@ _loop0_57_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_57[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' star_named_expression"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -32344,6 +32429,11 @@ _loop0_59_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_59[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' star_named_expression_sequence"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -32720,6 +32810,11 @@ _loop0_65_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_65[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' (slice | starred_expression)"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -33160,6 +33255,11 @@ _loop0_72_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_72[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "lambda_param_no_default"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -33226,6 +33326,11 @@ _loop0_73_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_73[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "lambda_param_with_default"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -33438,6 +33543,11 @@ _loop0_76_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_76[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "lambda_param_maybe_default"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -33577,6 +33687,11 @@ _loop0_78_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_78[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "fstring_format_spec"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -33643,6 +33758,11 @@ _loop0_79_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_79[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "fstring_middle"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -33711,6 +33831,11 @@ _loop0_80_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_80[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "tstring_format_spec"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -33777,6 +33902,11 @@ _loop0_81_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_81[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "tstring_middle"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -34047,6 +34177,11 @@ _loop0_85_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_85[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' double_starred_kvpair"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -34227,6 +34362,11 @@ _loop0_88_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_88[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "('if' disjunction)"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -34380,6 +34520,11 @@ _loop0_90_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_90[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' (starred_expression | (assignment_expression | expression !':=') !'=')"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -34545,6 +34690,11 @@ _loop0_93_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_93[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' kwarg_or_starred"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -34662,6 +34812,11 @@ _loop0_95_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_95[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' kwarg_or_double_starred"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -34770,6 +34925,11 @@ _loop0_97_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_97[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "(',' star_target)"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -34845,6 +35005,11 @@ _loop0_98_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_98[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' star_target"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -35075,6 +35240,11 @@ _loop0_102_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_102[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' del_target"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -35191,6 +35361,11 @@ _loop0_104_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_104[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' expression"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -35408,6 +35583,11 @@ _loop0_108_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_108[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' (starred_expression !'=')"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -36247,6 +36427,11 @@ _loop0_121_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_121[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "star_named_expressions"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -36313,6 +36498,11 @@ _loop0_122_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_122[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "(star_targets '=')"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -36868,6 +37058,11 @@ _loop0_131_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_131[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' lambda_param"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -37204,6 +37399,11 @@ _loop0_137_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_137[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' dotted_name"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -37362,6 +37562,11 @@ _loop0_140_rule(Parser *p)
         D(fprintf(stderr, "%*c%s _loop0_140[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' (expression ['as' star_target])"));
     }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
+    }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
         PyMem_Free(_children);
@@ -37478,6 +37683,11 @@ _loop0_142_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_142[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "',' (expressions ['as' star_target])"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -37643,6 +37853,11 @@ _loop0_145_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_145[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "block"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {
@@ -39296,6 +39511,11 @@ _loop0_174_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s _loop0_174[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "(',' bitwise_or)"));
+    }
+    if (p->error_indicator) {
+        PyMem_Free(_children);
+        p->level--;
+        return NULL;
     }
     asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);
     if (!_seq) {

--- a/Tools/peg_generator/pegen/c_generator.py
+++ b/Tools/peg_generator/pegen/c_generator.py
@@ -658,10 +658,12 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
             )
             if is_repeat1:
                 self.print("if (_n == 0 || p->error_indicator) {")
-                with self.indent():
-                    self.print("PyMem_Free(_children);")
-                    self.add_return("NULL")
-                self.print("}")
+            else:
+                self.print("if (p->error_indicator) {")
+            with self.indent():
+                self.print("PyMem_Free(_children);")
+                self.add_return("NULL")
+            self.print("}")
             self.print("asdl_seq *_seq = (asdl_seq*)_Py_asdl_generic_seq_new(_n, p->arena);")
             self.out_of_memory_return("!_seq", cleanup_code="PyMem_Free(_children);")
             self.print("for (Py_ssize_t i = 0; i < _n; i++) asdl_seq_SET_UNTYPED(_seq, i, _children[i]);")


### PR DESCRIPTION
Currently, the pegen output produces this for '+' rules after the children have been parsed:

```
    if (_n == 0 || p->error_indicator) {
        PyMem_Free(_children);
        p->level--;
        return NULL;
    }
```

But for '*' rules, no check is done at all, (skipping the `_n == 0` makes sesnse of course)

For '*' it's possible for an error to be raised when parsing children, and currently the parser sets the error flag/exception but does not return NULL, so parent rules might not detect the error appropriately, as in this code:

        if (
            (a = _PyPegen_expect_token(p, FSTRING_START))  // token='FSTRING_START'
            &&
            (b = _loop0_79_rule(p))  // fstring_middle*
            &&
            (c = _PyPegen_expect_token(p, FSTRING_END))  // token='FSTRING_END'
        )

In this example, _PyPegen_expect_token can raise a SyntaxWarning which trips a debug assert.

This change outputs the same p->error_indicator check for '*' rules as for '+' rules.

Note, there are lots of rules affected by this change, but it seems to me that this is a latent bug for each of them, even though it might not be possible to trigger an error for all of them.

<!-- gh-issue-number: gh-153437 -->
* Issue: gh-153437
<!-- /gh-issue-number -->
