### PR TITLE
gh-153444: Fix compile warning in `Modules/_interpchannelsmodule.c`

### DIFF
--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -2935,7 +2935,8 @@ channelsmod_create(PyObject *self, PyObject *args, PyObject *kwds)
 
     int64_t cid = channel_create(&_globals.channels, defaults);
     if (cid < 0) {
-        (void)handle_channel_error(cid, self, cid);
+        // Negative `cid` can't be too big for a downcast:
+        (void)handle_channel_error((int)cid, self, cid);
         return NULL;
     }
     module_state *state = get_module_state(self);


### PR DESCRIPTION
Refs https://github.com/python/cpython/pull/152642

CC @ByteFlowing1337 @stestagg
Skipping news, because the change was not released.

<!-- gh-issue-number: gh-153444 -->
* Issue: gh-153444
<!-- /gh-issue-number -->
