### PR TITLE
gh-153463: Include sys/syscall.h independently of getrandom support

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -153,7 +153,7 @@
 #ifdef HAVE_LINUX_RANDOM_H
 #  include <linux/random.h>       // GRND_RANDOM
 #endif
-#ifdef HAVE_GETRANDOM_SYSCALL
+#ifdef HAVE_SYS_SYSCALL_H
 #  include <sys/syscall.h>        // syscall()
 #endif
 


### PR DESCRIPTION
Guard sys/syscall.h in Modules/posixmodules.c with HAVE_SYS_SYSCALL_H


<!-- gh-issue-number: gh-153463 -->
* Issue: gh-153463
<!-- /gh-issue-number -->
