### PR TITLE
gh-153477: Fix IDLE startup crash on a corrupt user config file

### DIFF
--- a/Lib/idlelib/config.py
+++ b/Lib/idlelib/config.py
@@ -25,7 +25,7 @@ configuration problem notification and resolution.
 """
 # TODOs added Oct 2014, tjr
 
-from configparser import ConfigParser
+from configparser import ConfigParser, Error
 import os
 import sys
 
@@ -75,7 +75,11 @@ class IdleConfParser(ConfigParser):
         "Load the configuration file from disk."
         if self.file and os.path.exists(self.file):
             with open(self.file, encoding='utf-8', errors='replace') as f:
-                self.read_file(f)
+                try:
+                    self.read_file(f)
+                except Error as err:  # any configparser parse error
+                    _warn(f'\nInvalid config file, using default config:\n'
+                          f'{self.file!r}\n{err}\n', self.file)
 
 class IdleUserConfParser(IdleConfParser):
     """

--- a/Lib/idlelib/idle_test/test_config.py
+++ b/Lib/idlelib/idle_test/test_config.py
@@ -94,7 +94,7 @@ class IdleConfParserTest(unittest.TestCase):
         self.assertEqual(parser.GetOptionList('Foo Bar'), ['foo'])
 
     def test_load_invalid_file(self):
-        # gh-000000: a corrupt config file must warn and fall back to
+        # gh-153477: a corrupt config file must warn and fall back to
         # defaults, not abort IDLE startup.
         self.addCleanup(config._warned.clear)
         with tempfile.TemporaryDirectory() as tdir:

--- a/Lib/idlelib/idle_test/test_config.py
+++ b/Lib/idlelib/idle_test/test_config.py
@@ -93,6 +93,20 @@ class IdleConfParserTest(unittest.TestCase):
         self.assertEqual(parser.Get('Foo Bar', 'foo'), 'newbar')
         self.assertEqual(parser.GetOptionList('Foo Bar'), ['foo'])
 
+    def test_load_invalid_file(self):
+        # gh-000000: a corrupt config file must warn and fall back to
+        # defaults, not abort IDLE startup.
+        self.addCleanup(config._warned.clear)
+        with tempfile.TemporaryDirectory() as tdir:
+            path = os.path.join(tdir, 'invalid.cfg')
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write('option = value\n')  # missing section header
+            parser = config.IdleConfParser(path)
+            with captured_stderr() as stderr:
+                parser.Load()  # must not raise
+            self.assertEqual(parser.sections(), [])
+            self.assertIn('Invalid config file', stderr.getvalue())
+
 
 class IdleUserConfParserTest(unittest.TestCase):
     """Test that IdleUserConfParser works"""

--- a/Misc/NEWS.d/next/Library/2026-07-10-19-40-00.gh-issue-153477.Cf9Ld2.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-10-19-40-00.gh-issue-153477.Cf9Ld2.rst
@@ -1,0 +1,2 @@
+IDLE now warns and falls back to the default configuration when a user
+configuration file cannot be parsed, instead of failing to start.


### PR DESCRIPTION
`IdleConfParser.Load` called `configparser`'s `read_file` with no error handling, so a corrupt or partially written user configuration file (for example one left behind by an interrupted `Save`) raised a `configparser.Error` such as `MissingSectionHeaderError` and aborted IDLE startup. This contradicts the graceful-degradation behavior documented in the `config.py` module docstring.

`Load` now catches `configparser.Error`, warns to stderr, and falls back to the default configuration. The regression test writes a headerless config file and checks that `Load` warns and leaves the parser empty instead of raising.

<!-- gh-issue-number: gh-153477 -->
* Issue: gh-153477
<!-- /gh-issue-number -->
