### PR TITLE
Fix typos in stdlib docstrings

### DIFF
--- a/Lib/compression/zstd/_zstdfile.py
+++ b/Lib/compression/zstd/_zstdfile.py
@@ -34,7 +34,7 @@ class ZstdFile(_streams.BaseStream):
                  level=None, options=None, zstd_dict=None):
         """Open a Zstandard compressed file in binary mode.
 
-        *file* can be either an file-like object, or a file name to open.
+        *file* can be either a file-like object, or a file name to open.
 
         *mode* can be 'r' for reading (default), 'w' for (over)writing, 'x'
         for creating exclusively, or 'a' for appending.  These can

--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -703,5 +703,5 @@ class Executor(object):
 
 class BrokenExecutor(RuntimeError):
     """
-    Raised when a executor has become non-functional after a severe failure.
+    Raised when an executor has become non-functional after a severe failure.
     """


### PR DESCRIPTION
Fix two small grammar issues in standard library docstrings.

This is a documentation-only change:

- no behavior changes
- no tests needed
- no NEWS entry needed
- no linked issue, since this is a typo/grammar-only fix