### PR TITLE
gh-153480: Stop IDLE crashing when a file open in the editor is deleted

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -1118,7 +1118,13 @@ class EditorWindow:
 
     def last_mtime(self):
         file = self.io.filename
-        return os.path.getmtime(file) if file else 0
+        if not file:
+            return 0
+        try:
+            return os.path.getmtime(file)
+        except OSError:
+            # File gone or inaccessible: keep the last known mtime.
+            return self.mtime
 
     def focus_in_event(self, event):
         mtime = self.last_mtime()

--- a/Lib/idlelib/idle_test/test_editor.py
+++ b/Lib/idlelib/idle_test/test_editor.py
@@ -1,6 +1,9 @@
 "Test editor, coverage 53%."
 
 from idlelib import editor
+import os
+import tempfile
+import types
 import unittest
 from collections import namedtuple
 from test.support import requires
@@ -235,6 +238,26 @@ class RMenuTest(unittest.TestCase):
 
     def test_rclick(self):
         pass
+
+
+class LastMtimeTest(unittest.TestCase):
+    # Exercise last_mtime as an unbound method on a stub; no GUI needed.
+
+    def test_deleted_file_does_not_raise(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, 'gone.py')
+            open(p, 'w').close()
+            mtime = os.path.getmtime(p)
+            os.remove(p)
+            stub = types.SimpleNamespace(
+                io=types.SimpleNamespace(filename=p), mtime=mtime)
+            # Must not raise; returns the last known mtime.
+            self.assertEqual(Editor.last_mtime(stub), mtime)
+
+    def test_no_filename_returns_zero(self):
+        stub = types.SimpleNamespace(
+            io=types.SimpleNamespace(filename=None), mtime=123)
+        self.assertEqual(Editor.last_mtime(stub), 0)
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2026-07-10-19-41-00.gh-issue-153480.EdMt1x.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-10-19-41-00.gh-issue-153480.EdMt1x.rst
@@ -1,0 +1,2 @@
+IDLE no longer crashes with a traceback when a file open in the editor is
+deleted or renamed by another program and the editor window is refocused.


### PR DESCRIPTION
`EditorWindow.focus_in_event` runs on every `<FocusIn>` event and calls `last_mtime`, which called `os.path.getmtime(self.io.filename)` with no error handling. When the open file had been deleted or renamed by another program, refocusing the editor window let a `FileNotFoundError` escape the Tk event handler and broke the modified-on-disk reload check.

`last_mtime` now guards `getmtime` with `try/except OSError` and returns the last known mtime, so `focus_in_event` sees no change and does not prompt to reload a file that is gone. The regression test drives `last_mtime` as an unbound method against a duck-typed stub (no GUI) for both the deleted-file and no-filename cases.

<!-- gh-issue-number: gh-153480 -->
* Issue: gh-153480
<!-- /gh-issue-number -->
