### PR TITLE
gh-153438: Update NuGet download URL

### DIFF
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -1174,9 +1174,9 @@ on using nuget. What follows is a summary that is sufficient for Python
 developers.
 
 The ``nuget.exe`` command line tool may be downloaded directly from
-``https://aka.ms/nugetclidl``, for example, using curl or PowerShell. With the
-tool, the latest version of Python for 64-bit or 32-bit machines is installed
-using::
+``https://dist.nuget.org/win-x86-commandline/latest/nuget.exe``, for example,
+using curl or PowerShell. With the tool, the latest version of Python for
+64-bit or 32-bit machines is installed using::
 
    nuget.exe install python -ExcludeVersion -OutputDirectory .
    nuget.exe install pythonx86 -ExcludeVersion -OutputDirectory .

--- a/Misc/NEWS.d/next/Build/2026-07-09-22-45-00.gh-issue-153438.Qr7N2p.rst
+++ b/Misc/NEWS.d/next/Build/2026-07-09-22-45-00.gh-issue-153438.Qr7N2p.rst
@@ -1,0 +1,2 @@
+Update Windows build and installer tooling and documentation to use the
+current download URL for ``nuget.exe``.

--- a/PCbuild/find_python.bat
+++ b/PCbuild/find_python.bat
@@ -55,7 +55,7 @@
 @set _Py_HOST_PYTHON=%HOST_PYTHON%
 @if "%_Py_HOST_PYTHON%"=="" set _Py_HOST_PYTHON=py
 @if "%_Py_NUGET%"=="" (set _Py_NUGET=%_Py_EXTERNALS_DIR%\nuget.exe)
-@if "%_Py_NUGET_URL%"=="" (set _Py_NUGET_URL=https://aka.ms/nugetclidl)
+@if "%_Py_NUGET_URL%"=="" (set _Py_NUGET_URL=https://dist.nuget.org/win-x86-commandline/latest/nuget.exe)
 @if NOT exist "%_Py_NUGET%" (
     @if not "%_Py_Quiet%"=="1" @echo Downloading nuget...
     @rem NB: Must use single quotes around NUGET here, NOT double!

--- a/Tools/msi/get_externals.bat
+++ b/Tools/msi/get_externals.bat
@@ -6,7 +6,7 @@ set HERE=%~dp0
 if "%PCBUILD%"=="" (set PCBUILD=%HERE%..\..\PCbuild\)
 if "%EXTERNALS_DIR%"=="" (set EXTERNALS_DIR=%HERE%..\..\externals\windows-installer)
 if "%NUGET%"=="" (set NUGET=%EXTERNALS_DIR%\..\nuget.exe)
-if "%NUGET_URL%"=="" (set NUGET_URL=https://aka.ms/nugetclidl)
+if "%NUGET_URL%"=="" (set NUGET_URL=https://dist.nuget.org/win-x86-commandline/latest/nuget.exe)
 
 set DO_FETCH=true
 set DO_CLEAN=false


### PR DESCRIPTION
Closes #153438.

The `aka.ms/nugetclidl` redirect no longer resolves to `nuget.exe`, which
breaks Windows build bootstrapping when no suitable Python is installed.

This change:

- uses the current NuGet CLI download URL in both the regular Windows build
  bootstrap and MSI external-dependency bootstrap;
- updates the matching Windows documentation; and
- adds a Build NEWS entry.

Validation:

- `Tools/patchcheck/patchcheck.py` against the staged diff
- `git diff --cached --check`
- replacement endpoint returns HTTP 200 with
  `Content-Type: application/x-msdownload`

The Windows batch execution itself was not run locally because the development
host is macOS.


<!-- gh-issue-number: gh-153438 -->
* Issue: gh-153438
<!-- /gh-issue-number -->
