### PR TITLE
Fix typo in config.sub comment ("filed" → "field")

### DIFF
--- a/config.sub
+++ b/config.sub
@@ -1729,7 +1729,7 @@ case $os in
 	# Likewise for "kernel-abi"
 	eabi* | gnueabi*)
 		;;
-	# VxWorks passes extra cpu info in the 4th filed.
+	# VxWorks passes extra cpu info in the 4th field.
 	simlinux | simwindows | spe)
 		;;
 	# See `case $cpu-$os` validation below


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This PR fixes a minor typo in a comment in `config.sub`.

Changes:
- Corrected "filed" to "field" in the VxWorks comment.

This is a documentation-only change and does not affect functionality.
