### PR TITLE
gh-151213: Remove remaining `--retries` refs from 3.14 asyncio tools docs

### DIFF
--- a/Doc/library/asyncio-tools.rst
+++ b/Doc/library/asyncio-tools.rst
@@ -19,8 +19,8 @@ The following commands inspect the process identified by ``PID``:
 
 .. code-block:: shell-session
 
-   $ python -m asyncio pstree [--retries N] PID
-   $ python -m asyncio ps [--retries N] PID
+   $ python -m asyncio pstree PID
+   $ python -m asyncio ps PID
 
 The commands read the target process state without executing any code in it.
 They are only available on supported platforms and may require permission to


### PR DESCRIPTION
Missed that one too. Sorry :/
<!--

Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151213 -->
* Issue: gh-151213
<!-- /gh-issue-number -->
