### PR TITLE
gh-153201: Make TSan CI mandatory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -554,6 +554,7 @@ jobs:
         - Thread
         free-threading:
         - false
+        - true
         sanitizer:
         - TSan
         include:
@@ -564,17 +565,6 @@ jobs:
     with:
       sanitizer: ${{ matrix.sanitizer }}
       free-threading: ${{ matrix.free-threading }}
-
-  # XXX: Temporarily allow this job to fail to not block PRs.
-  build-san-free-threading:
-    # ${{ '' } is a hack to nest jobs under the same sidebar category.
-    name: Sanitizers${{ '' }}  # zizmor: ignore[obfuscation]
-    needs: build-context
-    if: needs.build-context.outputs.run-ubuntu == 'true'
-    uses: ./.github/workflows/reusable-san.yml
-    with:
-      sanitizer: TSan
-      free-threading: true
 
   cross-build-linux:
     name: Cross build Linux
@@ -679,7 +669,6 @@ jobs:
     - test-hypothesis
     - build-asan
     - build-san
-    - build-san-free-threading
     - cross-build-linux
     - cifuzz
     if: always()
@@ -691,7 +680,6 @@ jobs:
         allowed-failures: >-
           build-android,
           build-emscripten,
-          build-san-free-threading,
           build-windows-msi,
           build-ubuntu-ssltests,
           test-hypothesis,


### PR DESCRIPTION


This reverts commit 4f39efc47de9b1bc1cd9dfa88060efb4ff104d01.

I have fixed the CI failures and it is green for last 2 days so making it mandatory again.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
