### PR TITLE
gh-153419: Fix several issues around bytearray __init__

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -1860,6 +1860,54 @@ class ByteArrayTest(BaseBytesTest, unittest.TestCase):
         alloc = b.__alloc__()
         self.assertGreater(alloc, len(b))
 
+    def test_reinit_small_buffer(self):
+        # gh-153419: reinitializing a bytearray whose buffer allocation is
+        # exactly one byte used to fail a debug assertion
+        b = bytearray(1)
+        b.__init__()
+        self.assertEqual(b, bytearray())
+
+    def test_reinit_empty_buffer(self):
+        # gh-153419: Calling __init__ on a bytearray that has an active
+        # export should only be allowed if the bytearray is unchanged.
+        b = bytearray()
+        with memoryview(b):
+            self.assertRaises(BufferError, b.__init__, b"abc")
+            self.assertRaises(BufferError, b.__init__, "abc", "ascii")
+            self.assertRaises(BufferError, b.__init__, 3)
+            b.__init__()
+            b.__init__(b"")
+            b.__init__("", "ascii")
+            self.assertEqual(b, bytearray())
+
+    def test_reinit_nonempty_buffer(self):
+        # gh-153419: If a buffer is non-empty and has an active export
+        # calling __init__ on it should always fail, even if the
+        # new value ends up the same as the old one. This is purely for
+        # practical reasons rather than a design goal.
+        b = bytearray(b"abc")
+        with memoryview(b):
+            self.assertRaises(BufferError, b.__init__)
+            self.assertRaises(BufferError, b.__init__, b"xy")
+            self.assertRaises(BufferError, b.__init__, b"abc")
+
+    def test_new_without_init(self):
+        # gh-153419: a bytearray must be fully initialized by __new__
+        # alone to ensure that the underlying buffer is always valid.
+        b = bytearray.__new__(bytearray)
+        self.assertEqual(b, bytearray())
+        b.append(1)
+        self.assertEqual(b, bytearray(b"\x01"))
+
+        class B(bytearray):
+            def __init__(self, *args):
+                pass  # does not call super().__init__()
+
+        b = B(b"ignored")
+        self.assertEqual(b, bytearray())
+        b.extend(b"abc")
+        self.assertEqual(b, bytearray(b"abc"))
+
     def test_extend(self):
         orig = b'hello'
         a = bytearray(orig)

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -2197,11 +2197,9 @@ class ByteArrayTest(BaseBytesTest, unittest.TestCase):
 
         self.assertRaises(BufferError, ba.hex, S(b':'))
 
-    def test_uninitialized_instance(self):
-        # A bytearray created with __new__ so that __init__ is never called
-        # (often as a side-effect of a subclass not calling super().__init__)
-        # must be left in a state where methods called on it do not crash or
-        # assert (see gh-153419).
+    def test_no_init_called(self):
+        # A bytearray created without calling bytearray.__init__
+        # should not crash the interpreter (see gh-153419).
         def uninitialized():
             return bytearray.__new__(bytearray)
 
@@ -2223,7 +2221,7 @@ class ByteArrayTest(BaseBytesTest, unittest.TestCase):
         a = uninitialized()
         a[:] = b"xyz"
 
-    def test_reinit_length1(self):
+    def test_reinit_length(self):
         # There is a shortcut taken when resizing, where alloc/2 < newsize.
         # In this case, the existing buffer is reused, rather than reset.
         # If this happens when newsize == 0 and alloc == 1, then various

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -25,7 +25,7 @@ from test.support import warnings_helper
 import test.string_tests
 import test.list_tests
 from test.support import bigaddrspacetest, MAX_Py_ssize_t
-from test.support.script_helper import assert_python_failure
+from test.support.script_helper import assert_python_failure, assert_python_ok
 
 
 if sys.flags.bytes_warning:
@@ -2196,6 +2196,85 @@ class ByteArrayTest(BaseBytesTest, unittest.TestCase):
                 return 1
 
         self.assertRaises(BufferError, ba.hex, S(b':'))
+
+
+class ByteArrayInitialization1Test(unittest.TestCase):
+    # A bytearray created with __new__ so that __init__ is never called
+    # (often as a side-effect of a subclass not calling super().__init__).
+    # Is left with ob_bytes_object == NULL.  It's easy for implementation
+    # code to not realise that ob_bytes_object can be NULL, so these tests
+    # verify a set of code paths that have historically crashed or asserted
+    # (see gh-153419)
+
+    def _check(self, stmt, expected):
+        code = textwrap.dedent(f"""
+            a = bytearray.__new__(bytearray)
+            {stmt}
+            print(list(a))
+        """)
+        rc, out, err = assert_python_ok('-c', code)
+        self.assertEqual(out.decode().strip(), expected)
+
+    def test_append(self):
+        self._check("a.append(1)", "[1]")
+
+    def test_insert(self):
+        self._check("a.insert(0, 1)", "[1]")
+
+    def test_extend_bytes(self):
+        self._check("a.extend(b'x')", "[120]")
+
+    def test_extend_iterable(self):
+        self._check("a.extend([1, 2, 3])", "[1, 2, 3]")
+
+    def test_iadd(self):
+        self._check("a += b'x'", "[120]")
+
+    def test_slice_assign(self):
+        self._check("a[:] = b'xyz'", "[120, 121, 122]")
+
+    def test_resize(self):
+        self._check("a.resize(4)", "[0, 0, 0, 0]")
+
+    def test_init_int(self):
+        self._check("a.__init__(5)", "[0, 0, 0, 0, 0]")
+
+    def test_init_bytes(self):
+        self._check("a.__init__(b'xyz')", "[120, 121, 122]")
+
+    def test_reinit_length1(self):
+        # There is a shortcut taken when resizing, where alloc/2 < newsize.
+        # In this case, the existing buffer is reused, rather than reset
+        # If this happens when newsize == 0 and alloc == 1, then various
+        # code assumptions can be violated.  This test should catch those
+        # in debug builds. (see gh-153419)
+        code = textwrap.dedent("""
+            a = bytearray(1)
+            a.__init__()
+            print(list(a))
+        """)
+        rc, out, err = assert_python_ok('-c', code)
+        self.assertEqual(out.decode().strip(), repr([]))
+
+    def test_take_bytes_all(self):
+        self._check("a.take_bytes()", "[]")
+
+    def test_take_bytes_zero(self):
+        self._check("a.take_bytes(0)", "[]")
+
+    def test_reinit_with_view(self):
+        code = textwrap.dedent("""
+            a = bytearray()
+            v = memoryview(a)
+            try:
+                a.__init__("x", "ascii")
+            except BufferError:
+                print("PASS")
+            else:
+                print("NO EXCEPTION")
+        """)
+        rc, out, err = assert_python_ok('-c', code)
+        self.assertEqual(out.decode().strip(), "PASS")
 
 
 class AssortedBytesTest(unittest.TestCase):

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -1860,54 +1860,6 @@ class ByteArrayTest(BaseBytesTest, unittest.TestCase):
         alloc = b.__alloc__()
         self.assertGreater(alloc, len(b))
 
-    def test_reinit_small_buffer(self):
-        # gh-153419: reinitializing a bytearray whose buffer allocation is
-        # exactly one byte used to fail a debug assertion
-        b = bytearray(1)
-        b.__init__()
-        self.assertEqual(b, bytearray())
-
-    def test_reinit_empty_buffer(self):
-        # gh-153419: Calling __init__ on a bytearray that has an active
-        # export should only be allowed if the bytearray is unchanged.
-        b = bytearray()
-        with memoryview(b):
-            self.assertRaises(BufferError, b.__init__, b"abc")
-            self.assertRaises(BufferError, b.__init__, "abc", "ascii")
-            self.assertRaises(BufferError, b.__init__, 3)
-            b.__init__()
-            b.__init__(b"")
-            b.__init__("", "ascii")
-            self.assertEqual(b, bytearray())
-
-    def test_reinit_nonempty_buffer(self):
-        # gh-153419: If a buffer is non-empty and has an active export
-        # calling __init__ on it should always fail, even if the
-        # new value ends up the same as the old one. This is purely for
-        # practical reasons rather than a design goal.
-        b = bytearray(b"abc")
-        with memoryview(b):
-            self.assertRaises(BufferError, b.__init__)
-            self.assertRaises(BufferError, b.__init__, b"xy")
-            self.assertRaises(BufferError, b.__init__, b"abc")
-
-    def test_new_without_init(self):
-        # gh-153419: a bytearray must be fully initialized by __new__
-        # alone to ensure that the underlying buffer is always valid.
-        b = bytearray.__new__(bytearray)
-        self.assertEqual(b, bytearray())
-        b.append(1)
-        self.assertEqual(b, bytearray(b"\x01"))
-
-        class B(bytearray):
-            def __init__(self, *args):
-                pass  # does not call super().__init__()
-
-        b = B(b"ignored")
-        self.assertEqual(b, bytearray())
-        b.extend(b"abc")
-        self.assertEqual(b, bytearray(b"abc"))
-
     def test_extend(self):
         orig = b'hello'
         a = bytearray(orig)

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -2200,10 +2200,8 @@ class ByteArrayTest(BaseBytesTest, unittest.TestCase):
     def test_uninitialized_instance(self):
         # A bytearray created with __new__ so that __init__ is never called
         # (often as a side-effect of a subclass not calling super().__init__)
-        # is left with ob_bytes_object == NULL.  It's easy for implementation
-        # code to not realize that ob_bytes_object can be NULL, so these
-        # checks exercise code paths that have historically crashed or
-        # asserted (see gh-153419).
+        # must be left in a state where methods called on it do not crash or
+        # assert (see gh-153419).
         def uninitialized():
             return bytearray.__new__(bytearray)
 

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -25,7 +25,7 @@ from test.support import warnings_helper
 import test.string_tests
 import test.list_tests
 from test.support import bigaddrspacetest, MAX_Py_ssize_t
-from test.support.script_helper import assert_python_failure, assert_python_ok
+from test.support.script_helper import assert_python_failure
 
 
 if sys.flags.bytes_warning:
@@ -2197,50 +2197,33 @@ class ByteArrayTest(BaseBytesTest, unittest.TestCase):
 
         self.assertRaises(BufferError, ba.hex, S(b':'))
 
+    def test_uninitialized_instance(self):
+        # A bytearray created with __new__ so that __init__ is never called
+        # (often as a side-effect of a subclass not calling super().__init__)
+        # is left with ob_bytes_object == NULL.  It's easy for implementation
+        # code to not realize that ob_bytes_object can be NULL, so these
+        # checks exercise code paths that have historically crashed or
+        # asserted (see gh-153419).
+        def uninitialized():
+            return bytearray.__new__(bytearray)
 
-class ByteArrayInitialization1Test(unittest.TestCase):
-    # A bytearray created with __new__ so that __init__ is never called
-    # (often as a side-effect of a subclass not calling super().__init__).
-    # Is left with ob_bytes_object == NULL.  It's easy for implementation
-    # code to not realize that ob_bytes_object can be NULL, so these tests
-    # verify a set of code paths that have historically crashed or asserted
-    # (see gh-153419).
+        uninitialized().insert(0, 1)
+        uninitialized().extend(b"x")
+        uninitialized().extend([1, 2, 3])
+        uninitialized().resize(4)
+        uninitialized().__init__(5)
+        uninitialized().__init__(b"xyz")
+        uninitialized().take_bytes()
+        uninitialized().take_bytes(0)
 
-    def _check(self, stmt, expected):
-        code = textwrap.dedent(f"""
-            a = bytearray.__new__(bytearray)
-            {stmt}
-            print(list(a))
-        """)
-        rc, out, err = assert_python_ok('-c', code)
-        self.assertEqual(out.decode().strip(), expected)
+        a = uninitialized()
+        a.append(1)
 
-    def test_append(self):
-        self._check("a.append(1)", "[1]")
+        a = uninitialized()
+        a += b"x"
 
-    def test_insert(self):
-        self._check("a.insert(0, 1)", "[1]")
-
-    def test_extend_bytes(self):
-        self._check("a.extend(b'x')", "[120]")
-
-    def test_extend_iterable(self):
-        self._check("a.extend([1, 2, 3])", "[1, 2, 3]")
-
-    def test_iadd(self):
-        self._check("a += b'x'", "[120]")
-
-    def test_slice_assign(self):
-        self._check("a[:] = b'xyz'", "[120, 121, 122]")
-
-    def test_resize(self):
-        self._check("a.resize(4)", "[0, 0, 0, 0]")
-
-    def test_init_int(self):
-        self._check("a.__init__(5)", "[0, 0, 0, 0, 0]")
-
-    def test_init_bytes(self):
-        self._check("a.__init__(b'xyz')", "[120, 121, 122]")
+        a = uninitialized()
+        a[:] = b"xyz"
 
     def test_reinit_length1(self):
         # There is a shortcut taken when resizing, where alloc/2 < newsize.
@@ -2248,33 +2231,15 @@ class ByteArrayInitialization1Test(unittest.TestCase):
         # If this happens when newsize == 0 and alloc == 1, then various
         # code assumptions can be violated.  This test should catch those
         # in debug builds. (see gh-153419)
-        code = textwrap.dedent("""
-            a = bytearray(1)
-            a.__init__()
-            print(list(a))
-        """)
-        rc, out, err = assert_python_ok('-c', code)
-        self.assertEqual(out.decode().strip(), repr([]))
-
-    def test_take_bytes_all(self):
-        self._check("a.take_bytes()", "[]")
-
-    def test_take_bytes_zero(self):
-        self._check("a.take_bytes(0)", "[]")
+        a = bytearray(1)
+        a.__init__()
+        self.assertEqual(a, b"")
 
     def test_reinit_with_view(self):
-        code = textwrap.dedent("""
-            a = bytearray()
-            v = memoryview(a)
-            try:
-                a.__init__("x", "ascii")
-            except BufferError:
-                print("PASS")
-            else:
-                print("NO EXCEPTION")
-        """)
-        rc, out, err = assert_python_ok('-c', code)
-        self.assertEqual(out.decode().strip(), "PASS")
+        a = bytearray()
+        with memoryview(a):
+            self.assertRaises(BufferError, a.__init__, "x", "ascii")
+        self.assertEqual(a, b"")
 
 
 class AssortedBytesTest(unittest.TestCase):

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -2202,9 +2202,9 @@ class ByteArrayInitialization1Test(unittest.TestCase):
     # A bytearray created with __new__ so that __init__ is never called
     # (often as a side-effect of a subclass not calling super().__init__).
     # Is left with ob_bytes_object == NULL.  It's easy for implementation
-    # code to not realise that ob_bytes_object can be NULL, so these tests
+    # code to not realize that ob_bytes_object can be NULL, so these tests
     # verify a set of code paths that have historically crashed or asserted
-    # (see gh-153419)
+    # (see gh-153419).
 
     def _check(self, stmt, expected):
         code = textwrap.dedent(f"""
@@ -2244,7 +2244,7 @@ class ByteArrayInitialization1Test(unittest.TestCase):
 
     def test_reinit_length1(self):
         # There is a shortcut taken when resizing, where alloc/2 < newsize.
-        # In this case, the existing buffer is reused, rather than reset
+        # In this case, the existing buffer is reused, rather than reset.
         # If this happens when newsize == 0 and alloc == 1, then various
         # code assumptions can be violated.  This test should catch those
         # in debug builds. (see gh-153419)

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -2200,25 +2200,25 @@ class ByteArrayTest(BaseBytesTest, unittest.TestCase):
     def test_no_init_called(self):
         # A bytearray created without calling bytearray.__init__
         # should not crash the interpreter (see gh-153419).
-        def uninitialized():
+        def bytearray_new():
             return bytearray.__new__(bytearray)
 
-        uninitialized().insert(0, 1)
-        uninitialized().extend(b"x")
-        uninitialized().extend([1, 2, 3])
-        uninitialized().resize(4)
-        uninitialized().__init__(5)
-        uninitialized().__init__(b"xyz")
-        uninitialized().take_bytes()
-        uninitialized().take_bytes(0)
+        bytearray_new().insert(0, 1)
+        bytearray_new().extend(b"x")
+        bytearray_new().extend([1, 2, 3])
+        bytearray_new().resize(4)
+        bytearray_new().__init__(5)
+        bytearray_new().__init__(b"xyz")
+        bytearray_new().take_bytes()
+        bytearray_new().take_bytes(0)
 
-        a = uninitialized()
+        a = bytearray_new()
         a.append(1)
 
-        a = uninitialized()
+        a = bytearray_new()
         a += b"x"
 
-        a = uninitialized()
+        a = bytearray_new()
         a[:] = b"xyz"
 
     def test_reinit_length(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-10-10-53-11.gh-issue-153419.QI9uwG.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-10-10-53-11.gh-issue-153419.QI9uwG.rst
@@ -1,0 +1,2 @@
+Fix several crashes relating to calling (or not calling)
+``bytearray.__init__`` in unusual ways.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-10-10-53-11.gh-issue-153419.QI9uwG.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-10-10-53-11.gh-issue-153419.QI9uwG.rst
@@ -1,2 +1,0 @@
-Fix several crashes relating to calling (or not calling)
-``bytearray.__init__`` in unusual ways.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-01-17-57.gh-issue-153419.U8HJOJ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-01-17-57.gh-issue-153419.U8HJOJ.rst
@@ -1,0 +1,4 @@
+Fix several ``bytearray`` crashes caused by calling or not calling __init__
+at the expected times.  As a side-effect, calling __init__ on an empty
+bytearray that has an active buffer view (``memoryview`` or similar) will
+now raise a ``BufferError``

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-01-17-57.gh-issue-153419.U8HJOJ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-01-17-57.gh-issue-153419.U8HJOJ.rst
@@ -1,4 +1,1 @@
-Fix several ``bytearray`` crashes caused by calling, or not calling,
-``__init__`` when expected.  As a side-effect, calling ``__init__`` on
-an empty ``bytearray`` that has an active buffer view (``memoryview`` or
-similar) now raises a ``BufferError``.
+Fix several :class:`bytearray` crashes caused by calling :meth:`~object.__init__`/:meth:`~object.__new__` in unusual ways.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-01-17-57.gh-issue-153419.U8HJOJ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-01-17-57.gh-issue-153419.U8HJOJ.rst
@@ -1,1 +1,1 @@
-Fix several :class:`bytearray` crashes caused by calling :meth:`~object.__init__`/:meth:`~object.__new__` in unusual ways.
+Fix multiple :class:`bytearray` crashes and reference leaks caused by skipping :meth:`~object.__init__` and broken state setup code.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-01-17-57.gh-issue-153419.U8HJOJ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-01-17-57.gh-issue-153419.U8HJOJ.rst
@@ -1,4 +1,4 @@
-Fix several ``bytearray`` crashes caused by calling or not calling __init__
-at the expected times.  As a side-effect, calling __init__ on an empty
-bytearray that has an active buffer view (``memoryview`` or similar) will
-now raise a ``BufferError``
+Fix several ``bytearray`` crashes caused by calling, or not calling,
+``__init__`` when expected.  As a side-effect, calling ``__init__`` on
+an empty ``bytearray`` that has an active buffer view (``memoryview`` or
+similar) now raises a ``BufferError``.

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -236,6 +236,14 @@ bytearray_resize_lock_held(PyObject *self, Py_ssize_t requested_size)
         return -1;
     }
 
+    if (requested_size == 0) {
+        /* Resizing to zero just resets to the empty constant (#153419) */
+        Py_XSETREF(obj->ob_bytes_object,
+                   Py_GetConstant(Py_CONSTANT_EMPTY_BYTES));
+        bytearray_reinit_from_bytes(obj, 0, 0);
+        return 0;
+    }
+
     if (size + logical_offset <= alloc) {
         /* Current buffer is large enough to host the requested size,
            decide on a strategy. */
@@ -902,6 +910,19 @@ bytearray_ass_subscript(PyObject *op, PyObject *index, PyObject *values)
     return ret;
 }
 
+static PyObject *
+bytearray_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    PyObject *self = PyType_GenericNew(type, args, kwds);
+    if (self == NULL) {
+        return NULL;
+    }
+    PyByteArrayObject *obj = _PyByteArray_CAST(self);
+    obj->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
+    bytearray_reinit_from_bytes(obj, 0, 0);
+    return self;
+}
+
 /*[clinic input]
 bytearray.__init__
 
@@ -920,22 +941,13 @@ bytearray___init___impl(PyByteArrayObject *self, PyObject *arg,
     PyObject *it;
     PyObject *(*iternext)(PyObject *);
 
-    /* First __init__; set ob_bytes_object so ob_bytes is always non-null. */
-    if (self->ob_bytes_object == NULL) {
-        self->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
-        bytearray_reinit_from_bytes(self, 0, 0);
-        self->ob_exports = 0;
-    }
-
     if (Py_SIZE(self) != 0) {
-        /* Empty previous contents (yes, do this first of all!) */
+        /* Empty previous contents if possible (yes, do this first of all!). */
         if (PyByteArray_Resize((PyObject *)self, 0) < 0)
             return -1;
     }
 
-    /* Should be caused by first init or the resize to 0. */
     assert(self->ob_bytes_object == Py_GetConstantBorrowed(Py_CONSTANT_EMPTY_BYTES));
-    assert(self->ob_exports == 0);
 
     /* Make a quick exit if no first argument */
     if (arg == NULL) {
@@ -963,8 +975,11 @@ bytearray___init___impl(PyByteArrayObject *self, PyObject *arg,
         }
         assert(PyBytes_Check(encoded));
 
-        /* Most encodes return a new unique bytes, just use it as buffer. */
-        if (_PyObject_IsUniquelyReferenced(encoded)
+        /* Most encodes return a new unique bytes, just use it as buffer.
+           If there are active exports, let `iconcat` handle raising the
+           error when encoded is not empty */
+        if (self->ob_exports == 0
+            && _PyObject_IsUniquelyReferenced(encoded)
             && PyBytes_CheckExact(encoded))
         {
             Py_ssize_t size = Py_SIZE(encoded);
@@ -2937,7 +2952,7 @@ PyTypeObject PyByteArray_Type = {
     0,                                  /* tp_dictoffset */
     bytearray___init__,                 /* tp_init */
     PyType_GenericAlloc,                /* tp_alloc */
-    PyType_GenericNew,                  /* tp_new */
+    bytearray_new,                      /* tp_new */
     PyObject_Free,                      /* tp_free */
     .tp_version_tag = _Py_TYPE_VERSION_BYTEARRAY,
 };

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -916,15 +916,15 @@ bytearray_ass_subscript(PyObject *op, PyObject *index, PyObject *values)
 static PyObject *
 bytearray_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-    PyObject *obj = PyType_GenericNew(type, args, kwds);
-    if (obj == NULL) {
+    PyObject *op = PyType_GenericNew(type, args, kwds);
+    if (op == NULL) {
         return NULL;
     }
-    PyByteArrayObject *self = _PyByteArray_CAST(obj);
+    PyByteArrayObject *self = _PyByteArray_CAST(op);
     self->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
     bytearray_reinit_from_bytes(self, 0, 0);
     self->ob_exports = 0;
-    return obj;
+    return op;
 }
 
 /*[clinic input]
@@ -1628,7 +1628,7 @@ bytearray_take_bytes_impl(PyByteArrayObject *self, PyObject *n)
     }
 
     if (_PyBytes_Resize(&self->ob_bytes_object, to_take) == -1) {
-        assert(self.ob_bytes_object == NULL);
+        assert(self->ob_bytes_object == NULL);
         self->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
         bytearray_reinit_from_bytes(self, 0, 0);
         Py_DECREF(remaining);

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -236,14 +236,6 @@ bytearray_resize_lock_held(PyObject *self, Py_ssize_t requested_size)
         return -1;
     }
 
-    if (requested_size == 0) {
-        /* Resizing to zero just resets to the empty constant (#153419) */
-        Py_XSETREF(obj->ob_bytes_object,
-                   Py_GetConstant(Py_CONSTANT_EMPTY_BYTES));
-        bytearray_reinit_from_bytes(obj, 0, 0);
-        return 0;
-    }
-
     if (size + logical_offset <= alloc) {
         /* Current buffer is large enough to host the requested size,
            decide on a strategy. */
@@ -910,19 +902,6 @@ bytearray_ass_subscript(PyObject *op, PyObject *index, PyObject *values)
     return ret;
 }
 
-static PyObject *
-bytearray_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
-{
-    PyObject *self = PyType_GenericNew(type, args, kwds);
-    if (self == NULL) {
-        return NULL;
-    }
-    PyByteArrayObject *obj = _PyByteArray_CAST(self);
-    obj->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
-    bytearray_reinit_from_bytes(obj, 0, 0);
-    return self;
-}
-
 /*[clinic input]
 bytearray.__init__
 
@@ -941,13 +920,22 @@ bytearray___init___impl(PyByteArrayObject *self, PyObject *arg,
     PyObject *it;
     PyObject *(*iternext)(PyObject *);
 
+    /* First __init__; set ob_bytes_object so ob_bytes is always non-null. */
+    if (self->ob_bytes_object == NULL) {
+        self->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
+        bytearray_reinit_from_bytes(self, 0, 0);
+        self->ob_exports = 0;
+    }
+
     if (Py_SIZE(self) != 0) {
-        /* Empty previous contents if possible (yes, do this first of all!). */
+        /* Empty previous contents (yes, do this first of all!) */
         if (PyByteArray_Resize((PyObject *)self, 0) < 0)
             return -1;
     }
 
+    /* Should be caused by first init or the resize to 0. */
     assert(self->ob_bytes_object == Py_GetConstantBorrowed(Py_CONSTANT_EMPTY_BYTES));
+    assert(self->ob_exports == 0);
 
     /* Make a quick exit if no first argument */
     if (arg == NULL) {
@@ -975,11 +963,8 @@ bytearray___init___impl(PyByteArrayObject *self, PyObject *arg,
         }
         assert(PyBytes_Check(encoded));
 
-        /* Most encodes return a new unique bytes, just use it as buffer.
-           If there are active exports, let `iconcat` handle raising the
-           error when encoded is not empty */
-        if (self->ob_exports == 0
-            && _PyObject_IsUniquelyReferenced(encoded)
+        /* Most encodes return a new unique bytes, just use it as buffer. */
+        if (_PyObject_IsUniquelyReferenced(encoded)
             && PyBytes_CheckExact(encoded))
         {
             Py_ssize_t size = Py_SIZE(encoded);
@@ -2952,7 +2937,7 @@ PyTypeObject PyByteArray_Type = {
     0,                                  /* tp_dictoffset */
     bytearray___init__,                 /* tp_init */
     PyType_GenericAlloc,                /* tp_alloc */
-    bytearray_new,                      /* tp_new */
+    PyType_GenericNew,                  /* tp_new */
     PyObject_Free,                      /* tp_free */
     .tp_version_tag = _Py_TYPE_VERSION_BYTEARRAY,
 };

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -214,13 +214,7 @@ bytearray_resize_lock_held(PyObject *self, Py_ssize_t requested_size)
     _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(self);
     PyByteArrayObject *obj = ((PyByteArrayObject *)self);
 
-    /* If ob_bytes_object has not been initialized yet, eagerly initialize
-       it here so the following code can reason about state more easily,
-       and things like pointer comparisons are valid. */
-    if (obj->ob_bytes_object == NULL) {
-        obj->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
-        bytearray_reinit_from_bytes(obj, 0, 0);
-    }
+    assert(obj->ob_bytes_object != NULL);
 
     /* All computations are done unsigned to avoid integer overflows
        (see issue #22335). */
@@ -920,6 +914,19 @@ bytearray_ass_subscript(PyObject *op, PyObject *index, PyObject *values)
     return ret;
 }
 
+static PyObject *
+bytearray_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    PyObject *self = PyType_GenericNew(type, args, kwds);
+    if (self == NULL) {
+        return NULL;
+    }
+    PyByteArrayObject *obj = _PyByteArray_CAST(self);
+    obj->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
+    bytearray_reinit_from_bytes(obj, 0, 0);
+    return self;
+}
+
 /*[clinic input]
 bytearray.__init__
 
@@ -942,8 +949,7 @@ bytearray___init___impl(PyByteArrayObject *self, PyObject *arg,
         return -1;
     }
 
-    /* Empty any previous contents (do this first of all!).
-       Also initializes ob_bytes_object if needed */
+    /* Empty any previous contents (do this first of all!). */
     if (PyByteArray_Resize((PyObject *)self, 0) < 0) {
         return -1;
     }
@@ -1622,8 +1628,6 @@ bytearray_take_bytes_impl(PyByteArrayObject *self, PyObject *n)
     }
 
     if (_PyBytes_Resize(&self->ob_bytes_object, to_take) == -1) {
-        /* _PyBytes_Resize has made ob_bytes_object NULL here. We need to
-           ensure that the other bytearray fields are consistent. */
         self->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
         bytearray_reinit_from_bytes(self, 0, 0);
         Py_DECREF(remaining);
@@ -2956,7 +2960,7 @@ PyTypeObject PyByteArray_Type = {
     0,                                  /* tp_dictoffset */
     bytearray___init__,                 /* tp_init */
     PyType_GenericAlloc,                /* tp_alloc */
-    PyType_GenericNew,                  /* tp_new */
+    bytearray_new,                      /* tp_new */
     PyObject_Free,                      /* tp_free */
     .tp_version_tag = _Py_TYPE_VERSION_BYTEARRAY,
 };

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -916,15 +916,15 @@ bytearray_ass_subscript(PyObject *op, PyObject *index, PyObject *values)
 static PyObject *
 bytearray_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-    PyObject *self = PyType_GenericNew(type, args, kwds);
-    if (self == NULL) {
+    PyObject *obj = PyType_GenericNew(type, args, kwds);
+    if (obj == NULL) {
         return NULL;
     }
-    PyByteArrayObject *obj = _PyByteArray_CAST(self);
-    obj->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
-    bytearray_reinit_from_bytes(obj, 0, 0);
-    obj->ob_exports = 0;
-    return self;
+    PyByteArrayObject *self = _PyByteArray_CAST(obj);
+    self->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
+    bytearray_reinit_from_bytes(self, 0, 0);
+    self->ob_exports = 0;
+    return obj;
 }
 
 /*[clinic input]
@@ -955,7 +955,6 @@ bytearray___init___impl(PyByteArrayObject *self, PyObject *arg,
     if (PyByteArray_Resize((PyObject *)self, 0) < 0) {
         return -1;
     }
-
     assert(self->ob_bytes_object == Py_GetConstantBorrowed(Py_CONSTANT_EMPTY_BYTES));
     assert(self->ob_exports == 0);
 
@@ -1629,6 +1628,7 @@ bytearray_take_bytes_impl(PyByteArrayObject *self, PyObject *n)
     }
 
     if (_PyBytes_Resize(&self->ob_bytes_object, to_take) == -1) {
+        assert(self.ob_bytes_object == NULL);
         self->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
         bytearray_reinit_from_bytes(self, 0, 0);
         Py_DECREF(remaining);

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -923,6 +923,7 @@ bytearray_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyByteArrayObject *obj = _PyByteArray_CAST(self);
     obj->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
     bytearray_reinit_from_bytes(obj, 0, 0);
+    obj->ob_exports = 0;
     return self;
 }
 
@@ -944,6 +945,8 @@ bytearray___init___impl(PyByteArrayObject *self, PyObject *arg,
     PyObject *it;
     PyObject *(*iternext)(PyObject *);
 
+    /* Disallow any __init__ call if the object is not resizable (has exports)
+       to make the handling of non-null `source` init values simpler. */
     if (!_canresize(self)) {
         return -1;
     }

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -1622,8 +1622,8 @@ bytearray_take_bytes_impl(PyByteArrayObject *self, PyObject *n)
     }
 
     if (_PyBytes_Resize(&self->ob_bytes_object, to_take) == -1) {
-        /* _PyBytes_Resize has made ob_bytes_object NULL here
-           we need to ensure that the other byte array fields are consistent. */
+        /* _PyBytes_Resize has made ob_bytes_object NULL here. We need to
+           ensure that the other bytearray fields are consistent. */
         self->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
         bytearray_reinit_from_bytes(self, 0, 0);
         Py_DECREF(remaining);

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -213,6 +213,15 @@ bytearray_resize_lock_held(PyObject *self, Py_ssize_t requested_size)
 {
     _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(self);
     PyByteArrayObject *obj = ((PyByteArrayObject *)self);
+
+    /* If ob_bytes_object has not been initialized yet, eagerly initialize
+       it here so the following code can reason about state more easily,
+       and things like pointer comparisons are valid. */
+    if (obj->ob_bytes_object == NULL) {
+        obj->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
+        bytearray_reinit_from_bytes(obj, 0, 0);
+    }
+
     /* All computations are done unsigned to avoid integer overflows
        (see issue #22335). */
     size_t alloc = (size_t) obj->ob_alloc;
@@ -234,6 +243,15 @@ bytearray_resize_lock_held(PyObject *self, Py_ssize_t requested_size)
     }
     if (!_canresize(obj)) {
         return -1;
+    }
+
+    /* When resizing to 0, always reset to the empty-bytes constant to avoid
+       complexity in the realloc path below (see gh-153419). */
+    if (requested_size == 0) {
+        Py_XSETREF(obj->ob_bytes_object,
+                   Py_GetConstant(Py_CONSTANT_EMPTY_BYTES));
+        bytearray_reinit_from_bytes(obj, 0, 0);
+        return 0;
     }
 
     if (size + logical_offset <= alloc) {
@@ -920,20 +938,17 @@ bytearray___init___impl(PyByteArrayObject *self, PyObject *arg,
     PyObject *it;
     PyObject *(*iternext)(PyObject *);
 
-    /* First __init__; set ob_bytes_object so ob_bytes is always non-null. */
-    if (self->ob_bytes_object == NULL) {
-        self->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
-        bytearray_reinit_from_bytes(self, 0, 0);
-        self->ob_exports = 0;
+    if (!_canresize(self)) {
+        return -1;
     }
 
-    if (Py_SIZE(self) != 0) {
-        /* Empty previous contents (yes, do this first of all!) */
-        if (PyByteArray_Resize((PyObject *)self, 0) < 0)
-            return -1;
+    /* Empty any previous contents (do this first of all!).
+       Also initializes ob_bytes_object if needed */
+    if (PyByteArray_Resize((PyObject *)self, 0) < 0) {
+        return -1;
     }
 
-    /* Should be caused by first init or the resize to 0. */
+    /* PyByteArray_Resize(,0) should always leave the empty bytes constant */
     assert(self->ob_bytes_object == Py_GetConstantBorrowed(Py_CONSTANT_EMPTY_BYTES));
     assert(self->ob_exports == 0);
 
@@ -1607,6 +1622,10 @@ bytearray_take_bytes_impl(PyByteArrayObject *self, PyObject *n)
     }
 
     if (_PyBytes_Resize(&self->ob_bytes_object, to_take) == -1) {
+        /* _PyBytes_Resize has made ob_bytes_object NULL here
+           we need to ensure that the other byte array fields are consistent. */
+        self->ob_bytes_object = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
+        bytearray_reinit_from_bytes(self, 0, 0);
         Py_DECREF(remaining);
         return NULL;
     }

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -239,7 +239,7 @@ bytearray_resize_lock_held(PyObject *self, Py_ssize_t requested_size)
         return -1;
     }
 
-    /* resize to 0 resets to empty bytes (see issue #153419)*/
+    /* Resize to 0 resets to empty bytes (see issue #153419). */
     if (requested_size == 0) {
         Py_SETREF(obj->ob_bytes_object,
                    Py_GetConstant(Py_CONSTANT_EMPTY_BYTES));

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -241,7 +241,7 @@ bytearray_resize_lock_held(PyObject *self, Py_ssize_t requested_size)
 
     /* resize to 0 resets to empty bytes (see issue #153419)*/
     if (requested_size == 0) {
-        Py_XSETREF(obj->ob_bytes_object,
+        Py_SETREF(obj->ob_bytes_object,
                    Py_GetConstant(Py_CONSTANT_EMPTY_BYTES));
         bytearray_reinit_from_bytes(obj, 0, 0);
         return 0;

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -239,8 +239,7 @@ bytearray_resize_lock_held(PyObject *self, Py_ssize_t requested_size)
         return -1;
     }
 
-    /* When resizing to 0, always reset to the empty-bytes constant to avoid
-       complexity in the realloc path below (see gh-153419). */
+    /* resize to 0 resets to empty bytes (see issue #153419)*/
     if (requested_size == 0) {
         Py_XSETREF(obj->ob_bytes_object,
                    Py_GetConstant(Py_CONSTANT_EMPTY_BYTES));
@@ -954,7 +953,6 @@ bytearray___init___impl(PyByteArrayObject *self, PyObject *arg,
         return -1;
     }
 
-    /* PyByteArray_Resize(,0) should always leave the empty bytes constant */
     assert(self->ob_bytes_object == Py_GetConstantBorrowed(Py_CONSTANT_EMPTY_BYTES));
     assert(self->ob_exports == 0);
 

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -3380,6 +3380,7 @@ _PyBytes_Resize(PyObject **pv, Py_ssize_t newsize)
         Py_DECREF(v);
         return (*pv == NULL) ? -1 : 0;
     }
+    assert(v != bytes_get_empty());
 
 #ifdef Py_TRACE_REFS
     _Py_ForgetReference(v);


### PR DESCRIPTION
Introduce a bytearray_new function to ensure that
ob_bytes_object is always set on a bytearray.

Resizing a bytearray to 0 length explicitly sets
the ob_bytes_object to the empty constant immortal.

Add a check in the 'bytearray init from string'
fast path to ensure there are no active exports.

This fixes asserts/crashes on the following:
 - `bytearray(1).__init__()`
 - `bytearray().__new__(bytearray).append(1)`
 - `a = bytearray(); b = memoryview(a); a.__init__('x', 'ascii')`

I realise that the explicit setting of bytes_object to `Py_CONSTANT_EMPTY_BYTES` is not strictly necessary, as this is also done by the `_PyBytes_Resize` too, but this seemed to mark the intent of what's happening more clearly, given we rely and assert on that exact behaviour.

<!-- gh-issue-number: gh-153419 -->
* Issue: gh-153419
<!-- /gh-issue-number -->
