### PR TITLE
gh-153506: Guard IDLE completions against a non-iterable __all__

### DIFF
--- a/Lib/idlelib/autocomplete.py
+++ b/Lib/idlelib/autocomplete.py
@@ -180,15 +180,18 @@ class AutoComplete:
         else:
             if mode == ATTRS:
                 if what == "":  # Main module names.
-                    namespace = {**__main__.__builtins__.__dict__,
-                                 **__main__.__dict__}
-                    bigl = eval("dir()", namespace)
-                    bigl.extend(completion_kwds)
-                    bigl.sort()
-                    if "__all__" in bigl:
-                        smalll = sorted(eval("__all__", namespace))
-                    else:
-                        smalll = [s for s in bigl if s[:1] != '_']
+                    try:
+                        namespace = {**__main__.__builtins__.__dict__,
+                                     **__main__.__dict__}
+                        bigl = eval("dir()", namespace)
+                        bigl.extend(completion_kwds)
+                        bigl.sort()
+                        if "__all__" in bigl:
+                            smalll = sorted(eval("__all__", namespace))
+                        else:
+                            smalll = [s for s in bigl if s[:1] != '_']
+                    except Exception:  # a broken __all__ must not abort completion
+                        return [], []
                 else:
                     try:
                         entity = self.get_entity(what)

--- a/Lib/idlelib/idle_test/test_autocomplete.py
+++ b/Lib/idlelib/idle_test/test_autocomplete.py
@@ -277,6 +277,15 @@ class AutoCompleteTest(unittest.TestCase):
             self.assertEqual(s, ['monty', 'python'])
             self.assertEqual(b, ['.hidden', 'monty', 'python'])
 
+    def test_fetch_completions_bad_all(self):
+        # gh-153506: a non-iterable __main__.__all__ must not abort
+        # module-name completion at an empty prefix.
+        acp = self.autocomplete
+        with patch.dict('__main__.__dict__', {'__all__': None}):
+            self.assertEqual(acp.fetch_completions('', ac.ATTRS), ([], []))
+        # A valid namespace still yields real completions.
+        self.assertIn('__name__', acp.fetch_completions('', ac.ATTRS)[1])
+
     def test_get_entity(self):
         # Test that a name is in the namespace of sys.modules and
         # __main__.__dict__.

--- a/Misc/NEWS.d/next/Library/2026-07-10-19-42-00.gh-issue-153506.AcAll7.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-10-19-42-00.gh-issue-153506.AcAll7.rst
@@ -1,0 +1,2 @@
+IDLE no longer fails to show module-name completions when the interactive
+namespace has a non-iterable ``__all__``.


### PR DESCRIPTION
`autocomplete.AutoComplete.fetch_completions` evaluated `__main__.__all__` in the ATTRS empty-prefix branch with `sorted(eval("__all__", namespace))` and no guard, while the sibling non-empty-prefix branch already wrapped the equivalent `sorted(entity.__all__)` in `try`/`except` and returned empty lists on failure. A non-iterable `__all__` in the interactive namespace (for example `__all__ = None`) therefore raised `TypeError` on Tab at an empty prefix instead of showing completions.

This guards the empty-prefix branch the same way, returning empty completion lists when `__all__` cannot be evaluated or sorted, and leaves the sibling branch untouched. A regression test drives `fetch_completions` with a patched `__main__.__all__` and asserts empty lists, and that a valid namespace still yields completions.

<!-- gh-issue-number: gh-153506 -->
* Issue: gh-153506
<!-- /gh-issue-number -->
