### PR TITLE
gh-148589: Clarify PyThreadState_GetFrame thread state requirement

### DIFF
--- a/Doc/c-api/threads.rst
+++ b/Doc/c-api/threads.rst
@@ -708,7 +708,8 @@ Low-level APIs
 
    See also :c:func:`PyEval_GetFrame`.
 
-   *tstate* must not be ``NULL``, and must be :term:`attached <attached thread state>`.
+   *tstate* must not be ``NULL``, and must be the :term:`thread state`
+   :term:`attached <attached thread state>` to the current OS thread.
 
    .. versionadded:: 3.9
 


### PR DESCRIPTION
## Summary

Clarify that `PyThreadState_GetFrame()` expects the supplied thread state to be the thread state attached to the current OS thread.

This follows the maintainer discussion in GH-148589 and matches the glossary definition of an attached thread state.

This is a documentation-only change. No runtime behavior is changed.

Close: gh-148589