### PR TITLE
gh-153513: Remove redundant conversions in tkinter tests

### DIFF
--- a/Lib/test/test_tkinter/test_filedialog.py
+++ b/Lib/test/test_tkinter/test_filedialog.py
@@ -124,7 +124,7 @@ class FileDialogTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(d.ok_button.winfo_class(), 'Button')
         self.assertEqual(d.selection.winfo_class(), 'Entry')
         if d.top._windowingsystem == 'x11':
-            self.assertEqual(str(d.botframe.cget('relief')), 'raised')
+            self.assertEqual(d.botframe.cget('relief'), 'raised')
 
     def test_background(self):
         # The ttk dialog adopts the ttk background, even a customized one, while
@@ -145,18 +145,19 @@ class FileDialogTest(AbstractTkTest, unittest.TestCase):
         # The buttons' "&" accelerators are parsed.
         d = self.open()
         self.assertEqual(str(d.ok_button.cget('text')), 'OK')
-        self.assertEqual(int(d.ok_button.cget('underline')), 0)
+        self.assertEqual(d.ok_button.cget('underline'),
+                         0 if self.wantobjects else '0')
 
     def test_default_ring(self):
         # The default ring follows the keyboard focus among the buttons.
         d = self.open()
-        self.assertEqual(str(d.cancel_button.cget('default')), 'normal')
+        self.assertEqual(d.cancel_button.cget('default'), 'normal')
         d.cancel_button.focus_force()
         d.top.update()
-        self.assertEqual(str(d.cancel_button.cget('default')), 'active')
+        self.assertEqual(d.cancel_button.cget('default'), 'active')
         d.ok_button.focus_force()
         d.top.update()
-        self.assertEqual(str(d.cancel_button.cget('default')), 'normal')
+        self.assertEqual(d.cancel_button.cget('default'), 'normal')
 
     def test_alt_key(self):
         # Alt + the underlined letter invokes the matching button.
@@ -182,8 +183,8 @@ class FileDialogTest(AbstractTkTest, unittest.TestCase):
     def test_horizontal_scrollbars(self):
         # Each list has a horizontal scrollbar besides the vertical one.
         d = self.open()
-        self.assertEqual(str(d.dirshbar.cget('orient')), 'horizontal')
-        self.assertEqual(str(d.fileshbar.cget('orient')), 'horizontal')
+        self.assertEqual(d.dirshbar.cget('orient'), 'horizontal')
+        self.assertEqual(d.fileshbar.cget('orient'), 'horizontal')
         self.assertTrue(d.dirs.cget('xscrollcommand'))
         self.assertTrue(d.files.cget('xscrollcommand'))
 

--- a/Lib/test/test_tkinter/test_simpledialog.py
+++ b/Lib/test/test_tkinter/test_simpledialog.py
@@ -32,7 +32,7 @@ class SimpleDialogTest(AbstractTkTest, unittest.TestCase):
         d = self.create(buttons=['OK'], bitmap='warning')
         self.assertEqual(d._buttons[0].winfo_class(), 'TButton')
         self.assertEqual(d.message.winfo_class(), 'TLabel')
-        self.assertEqual(str(d.message.cget('anchor')), 'nw')  # cf. MessageBox
+        self.assertEqual(d.message.cget('anchor'), 'nw')  # cf. MessageBox
         # The standard icons are drawn with themed images (cf. MessageBox).
         self.assertEqual(d.bitmap.winfo_class(), 'TLabel')
         self.assertIn('::tk::icons::warning', str(d.bitmap.cget('image')))
@@ -57,7 +57,7 @@ class SimpleDialogTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(d._buttons[0].winfo_class(), 'Button')
         self.assertEqual(d.message.winfo_class(), 'Label')
         if d.root._windowingsystem == 'x11':
-            self.assertEqual(str(d.frame.cget('relief')), 'raised')
+            self.assertEqual(d.frame.cget('relief'), 'raised')
         # tk_dialog does not make the buttons equal width.
         self.assertIsNone(d.root.children['bot'].grid_columnconfigure(0)['uniform'])
         # The bitmap is a classic monochrome label.
@@ -75,17 +75,20 @@ class SimpleDialogTest(AbstractTkTest, unittest.TestCase):
         # Without a detail message the message label expands.
         d = self.create()
         self.assertIsNone(d.detail)
-        self.assertEqual(int(d.message.pack_info()['expand']), 1)
+        self.assertEqual(d.message.pack_info()['expand'],
+                         1 if self.wantobjects else '1')
 
     def test_detail(self):
         # The detail message is shown below the main message.
         d = self.create(detail='More information.')
         self.assertEqual(d.detail.winfo_class(), 'TLabel')
         self.assertEqual(str(d.detail.cget('text')), 'More information.')
-        self.assertEqual(str(d.detail.cget('anchor')), 'nw')  # cf. MessageBox
+        self.assertEqual(d.detail.cget('anchor'), 'nw')  # cf. MessageBox
         # With a detail message it expands and the main message does not.
-        self.assertEqual(int(d.message.pack_info()['expand']), 0)
-        self.assertEqual(int(d.detail.pack_info()['expand']), 1)
+        self.assertEqual(d.message.pack_info()['expand'],
+                         0 if self.wantobjects else '0')
+        self.assertEqual(d.detail.pack_info()['expand'],
+                         1 if self.wantobjects else '1')
 
     def test_bitmap_fallback(self):
         # A non-standard bitmap has no themed image, so even the ttk version
@@ -114,11 +117,11 @@ class SimpleDialogTest(AbstractTkTest, unittest.TestCase):
         yes, no = d._buttons
         self.assertEqual(str(yes.cget('text')), 'Yes')
         self.assertEqual(str(no.cget('text')), 'No')
-        self.assertEqual(int(no.cget('underline')), 0)
+        self.assertEqual(no.cget('underline'), 0 if self.wantobjects else '0')
         self.assertEqual(str(no.cget('width')), '12')
         # The dialog still controls the default ring (default=0) ...
-        self.assertEqual(str(yes.cget('default')), 'active')
-        self.assertEqual(str(no.cget('default')), 'normal')
+        self.assertEqual(yes.cget('default'), 'active')
+        self.assertEqual(no.cget('default'), 'normal')
         # ... and the command, which records the button index.
         no.invoke()
         self.assertEqual(d.num, 1)
@@ -128,13 +131,13 @@ class SimpleDialogTest(AbstractTkTest, unittest.TestCase):
         # (cf. tk::MessageBox).
         d = self.create()  # buttons ['Yes', 'No'], default 0
         b0, b1 = d._buttons
-        self.assertEqual(str(b1.cget('default')), 'normal')
+        self.assertEqual(b1.cget('default'), 'normal')
         b1.focus_force()
         d.root.update()
-        self.assertEqual(str(b1.cget('default')), 'active')   # focused -> ring
+        self.assertEqual(b1.cget('default'), 'active')   # focused -> ring
         b0.focus_force()
         d.root.update()
-        self.assertEqual(str(b1.cget('default')), 'normal')   # unfocused -> none
+        self.assertEqual(b1.cget('default'), 'normal')   # unfocused -> none
 
     def test_alt_key(self):
         # Alt + an underlined character (the "underline" button option) invokes
@@ -269,7 +272,7 @@ class DialogTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(d.children['ok'].winfo_class(), 'Button')
         self.assertEqual(d.entry.winfo_class(), 'Entry')
         if d._windowingsystem == 'x11':
-            self.assertEqual(str(d.children['bot'].cget('relief')), 'raised')
+            self.assertEqual(d.children['bot'].cget('relief'), 'raised')
         # tk_dialog does not make the buttons equal width.
         self.assertIsNone(d.children['bot'].grid_columnconfigure(0)['uniform'])
         # The bindings work with the classic buttons too.
@@ -311,8 +314,8 @@ class DialogTest(AbstractTkTest, unittest.TestCase):
 
     def test_button_default(self):
         d = self.open()
-        self.assertEqual(str(d.children['ok'].cget('default')), 'active')
-        self.assertEqual(str(d.children['cancel'].cget('default')), 'normal')
+        self.assertEqual(d.children['ok'].cget('default'), 'active')
+        self.assertEqual(d.children['cancel'].cget('default'), 'normal')
 
     def test_underline_ampersand(self):
         self.assertEqual(_underline_ampersand('Yes'), ('Yes', -1))
@@ -326,19 +329,19 @@ class DialogTest(AbstractTkTest, unittest.TestCase):
         d = self.open()
         ok = d.children['ok']  # "&OK" -> underline 0 -> "O"
         self.assertEqual(str(ok.cget('text')), 'OK')
-        self.assertEqual(int(ok.cget('underline')), 0)
+        self.assertEqual(ok.cget('underline'), 0 if self.wantobjects else '0')
 
     def test_default_ring(self):
         # The default ring follows the keyboard focus among the buttons.
         d = self.open()
         cancel = d.children['cancel']
-        self.assertEqual(str(cancel.cget('default')), 'normal')
+        self.assertEqual(cancel.cget('default'), 'normal')
         cancel.focus_force()
         d.update()
-        self.assertEqual(str(cancel.cget('default')), 'active')
+        self.assertEqual(cancel.cget('default'), 'active')
         d.children['ok'].focus_force()
         d.update()
-        self.assertEqual(str(cancel.cget('default')), 'normal')
+        self.assertEqual(cancel.cget('default'), 'normal')
 
     def test_find_alt_key_target(self):
         d = self.open()

--- a/Lib/test/test_tkinter/test_text.py
+++ b/Lib/test/test_tkinter/test_text.py
@@ -508,10 +508,12 @@ class TextTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(str(text.image_cget(name, 'image')), str(image))
         for value in ('top', 'center', 'bottom', 'baseline'):
             text.image_configure(name, align=value)
-            self.assertEqual(str(text.image_cget(name, 'align')), value)
+            self.assertEqual(text.image_cget(name, 'align'), value)
         text.image_configure(name, padx=3, pady=4)
-        self.assertEqual(text.tk.getint(text.image_cget(name, 'padx')), 3)
-        self.assertEqual(text.tk.getint(text.image_cget(name, 'pady')), 4)
+        self.assertEqual(text.image_cget(name, 'padx'),
+                         3 if self.wantobjects else '3')
+        self.assertEqual(text.image_cget(name, 'pady'),
+                         4 if self.wantobjects else '4')
 
         # Querying returns the full option set.
         cnf = text.image_configure(name)
@@ -528,10 +530,12 @@ class TextTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(text.window_cget('1.1', 'window'), str(button))
         for value in ('top', 'center', 'bottom', 'baseline'):
             text.window_configure('1.1', align=value)
-            self.assertEqual(str(text.window_cget('1.1', 'align')), value)
+            self.assertEqual(text.window_cget('1.1', 'align'), value)
         text.window_configure('1.1', padx=3, pady=4)
-        self.assertEqual(text.tk.getint(text.window_cget('1.1', 'padx')), 3)
-        self.assertEqual(text.tk.getint(text.window_cget('1.1', 'pady')), 4)
+        self.assertEqual(text.window_cget('1.1', 'padx'),
+                         3 if self.wantobjects else '3')
+        self.assertEqual(text.window_cget('1.1', 'pady'),
+                         4 if self.wantobjects else '4')
         text.window_configure('1.1', stretch=True)
         self.assertIs(text.tk.getboolean(text.window_cget('1.1', 'stretch')),
                       True)

--- a/Lib/test/test_tkinter/test_widgets.py
+++ b/Lib/test/test_tkinter/test_widgets.py
@@ -266,7 +266,7 @@ class CheckbuttonTest(AbstractLabelTest, unittest.TestCase):
                 b = tkinter.Checkbutton(f, text=j)
                 b.pack()
                 buttons.append(b)
-        variables = [str(b['variable']) for b in buttons]
+        variables = [b['variable'] for b in buttons]
         self.assertEqual(len(set(variables)), 4, variables)
 
     def test_same_name(self):
@@ -442,14 +442,15 @@ class OptionMenuTest(MenubuttonTest, unittest.TestCase):
         # Menubutton options can be passed at construction (gh-101284).
         widget = tkinter.OptionMenu(self.root, None, 'b',
                                     width=10, direction='right')
+        # Menubutton -width is a string on Tk 8.6, an int on 9.0+.
         self.assertEqual(int(widget['width']), 10)
-        self.assertEqual(str(widget['direction']), 'right')
+        self.assertEqual(widget['direction'], 'right')
         # They override OptionMenu's own appearance defaults,
         widget = tkinter.OptionMenu(self.root, None, 'b', relief='flat')
-        self.assertEqual(str(widget['relief']), 'flat')
+        self.assertEqual(widget['relief'], 'flat')
         # which otherwise keep their historical values.
         widget = tkinter.OptionMenu(self.root, None, 'b')
-        self.assertEqual(str(widget['relief']), 'raised')
+        self.assertEqual(widget['relief'], 'raised')
 
     def test_bad_kwarg(self):
         with self.assertRaisesRegex(TclError, r'^unknown option "-spam"$'):
@@ -2472,9 +2473,9 @@ class MenuTest(AbstractWidgetTest, unittest.TestCase):
         v2 = tkinter.BooleanVar(self.root)
         m1.add_checkbutton(variable=v1, onvalue=True, offvalue=False,
                            label='Nonsense')
-        self.assertEqual(str(m1.entrycget(1, 'variable')), str(v1))
+        self.assertEqual(m1.entrycget(1, 'variable'), str(v1))
         m1.entryconfigure(1, variable=v2)
-        self.assertEqual(str(m1.entrycget(1, 'variable')), str(v2))
+        self.assertEqual(m1.entrycget(1, 'variable'), str(v2))
 
     def test_add(self):
         m = self.create(tearoff=False)

--- a/Lib/test/test_tkinter/widget_tests.py
+++ b/Lib/test/test_tkinter/widget_tests.py
@@ -67,6 +67,11 @@ class AbstractWidgetTest(AbstractTkTest):
                 expected = tkinter._join(expected)
             else:
                 expected = str(expected)
+        elif type(expected) is int:
+            self.assertIsInstance(widget[name], int)
+        elif type(expected) is float:
+            # An integral value may be returned as an int.
+            self.assertIsInstance(widget[name], (int, float))
         if eq is None:
             eq = tcl_obj_eq
         self.assertEqual2(widget[name], expected, eq=eq)
@@ -439,7 +444,7 @@ class StandardOptionsTests(PixelOptionsTests):
 
     def test_configure_orient(self):
         widget = self.create()
-        self.assertEqual(str(widget['orient']), self.default_orient)
+        self.assertEqual(widget['orient'], self.default_orient)
         self.checkEnumParam(widget, 'orient', 'horizontal', 'vertical')
 
     @requires_tk(8, 7)

--- a/Lib/test/test_ttk/test_widgets.py
+++ b/Lib/test/test_ttk/test_widgets.py
@@ -310,7 +310,7 @@ class CheckbuttonTest(AbstractLabelTest, unittest.TestCase):
                 b = ttk.Checkbutton(f, text=j)
                 b.pack()
                 buttons.append(b)
-        variables = [str(b['variable']) for b in buttons]
+        variables = [b['variable'] for b in buttons]
         self.assertEqual(len(set(variables)), 4, variables)
 
     def test_unique_variables2(self):
@@ -331,7 +331,7 @@ class CheckbuttonTest(AbstractLabelTest, unittest.TestCase):
             buttons.append(b)
         names = [str(b) for b in buttons]
         self.assertEqual(len(set(names)), len(buttons), names)
-        variables = [str(b['variable']) for b in buttons]
+        variables = [b['variable'] for b in buttons]
         self.assertEqual(len(set(variables)), len(buttons), variables)
 
 
@@ -618,14 +618,14 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_configure_orient(self):
         widget = self.create()
-        self.assertEqual(str(widget['orient']), 'vertical')
+        self.assertEqual(widget['orient'], 'vertical')
         errmsg='attempt to change read-only option'
         if get_tk_patchlevel(self.root) < (8, 6, 0, 'beta', 3):
             errmsg='Attempt to change read-only option'
         self.checkInvalidParam(widget, 'orient', 'horizontal',
                 errmsg=errmsg)
         widget2 = self.create(orient='horizontal')
-        self.assertEqual(str(widget2['orient']), 'horizontal')
+        self.assertEqual(widget2['orient'], 'horizontal')
 
     def test_add(self):
         # attempt to add a child that is not a direct child of the paned window
@@ -790,7 +790,7 @@ class RadiobuttonTest(AbstractLabelTest, unittest.TestCase):
         self.assertEqual(myvar.get(),
             conv(cbtn.tk.globalgetvar(cbtn['variable'])))
 
-        self.assertEqual(str(cbtn['variable']), str(cbtn2['variable']))
+        self.assertEqual(cbtn['variable'], cbtn2['variable'])
 
 
 @add_configure_tests(StandardTtkOptionsTests)
@@ -985,13 +985,13 @@ class ProgressbarTest(AbstractWidgetTest, unittest.TestCase):
 
     def test_step(self):
         widget = self.create(maximum=100, mode='determinate')
-        self.assertEqual(float(widget['value']), 0.0)
+        self.assertEqual(widget['value'], self._str(0.0))
         widget.step()  # The default increment is 1.0.
-        self.assertEqual(float(widget['value']), 1.0)
+        self.assertEqual(widget['value'], self._str(1.0))
         widget.step(5)
-        self.assertEqual(float(widget['value']), 6.0)
+        self.assertEqual(widget['value'], self._str(6.0))
         widget.step(-2)
-        self.assertEqual(float(widget['value']), 4.0)
+        self.assertEqual(widget['value'], self._str(4.0))
 
     def test_start_stop(self):
         widget = self.create(maximum=100, mode='determinate')
@@ -1000,9 +1000,9 @@ class ProgressbarTest(AbstractWidgetTest, unittest.TestCase):
         widget.update()
         widget.stop()   # Cancel it.
         # After stopping, the value no longer changes.
-        value = float(widget['value'])
+        value = widget['value']
         widget.update()
-        self.assertEqual(float(widget['value']), value)
+        self.assertEqual(widget['value'], value)
 
 
 @unittest.skipIf(sys.platform == 'darwin',


### PR DESCRIPTION
Test-only follow-up to gh-153513 (#153514).

Now that `index`, `window` and `parsedVarName` options are returned as `str` and unitless `pixel` options as `int`/`float`, this drops the `str()`/`int()`/`float()`/`getint()` wrappers that only worked around the previous `Tcl_Obj` results. Where the value crosses `wantobjects` modes (an `int`/`float` with objects enabled, a string with objects disabled), the bare wrapper is replaced with a mode-aware exact comparison rather than dropped, so the returned type is verified instead of masked.

The generated `test_configure_*` tests also gain a check that an int- or float-valued option is returned as a number (not a `Tcl_Obj`), and that an int-valued option is not returned as a float.

Wrappers are kept where the returned type is not uniform: resource types (`color`, `bitmap`, `font`, `cursor`), screen distances with a unit suffix, canvas item options and `OptionMenu -width` (which Tk returns as strings), and plain-string options.

Tested with Tk 8.6, 9.0 and 9.1, with objects enabled and disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- gh-issue-number: gh-153513 -->
* Issue: gh-153513
<!-- /gh-issue-number -->
