### PR TITLE
gh-153529: Fix zipfile.Path.is_symlink() on archive root

### DIFF
--- a/Lib/zipfile/_path/__init__.py
+++ b/Lib/zipfile/_path/__init__.py
@@ -414,6 +414,9 @@ class Path:
         """
         Return whether this path is a symlink.
         """
+        if not self.at:
+            return False
+
         info = self.root.getinfo(self.at)
         mode = info.external_attr >> 16
         return stat.S_ISLNK(mode)


### PR DESCRIPTION
Return `False` for the archive root in `zipfile.Path.is_symlink()` instead of raising `KeyError`.

Closes #153529 

<!-- gh-issue-number: gh-153529 -->
* Issue: gh-153529
<!-- /gh-issue-number -->
