### PR TITLE
gh-114795: Fix Element re-init memory leak in the C accelerator

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2654,6 +2654,19 @@ class BugsTest(unittest.TestCase):
 
 class BasicElementTest(ElementTestCase, unittest.TestCase):
 
+    def test_reinit_releases_children(self):
+        # gh-153537: re-init should release the previous children.
+        e = ET.Element('a', {'k': 'v'})
+        children = [ET.SubElement(e, 'b') for _ in range(3)]
+        refs = [weakref.ref(c) for c in children]
+        del children
+        self.assertEqual(len(e), 3)
+        e.__init__('a')
+        gc_collect()
+        self.assertEqual(len(e), 0)
+        self.assertEqual(e.attrib, {})
+        self.assertTrue(all(ref() is None for ref in refs))
+
     def test___init__(self):
         tag = "foo"
         attrib = { "zix": "wyp" }

--- a/Misc/NEWS.d/next/Library/2026-07-11-11-36-15.gh-issue-153537.2KySPQ.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-11-11-36-15.gh-issue-153537.2KySPQ.rst
@@ -1,0 +1,3 @@
+Re-initializing an :class:`xml.etree.ElementTree.Element` in the C accelerator
+now discards the previous children and attributes instead of leaking them,
+matching the pure-Python implementation. Patch by tonghuaroot.

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -449,6 +449,9 @@ element_init(PyObject *self, PyObject *args, PyObject *kwds)
 
     self_elem = (ElementObject *)self;
 
+    /* On re-init, drop any children and attrib from a previous init. */
+    clear_extra(self_elem);
+
     if (attrib != NULL && !is_empty_dict(attrib)) {
         if (create_extra(self_elem, attrib) < 0) {
             Py_DECREF(attrib);


### PR DESCRIPTION
`Element.__init__` in the C accelerator leaked the element's previous children and attributes when called more than once, because `create_extra` allocated a new `extra` without freeing the old one. Clear it first, so re-initialization now discards the previous children and attributes like the pure-Python implementation.

<!-- gh-issue-number: gh-153537 -->
* Issue: gh-153537
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-114795 -->
* Issue: gh-114795
<!-- /gh-issue-number -->
