### PR TITLE
gh-126877: Fix the configure check for Tcl/Tk with optimizing compilers

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-07-11-07-26-16.gh-issue-126877.Zt7Kq2.rst
+++ b/Misc/NEWS.d/next/Build/2026-07-11-07-26-16.gh-issue-126877.Zt7Kq2.rst
@@ -1,0 +1,2 @@
+Fix the :program:`configure` check for Tcl/Tk which could wrongly succeed
+with optimizing compilers when the libraries are missing.

--- a/configure
+++ b/configure
@@ -17975,8 +17975,8 @@ int
 main (void)
 {
 
-      void *x1 = Tcl_Init;
-      void *x2 = Tk_Init;
+      Tcl_Init(NULL);
+      Tk_Init(NULL);
 
   ;
   return 0;

--- a/configure.ac
+++ b/configure.ac
@@ -4618,8 +4618,8 @@ WITH_SAVE_ENV([
       #  error "Tk older than 8.5.12 not supported"
       #endif
     ], [
-      void *x1 = Tcl_Init;
-      void *x2 = Tk_Init;
+      Tcl_Init(NULL);
+      Tk_Init(NULL);
     ])
   ], [
     have_tcltk=yes


### PR DESCRIPTION
The `configure` check for Tcl/Tk assigned the addresses of `Tcl_Init()` and `Tk_Init()` to unused variables. Optimizing compilers can eliminate these dead stores, dropping the only reference to the symbols, so the check links — and Tcl/Tk is detected as available — even when the libraries are missing.

This calls the functions instead, matching the existing `__register_frame()` probe in the same file. A call to an external function cannot be optimized away, and the check still only links and never runs, so it stays cross-compile safe.

Verified with gcc at `-O2`: the old probe links with the symbols absent, the new one correctly fails, and `configure` then reports `_tkinter... missing` instead of a false positive.


<!-- gh-issue-number: gh-126877 -->
* Issue: gh-126877
<!-- /gh-issue-number -->
