### PR TITLE
gh-88647: Fix tkinter config() docs for synonym options

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -545,11 +545,8 @@ arguments, or by calling the :meth:`~Misc.keys` method on that widget.
 The return value of these calls is a dictionary whose key is the name of the
 option as a string (for example, ``'relief'``) and whose values are 5-tuples.
 
-Some options, like ``bg`` are synonyms for common options with long names
-(``bg`` is shorthand for "background"). Passing the ``config()`` method the name
-of a shorthand option will return a 2-tuple, not 5-tuple. The 2-tuple passed
-back will contain the name of the synonym and the "real" option (such as
-``('bg', 'background')``).
+Some options, like ``bg``, are synonyms for common options with long names
+(``bg`` is shorthand for "background").
 
 +-------+---------------------------------+--------------+
 | Index | Meaning                         | Example      |


### PR DESCRIPTION
The documentation claimed that passing `config()` the name of a shorthand
option (like `bg`) returns a 2-tuple `('bg', 'background')` instead of the
usual 5-tuple. This has not been true since Tk 8.5 -- synonym options return
the same 5-tuple as their real option (verified on Tk 8.6 and 9.1). Remove the
inaccurate sentences and keep only the note that such options are synonyms.

<!-- gh-issue-number: 88647 -->
* Issue: gh-88647
