### PR TITLE
gh-151763: Fix dealloc clears the in-flight exception in subtype_dealloc

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-14-39-38.gh-issue-151763.nlYxAk.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-14-39-38.gh-issue-151763.nlYxAk.rst
@@ -1,0 +1,2 @@
+Fixed a bug in free-threaded builds where the active exception could be
+unexpectedly cleared during subtype deallocation in ``subtype_dealloc()``.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2763,6 +2763,13 @@ subtype_dealloc(PyObject *self)
         }
     }
 
+    /* Save the current exception: clear_slots() and the dict/base-dealloc
+           below decref arbitrary attribute values, which may clear
+           tstate->current_exception (gh-89373).  Mirroring slot_tp_finalize(). */
+     PyThreadState *tstate = _PyThreadState_GET();
+     PyObject *exc = _PyErr_GetRaisedException(tstate);   /* preserve in-flight exception */
+
+
     /*  Clear slots up to the nearest base with a different tp_dealloc */
     base = type;
     while ((basedealloc = base->tp_dealloc) == subtype_dealloc) {
@@ -2812,6 +2819,9 @@ subtype_dealloc(PyObject *self)
     if (type_needs_decref) {
         _Py_DECREF_TYPE(type);
     }
+
+    /* Restore the saved exception (see save above). */
+    _PyErr_SetRaisedException(tstate, exc);
 }
 
 static PyTypeObject *solid_base(PyTypeObject *type);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2764,6 +2764,13 @@ subtype_dealloc(PyObject *self)
         }
     }
 
+    /* Save the current exception: clear_slots() and the dict/base-dealloc
+           below decref arbitrary attribute values, which may clear
+           tstate->current_exception (gh-89373).  Mirroring slot_tp_finalize(). */
+     PyThreadState *tstate = _PyThreadState_GET();
+     PyObject *exc = _PyErr_GetRaisedException(tstate);   /* preserve in-flight exception */
+
+
     /*  Clear slots up to the nearest base with a different tp_dealloc */
     base = type;
     while ((basedealloc = base->tp_dealloc) == subtype_dealloc) {
@@ -2813,6 +2820,9 @@ subtype_dealloc(PyObject *self)
     if (type_needs_decref) {
         _Py_DECREF_TYPE(type);
     }
+
+    /* Restore the saved exception (see save above). */
+    _PyErr_SetRaisedException(tstate, exc);
 }
 
 static PyTypeObject *solid_base(PyTypeObject *type);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Fixes: #gh-151763 [OOM-0023](https://gist.github.com/devdanzin/dc5123e50ea0402292e841411a294d3d) 

`subtype_dealloc()` can clear the in-flight exception while tearing down heap-type instances. Unlike slot_tp_finalize(), this deallocation path does not preserve the current exception across operations that may perform arbitrary Py_DECREFs, potentially causing `tstate->current_exception` to be lost.

This patch saves the current exception before the destructive teardown (clear_slots(), managed dict clearing, base deallocation, and type decref) and restores it afterward, mirroring the existing exception-preservation pattern used in slot_tp_finalize().