### PR TITLE
gh-86726: Note that the ttk Treeview separator column option needs Tk 9.0

### DIFF
--- a/Doc/library/tkinter.ttk.rst
+++ b/Doc/library/tkinter.ttk.rst
@@ -884,8 +884,8 @@ This widget accepts the following specific options:
    The *selectmode* option gained the values ``"single"`` and ``"multiple"``;
    the new widget options *selecttype* (``"item"`` or ``"cell"`` selection),
    *striped* (zebra-striped rows), and *titlecolumns* / *titleitems* (columns
-   or rows frozen against scrolling) were introduced; and items gained a
-   *hidden* option.
+   or rows frozen against scrolling) were introduced; the column *separator*
+   option was added; and items gained a *hidden* option.
    Tk 9.1 added the *rowheight* and *headingheight* options.
 
 


### PR DESCRIPTION
The ttk `Treeview` column `separator` option is available only with Tk 9.0
or newer, so add it to the note listing the Tk 9.0 Treeview features.

<!-- gh-issue-number: 86726 -->
* Issue: gh-86726
