### PR TITLE
gh-153528: Document `mode="func_type"` in `compile()`

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -314,6 +314,8 @@ are always available.  They are listed here in alphabetical order.
    consists of a single expression, or ``'single'`` if it consists of a single
    interactive statement (in the latter case, expression statements that
    evaluate to something other than ``None`` will be printed).
+   It can also be ``'func_type'`` if *source* consists of a single :pep:`484`
+   signature type comment; see :func:`ast.parse` for more information.
 
    The optional arguments *flags* and *dont_inherit* control which
    :ref:`compiler options <ast-compiler-flags>` should be activated

--- a/Misc/NEWS.d/next/Documentation/2026-07-11-11-12-00.gh-issue-153528.aBcDeF.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-07-11-11-12-00.gh-issue-153528.aBcDeF.rst
@@ -1,0 +1,1 @@
+Document ``mode="func_type"`` in :func:`compile`.

--- a/Misc/NEWS.d/next/Documentation/2026-07-11-11-12-00.gh-issue-153528.aBcDeF.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-07-11-11-12-00.gh-issue-153528.aBcDeF.rst
@@ -1,1 +1,0 @@
-Document ``mode="func_type"`` in :func:`compile`.


### PR DESCRIPTION
Fixes #153528.

This adds a brief documentation note to `compile()` explaining the `func_type` mode and linking it to `ast.parse` for more details. 

*(Note: This replaces the previous PR #153542 which was accidentally submitted with unrelated commits from another branch).*

<!-- gh-issue-number: gh-153528 -->
* Issue: gh-153528
<!-- /gh-issue-number -->