### PR TITLE
gh-153568: Skip parser memo lookups that cannot match

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-14-57-19.gh-issue-153568.memoflt.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-14-57-19.gh-issue-153568.memoflt.rst
@@ -1,0 +1,2 @@
+Speed up the parser by letting memoization lookups that cannot match return
+immediately.

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -90,6 +90,7 @@ _PyPegen_insert_memo(Parser *p, int mark, int type, void *node)
     m->mark = p->mark;
     m->next = p->tokens[mark]->memo;
     p->tokens[mark]->memo = m;
+    p->tokens[mark]->memo_mask |= 1ULL << (type & 63);
     return 0;
 }
 
@@ -349,6 +350,10 @@ _PyPegen_is_memoized(Parser *p, int type, void *pres)
     }
 
     Token *t = p->tokens[p->mark];
+
+    if (!(t->memo_mask & (1ULL << (type & 63)))) {
+        return 0;
+    }
 
     for (Memo *m = t->memo; m != NULL; m = m->next) {
         if (m->type == type) {

--- a/Parser/pegen.h
+++ b/Parser/pegen.h
@@ -42,6 +42,10 @@ typedef struct {
     int level;
     int lineno, col_offset, end_lineno, end_col_offset;
     Memo *memo;
+    // Filter over the rule types present in `memo` (bit `type & 63` is set
+    // for every entry): lets lookups skip walking the list on definite
+    // misses, which are the common case.
+    uint64_t memo_mask;
     PyObject *metadata;
 } Token;
 


### PR DESCRIPTION
Most memoization probes miss, and each one walked a linked list through arena memory to find out. A per-token filter of the memoized rule types answers definite misses with a single bit test.

**Benchmark** (parsing 8 of the largest stdlib files, 1.3 MB, 20 times per run with `_PyParser_ASTFromString` — parser only, no AST-to-Python conversion; pyperf, interleaved runs):

| build | time per run | speedup |
|-------|--------------|---------|
| main | 1.82 s | |
| this PR | 1.72 s | 1.06x faster |