### PR TITLE
gh-153568: Cache repeated identifiers while parsing

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-15-07-49.gh-issue-153568.identcache.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-15-07-49.gh-issue-153568.identcache.rst
@@ -1,0 +1,1 @@
+Speed up the parser by caching repeated identifiers during a parse.

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -572,10 +572,40 @@ _PyPegen_name_from_token(Parser *p, Token* t)
         p->error_indicator = 1;
         return NULL;
     }
+    // Identifiers repeat constantly; a small span-keyed cache skips the
+    // UTF-8 decode + intern for repeated occurrences. Keys point into
+    // arena-owned token bytes and values are arena-owned interned strings,
+    // so borrowed references are valid for the lifetime of the parse
+    // (including the second error pass, which reuses parser and arena).
+    Py_ssize_t len = PyBytes_GET_SIZE(t->bytes);
+    uint32_t hash = 2166136261u;
+    for (Py_ssize_t i = 0; i < len; i++) {
+        hash = (hash ^ (unsigned char)s[i]) * 16777619u;
+    }
+    struct _identifier_cache_entry *free_slot = NULL;
+    size_t idx = hash & (_PYPEGEN_IDENT_CACHE_SIZE - 1);
+    for (int probe = 0; probe < _PYPEGEN_IDENT_CACHE_MAX_PROBES; probe++) {
+        struct _identifier_cache_entry *e =
+            &p->ident_cache[(idx + probe) & (_PYPEGEN_IDENT_CACHE_SIZE - 1)];
+        if (e->key == NULL) {
+            free_slot = e;
+            break;
+        }
+        if (e->hash == hash && e->len == len && memcmp(e->key, s, len) == 0) {
+            return _PyAST_Name(e->value, Load, t->lineno, t->col_offset,
+                               t->end_lineno, t->end_col_offset, p->arena);
+        }
+    }
     PyObject *id = _PyPegen_new_identifier(p, s);
     if (id == NULL) {
         p->error_indicator = 1;
         return NULL;
+    }
+    if (free_slot != NULL) {
+        free_slot->key = s;
+        free_slot->len = len;
+        free_slot->hash = hash;
+        free_slot->value = id;
     }
     return _PyAST_Name(id, Load, t->lineno, t->col_offset, t->end_lineno,
                        t->end_col_offset, p->arena);
@@ -844,6 +874,15 @@ _PyPegen_Parser_New(struct tok_state *tok, int start_rule, int flags,
     p->flags = flags;
     p->feature_version = feature_version;
     p->known_err_token = NULL;
+    p->ident_cache = PyMem_Calloc(_PYPEGEN_IDENT_CACHE_SIZE,
+                                  sizeof(struct _identifier_cache_entry));
+    if (p->ident_cache == NULL) {
+        growable_comment_array_deallocate(&p->type_ignore_comments);
+        PyMem_Free(p->tokens[0]);
+        PyMem_Free(p->tokens);
+        PyMem_Free(p);
+        return (Parser *) PyErr_NoMemory();
+    }
     p->level = 0;
     p->call_invalid_rules = 0;
     p->last_stmt_location.lineno = 0;
@@ -859,6 +898,7 @@ _PyPegen_Parser_New(struct tok_state *tok, int start_rule, int flags,
 void
 _PyPegen_Parser_Free(Parser *p)
 {
+    PyMem_Free(p->ident_cache);
     Py_XDECREF(p->normalize);
     for (int i = 0; i < p->size; i++) {
         PyMem_Free(p->tokens[i]);

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -12,6 +12,16 @@
 #include "tokenizer/helpers.h"
 #include "pegen.h"
 
+#define IDENTIFIER_CACHE_SIZE 2048  // Must be a power of two.
+#define IDENTIFIER_CACHE_MAX_PROBES 8
+
+struct _identifier_cache_entry {
+    const char *key;   // Borrowed from arena-owned token bytes.
+    Py_ssize_t len;
+    uint32_t hash;
+    PyObject *value;   // Borrowed from an arena-owned identifier.
+};
+
 // Internal parser functions
 
 asdl_stmt_seq*
@@ -561,6 +571,20 @@ error:
     return NULL;
 }
 
+static uint32_t
+identifier_hash(const char *str, Py_ssize_t len)
+{
+    // 32-bit FNV-1a parameters.
+    const uint32_t offset_basis = 2166136261U;
+    const uint32_t prime = 16777619U;
+
+    uint32_t hash = offset_basis;
+    for (Py_ssize_t i = 0; i < len; i++) {
+        hash = (hash ^ (unsigned char)str[i]) * prime;
+    }
+    return hash;
+}
+
 static expr_ty
 _PyPegen_name_from_token(Parser *p, Token* t)
 {
@@ -578,21 +602,20 @@ _PyPegen_name_from_token(Parser *p, Token* t)
     // so borrowed references are valid for the lifetime of the parse
     // (including the second error pass, which reuses parser and arena).
     Py_ssize_t len = PyBytes_GET_SIZE(t->bytes);
-    uint32_t hash = 2166136261u;
-    for (Py_ssize_t i = 0; i < len; i++) {
-        hash = (hash ^ (unsigned char)s[i]) * 16777619u;
-    }
-    struct _identifier_cache_entry *free_slot = NULL;
-    size_t idx = hash & (_PYPEGEN_IDENT_CACHE_SIZE - 1);
-    for (int probe = 0; probe < _PYPEGEN_IDENT_CACHE_MAX_PROBES; probe++) {
-        struct _identifier_cache_entry *e =
-            &p->ident_cache[(idx + probe) & (_PYPEGEN_IDENT_CACHE_SIZE - 1)];
-        if (e->key == NULL) {
-            free_slot = e;
+    uint32_t hash = identifier_hash(s, len);
+    IdentifierCacheEntry *free_slot = NULL;
+    size_t idx = hash & (IDENTIFIER_CACHE_SIZE - 1);
+    for (int probe = 0; probe < IDENTIFIER_CACHE_MAX_PROBES; probe++) {
+        IdentifierCacheEntry *entry = &p->identifier_cache[
+            (idx + probe) & (IDENTIFIER_CACHE_SIZE - 1)];
+        if (entry->key == NULL) {
+            free_slot = entry;
             break;
         }
-        if (e->hash == hash && e->len == len && memcmp(e->key, s, len) == 0) {
-            return _PyAST_Name(e->value, Load, t->lineno, t->col_offset,
+        if (entry->hash == hash && entry->len == len &&
+            memcmp(entry->key, s, len) == 0)
+        {
+            return _PyAST_Name(entry->value, Load, t->lineno, t->col_offset,
                                t->end_lineno, t->end_col_offset, p->arena);
         }
     }
@@ -874,9 +897,9 @@ _PyPegen_Parser_New(struct tok_state *tok, int start_rule, int flags,
     p->flags = flags;
     p->feature_version = feature_version;
     p->known_err_token = NULL;
-    p->ident_cache = PyMem_Calloc(_PYPEGEN_IDENT_CACHE_SIZE,
-                                  sizeof(struct _identifier_cache_entry));
-    if (p->ident_cache == NULL) {
+    p->identifier_cache = PyMem_Calloc(
+        IDENTIFIER_CACHE_SIZE, sizeof(*p->identifier_cache));
+    if (p->identifier_cache == NULL) {
         growable_comment_array_deallocate(&p->type_ignore_comments);
         PyMem_Free(p->tokens[0]);
         PyMem_Free(p->tokens);
@@ -898,7 +921,7 @@ _PyPegen_Parser_New(struct tok_state *tok, int start_rule, int flags,
 void
 _PyPegen_Parser_Free(Parser *p)
 {
-    PyMem_Free(p->ident_cache);
+    PyMem_Free(p->identifier_cache);
     Py_XDECREF(p->normalize);
     for (int i = 0; i < p->size; i++) {
         PyMem_Free(p->tokens[i]);

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -18,7 +18,7 @@
 struct _identifier_cache_entry {
     const char *key;   // Borrowed from arena-owned token bytes.
     Py_ssize_t len;
-    uint32_t hash;
+    Py_hash_t hash;
     PyObject *value;   // Borrowed from an arena-owned identifier.
 };
 
@@ -571,20 +571,6 @@ error:
     return NULL;
 }
 
-static uint32_t
-identifier_hash(const char *str, Py_ssize_t len)
-{
-    // 32-bit FNV-1a parameters.
-    const uint32_t offset_basis = 2166136261U;
-    const uint32_t prime = 16777619U;
-
-    uint32_t hash = offset_basis;
-    for (Py_ssize_t i = 0; i < len; i++) {
-        hash = (hash ^ (unsigned char)str[i]) * prime;
-    }
-    return hash;
-}
-
 static expr_ty
 _PyPegen_name_from_token(Parser *p, Token* t)
 {
@@ -602,9 +588,13 @@ _PyPegen_name_from_token(Parser *p, Token* t)
     // so borrowed references are valid for the lifetime of the parse
     // (including the second error pass, which reuses parser and arena).
     Py_ssize_t len = PyBytes_GET_SIZE(t->bytes);
-    uint32_t hash = identifier_hash(s, len);
+    Py_hash_t hash = PyObject_Hash(t->bytes);
+    if (hash == -1) {
+        p->error_indicator = 1;
+        return NULL;
+    }
     IdentifierCacheEntry *free_slot = NULL;
-    size_t idx = hash & (IDENTIFIER_CACHE_SIZE - 1);
+    size_t idx = (size_t)hash & (IDENTIFIER_CACHE_SIZE - 1);
     for (int probe = 0; probe < IDENTIFIER_CACHE_MAX_PROBES; probe++) {
         IdentifierCacheEntry *entry = &p->identifier_cache[
             (idx + probe) & (IDENTIFIER_CACHE_SIZE - 1)];

--- a/Parser/pegen.h
+++ b/Parser/pegen.h
@@ -67,6 +67,8 @@ typedef struct {
     int end_col_offset;
 } location;
 
+typedef struct _identifier_cache_entry IdentifierCacheEntry;
+
 typedef struct {
     struct tok_state *tok;
     Token **tokens;
@@ -91,16 +93,8 @@ typedef struct {
     int call_invalid_rules;
     int debug;
     location last_stmt_location;
-    struct _identifier_cache_entry {
-        const char *key;   // borrowed; points into arena-owned token bytes
-        Py_ssize_t len;
-        uint32_t hash;
-        PyObject *value;   // borrowed; arena-owned interned identifier
-    } *ident_cache;
+    IdentifierCacheEntry *identifier_cache;
 } Parser;
-
-#define _PYPEGEN_IDENT_CACHE_SIZE 2048  // power of two
-#define _PYPEGEN_IDENT_CACHE_MAX_PROBES 8
 
 typedef struct {
     cmpop_ty cmpop;

--- a/Parser/pegen.h
+++ b/Parser/pegen.h
@@ -91,7 +91,16 @@ typedef struct {
     int call_invalid_rules;
     int debug;
     location last_stmt_location;
+    struct _identifier_cache_entry {
+        const char *key;   // borrowed; points into arena-owned token bytes
+        Py_ssize_t len;
+        uint32_t hash;
+        PyObject *value;   // borrowed; arena-owned interned identifier
+    } *ident_cache;
 } Parser;
+
+#define _PYPEGEN_IDENT_CACHE_SIZE 2048  // power of two
+#define _PYPEGEN_IDENT_CACHE_MAX_PROBES 8
 
 typedef struct {
     cmpop_ty cmpop;


### PR DESCRIPTION
Every occurrence of a name paid a UTF-8 decode, a hash and an intern lookup, even though identifiers repeat constantly in real code. A small per-parse table now reuses the interned name created the first time a given spelling is seen, and everything it stores lives in the parse arena so no lifetime management is needed.

**Benchmark** (parsing 8 of the largest stdlib files, 1.3 MB, 20 times per run with `_PyParser_ASTFromString` — parser only, no AST-to-Python conversion; pyperf, interleaved runs):

| build | time per run | speedup |
|-------|--------------|---------|
| main | 1.70 s ± 0.02 | |
| this PR | 1.45 s ± 0.01 | 1.17x faster |

<!-- gh-issue-number: gh-153568 -->
* Issue: gh-153568
<!-- /gh-issue-number -->
