### PR TITLE
gh-153568: Pause the GC while converting the AST to Python objects

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-16-51-51.gh-issue-153568.ast2objgc.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-11-16-51-51.gh-issue-153568.ast2objgc.rst
@@ -1,0 +1,2 @@
+Speed up :func:`ast.parse` by pausing the garbage collector while the AST is
+converted to Python objects.

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -2117,7 +2117,15 @@ PyObject* PyAST_mod2obj(mod_ty t)
     if (state == NULL) {
         return NULL;
     }
+    // Freshly converted AST nodes cannot be part of a reference cycle yet,
+    // so a garbage collection while building them cannot free anything of
+    // this tree and only pays to traverse its half-built nodes. Pause the
+    // collector while the conversion runs.
+    int gc_was_enabled = PyGC_Disable();
     PyObject *result = ast2obj_mod(state, t);
+    if (gc_was_enabled) {
+        PyGC_Enable();
+    }
 
     return result;
 }

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -18544,7 +18544,15 @@ PyObject* PyAST_mod2obj(mod_ty t)
     if (state == NULL) {
         return NULL;
     }
+    // Freshly converted AST nodes cannot be part of a reference cycle yet,
+    // so a garbage collection while building them cannot free anything of
+    // this tree and only pays to traverse its half-built nodes. Pause the
+    // collector while the conversion runs.
+    int gc_was_enabled = PyGC_Disable();
     PyObject *result = ast2obj_mod(state, t);
+    if (gc_was_enabled) {
+        PyGC_Enable();
+    }
 
     return result;
 }


### PR DESCRIPTION
Building the Python object tree out of the C AST allocates thousands of container objects in a burst, which repeatedly trips the garbage collector into traversing the half-built tree. Those nodes cannot be part of a reference cycle until the conversion exposes them, so a collection during the conversion can never free anything of this tree. Pausing the collector around the conversion (restoring the previous state, so a user-disabled GC stays disabled) removes those wasted traversals.

**Benchmark** (running `ast.parse` over 8 of the largest stdlib files, 1.3 MB, 20 times per run; pinned cores):

| build | time per run | speedup |
|-------|--------------|---------|
| main | 133.6 ms | |
| this PR | 120.5 ms | 1.11x faster |

Executed instructions (stable under machine load, `perf stat`) drop by 5.6%.

<!-- gh-issue-number: gh-153568 -->
* Issue: gh-153568
<!-- /gh-issue-number -->
