### PR TITLE
gh-153603: Fix out-of-bounds read in the ISO-2022 decoder for an unknown charset

### DIFF
--- a/Lib/test/test_multibytecodec.py
+++ b/Lib/test/test_multibytecodec.py
@@ -306,6 +306,24 @@ class Test_IncrementalDecoder(unittest.TestCase):
         self.assertRaises(TypeError, decoder.setstate, (b"1234", "invalid"))
         self.assertRaises(UnicodeDecodeError, decoder.setstate, (b"123456789", 0))
 
+    def test_setstate_invalid_designation(self):
+        # gh-153603: an unknown charset designation in the state must not crash
+        # the decoder.  0xff is not a registered charset mark and 0x21 ('!') is
+        # a GL byte that triggers the designation lookup.
+        for name in ('iso-2022-jp', 'iso-2022-kr'):
+            with self.subTest(codec=name):
+                decoder = codecs.getincrementaldecoder(name)()
+                decoder.setstate((b'', 0xff))
+                with self.assertRaises(UnicodeDecodeError) as cm:
+                    decoder.decode(b'!', final=True)
+                self.assertEqual(cm.exception.reason,
+                                 'illegal multibyte sequence')
+                self.assertEqual((cm.exception.start, cm.exception.end), (0, 1))
+                # One illegal byte is reported, so error handlers still work.
+                decoder = codecs.getincrementaldecoder(name)(errors='replace')
+                decoder.setstate((b'', 0xff))
+                self.assertEqual(decoder.decode(b'!', final=True), '\ufffd')
+
 class Test_StreamReader(unittest.TestCase):
     def test_bug1728403(self):
         try:

--- a/Misc/NEWS.d/next/Library/2026-07-11-13-24-49.gh-issue-153603.YbKlry.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-11-13-24-49.gh-issue-153603.YbKlry.rst
@@ -1,0 +1,3 @@
+Fix a crash in the ISO-2022 decoders when decoding a byte after an unknown
+charset designation is set via the decoder's ``setstate`` method.
+Patch by tonghuaroot.

--- a/Modules/cjkcodecs/_codecs_iso2022.c
+++ b/Modules/cjkcodecs/_codecs_iso2022.c
@@ -533,15 +533,16 @@ bypass:
                         dsg = dsgcache;
                 else {
                     for (dsg = CONFIG_DESIGNATIONS;
-                         dsg->mark != charset
-#ifdef Py_DEBUG
-                            && dsg->mark != '\0'
-#endif
-                         ; dsg++)
+                         dsg->mark != charset && dsg->mark != '\0';
+                         dsg++)
                     {
                         /* noop */
                     }
-                    assert(dsg->mark != '\0');
+                    if (dsg->mark == '\0') {
+                        /* Unknown charset designation from a corrupt
+                           setstate(); no width to trust, report one byte. */
+                        return 1;
+                    }
                     dsgcache = dsg;
                 }
 


### PR DESCRIPTION
The ISO-2022 decoders' designation-table scan compiled its `dsg->mark != '\0'`
terminator only under `Py_DEBUG`, so a release build walked off the table for an
unknown charset set via `setstate()`. Make the terminator unconditional and
report the byte as undecodable when the charset is unknown.

<!-- gh-issue-number: gh-153603 -->
* Issue: gh-153603
<!-- /gh-issue-number -->
