### PR TITLE
gh-153605: Fix gettext.GNUTranslations struct.error on a malformed .mo file

### DIFF
--- a/Lib/gettext.py
+++ b/Lib/gettext.py
@@ -360,20 +360,30 @@ class GNUTranslations(NullTranslations):
         buf = fp.read()
         buflen = len(buf)
         # Are we big endian or little endian?
+        if buflen < 4:
+            raise OSError(0, 'File is corrupt', filename)
         magic = unpack('<I', buf[:4])[0]
         if magic == self.LE_MAGIC:
-            version, msgcount, masteridx, transidx = unpack('<4I', buf[4:20])
             ii = '<II'
+            hdr = '<4I'
         elif magic == self.BE_MAGIC:
-            version, msgcount, masteridx, transidx = unpack('>4I', buf[4:20])
             ii = '>II'
+            hdr = '>4I'
         else:
             raise OSError(0, 'Bad magic number', filename)
+        if buflen < 20:
+            raise OSError(0, 'File is corrupt', filename)
+        version, msgcount, masteridx, transidx = unpack(hdr, buf[4:20])
 
         major_version, minor_version = self._get_versions(version)
 
         if major_version not in self.VERSIONS:
             raise OSError(0, 'Bad version number ' + str(major_version), filename)
+
+        # The seek tables must lie within the file.
+        if (masteridx + 8 * msgcount > buflen
+                or transidx + 8 * msgcount > buflen):
+            raise OSError(0, 'File is corrupt', filename)
 
         # Now put all messages from the .mo file buffer into the catalog
         # dictionary.

--- a/Lib/test/test_gettext.py
+++ b/Lib/test/test_gettext.py
@@ -1,6 +1,7 @@
 import os
 import base64
 import gettext
+import io
 import unittest
 import unittest.mock
 from functools import partial
@@ -313,6 +314,39 @@ class GettextTestCase2(GettextBaseTest):
             self.assertEqual(exception.errno, 0)
             self.assertEqual(exception.strerror, "File is corrupt")
             self.assertEqual(exception.filename, MOFILE_CORRUPT)
+
+    def test_truncated_header(self):
+        magic = b'\xde\x12\x04\x95'
+        for buf in (b'', magic, magic + bytes(15)):
+            with self.subTest(buflen=len(buf)):
+                with self.assertRaises(OSError) as cm:
+                    gettext.GNUTranslations(io.BytesIO(buf))
+                self.assertEqual(cm.exception.errno, 0)
+                self.assertEqual(cm.exception.strerror, "File is corrupt")
+
+    def test_offsets_out_of_bounds(self):
+        buf = bytes([
+            0xde, 0x12, 0x04, 0x95,  # Magic
+            0x00, 0x00, 0x00, 0x00,  # Version
+            0x01, 0x00, 0x00, 0x00,  # Message count
+            0xe8, 0x03, 0x00, 0x00,  # Message offset (past EOF)
+            0xd0, 0x07, 0x00, 0x00,  # Translation offset (past EOF)
+        ])
+        with self.assertRaises(OSError) as cm:
+            gettext.GNUTranslations(io.BytesIO(buf))
+        self.assertEqual(cm.exception.errno, 0)
+        self.assertEqual(cm.exception.strerror, "File is corrupt")
+
+    def test_empty_catalog(self):
+        buf = bytes([
+            0xde, 0x12, 0x04, 0x95,  # Magic
+            0x00, 0x00, 0x00, 0x00,  # Version
+            0x00, 0x00, 0x00, 0x00,  # Message count
+            0x14, 0x00, 0x00, 0x00,  # Message offset
+            0x14, 0x00, 0x00, 0x00,  # Translation offset
+        ])
+        t = gettext.GNUTranslations(io.BytesIO(buf))
+        self.assertEqual(t.gettext('foo'), 'foo')
 
     def test_big_endian_file(self):
         with open(MOFILE_BIG_ENDIAN, 'rb') as fp:

--- a/Misc/NEWS.d/next/Library/2026-07-11-16-00-00.gh-issue-153605.Rk7Xz3.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-11-16-00-00.gh-issue-153605.Rk7Xz3.rst
@@ -1,0 +1,2 @@
+Fix :class:`gettext.GNUTranslations` raising :exc:`struct.error` instead of
+:exc:`OSError` when reading a malformed ``.mo`` file. Patch by tonghuaroot.


### PR DESCRIPTION
`gettext.GNUTranslations` unpacked the `.mo` header and per-entry seek tables
with `struct.unpack` without first checking the file was long enough, so a
truncated file or one whose seek tables point past the end raised a raw
`struct.error` instead of the `OSError` the module already raises for other
malformed input. Validate the lengths and raise `OSError` instead.

<!-- gh-issue-number: gh-153605 -->
* Issue: gh-153605
<!-- /gh-issue-number -->
