### PR TITLE
[3.13] gh-128846: Fix test_configure_custom_copy for the aqua theme with Tk 9

### DIFF
--- a/Lib/test/test_ttk/test_style.py
+++ b/Lib/test/test_ttk/test_style.py
@@ -161,11 +161,12 @@ class StyleTest(AbstractTkTest, unittest.TestCase):
                     newname = f'C.{name}'
                     self.assertEqual(style.configure(newname), None)
                     style.configure(newname, **default)
-                    # With Tk 9 and the aqua theme an empty option value is
-                    # read back as an empty tuple rather than an empty string
-                    # (see gh-128846); normalize before comparing.
+                    # gh-128846: on 3.13 the aqua theme with Tk 9 reports an
+                    # unset option as an empty tuple in the original style but
+                    # as an empty string in the copy.  Normalize the copy back
+                    # to the empty tuple before comparing.
                     def norm(value):
-                        return '' if value == () else value
+                        return () if value == '' else value
                     copy = style.configure(newname)
                     self.assertEqual({k: norm(v) for k, v in copy.items()},
                                      default)

--- a/Lib/test/test_ttk/test_style.py
+++ b/Lib/test/test_ttk/test_style.py
@@ -161,18 +161,16 @@ class StyleTest(AbstractTkTest, unittest.TestCase):
                     newname = f'C.{name}'
                     self.assertEqual(style.configure(newname), None)
                     style.configure(newname, **default)
-                    # gh-128846: on 3.13 the aqua theme with Tk 9 reports an
-                    # unset option as an empty tuple in the original style but
-                    # as an empty string in the copy.  Normalize the copy back
-                    # to the empty tuple before comparing.
+                    # gh-128846: the aqua theme with Tk 9 reports an unset
+                    # option as an empty tuple, while the copy reports it as an
+                    # empty string.
                     def norm(value):
-                        return () if value == '' else value
-                    copy = style.configure(newname)
-                    self.assertEqual({k: norm(v) for k, v in copy.items()},
-                                     default)
+                        return '' if value == () else value
+                    self.assertEqual(style.configure(newname),
+                                     {k: norm(v) for k, v in default.items()})
                     for key, value in default.items():
-                        self.assertEqual(norm(style.configure(newname, key)),
-                                         value)
+                        self.assertEqual(style.configure(newname, key),
+                                         norm(value))
 
 
     def test_map_custom_copy(self):

--- a/Lib/test/test_ttk/test_style.py
+++ b/Lib/test/test_ttk/test_style.py
@@ -161,9 +161,17 @@ class StyleTest(AbstractTkTest, unittest.TestCase):
                     newname = f'C.{name}'
                     self.assertEqual(style.configure(newname), None)
                     style.configure(newname, **default)
-                    self.assertEqual(style.configure(newname), default)
+                    # With Tk 9 and the aqua theme an empty option value is
+                    # read back as an empty tuple rather than an empty string
+                    # (see gh-128846); normalize before comparing.
+                    def norm(value):
+                        return '' if value == () else value
+                    copy = style.configure(newname)
+                    self.assertEqual({k: norm(v) for k, v in copy.items()},
+                                     default)
                     for key, value in default.items():
-                        self.assertEqual(style.configure(newname, key), value)
+                        self.assertEqual(norm(style.configure(newname, key)),
+                                         value)
 
 
     def test_map_custom_copy(self):


### PR DESCRIPTION
On macOS with the aqua theme and Tk 9, an empty ttk style option value is
read back as an empty tuple rather than an empty string, so
`test_configure_custom_copy` failed when comparing a copied style against its
default. Normalize the empty tuple to an empty string before comparing.

Test-only; 3.13 lacks the `_tclobj_to_py` normalization that fixes this in
the library on 3.14+.

<!-- gh-issue-number: 128846 -->
* Issue: gh-128846
