### PR TITLE
gh-153513: Remove obsolete Tk version guards in tkinter tests

### DIFF
--- a/Lib/test/test_tkinter/test_widgets.py
+++ b/Lib/test/test_tkinter/test_widgets.py
@@ -915,9 +915,7 @@ class TextTest(AbstractWidgetTest, unittest.TestCase):
         widget = self.create()
         self.checkParam(widget, 'tabs', (10.2, 20.7, '1i', '2i'))
         self.checkParam(widget, 'tabs', '10.2 20.7 1i 2i',
-                        expected=(10.2, 20.7, '1i', '2i')
-                                 if get_tk_patchlevel(self.root) >= (8, 6, 14)
-                                 else ('10.2', '20.7', '1i', '2i'))
+                        expected=(10.2, 20.7, '1i', '2i'))
         self.checkParam(widget, 'tabs', '2c left 4c 6c center',
                         expected=('2c', 'left', '4c', '6c', 'center'))
         self.checkInvalidParam(widget, 'tabs', 'spam',

--- a/Lib/test/test_ttk/test_widgets.py
+++ b/Lib/test/test_ttk/test_widgets.py
@@ -29,20 +29,14 @@ class StandardTtkOptionsTests(StandardOptionsTests):
 
     def test_configure_padding(self):
         widget = self.create()
-        if get_tk_patchlevel(self.root) < (8, 6, 14):
-            def padding_conv(value):
-                self.assertIsInstance(value, tuple)
-                return tuple(map(str, value))
-        else:
-            padding_conv = None
-        self.checkParam(widget, 'padding', 0, expected=(0,), conv=padding_conv)
-        self.checkParam(widget, 'padding', 5, expected=(5,), conv=padding_conv)
+        self.checkParam(widget, 'padding', 0, expected=(0,))
+        self.checkParam(widget, 'padding', 5, expected=(5,))
         self.checkParam(widget, 'padding', (5, 6),
-                        expected=(5, 6), conv=padding_conv)
+                        expected=(5, 6))
         self.checkParam(widget, 'padding', (5, 6, 7),
-                        expected=(5, 6, 7), conv=padding_conv)
+                        expected=(5, 6, 7))
         self.checkParam(widget, 'padding', (5, 6, 7, 8),
-                        expected=(5, 6, 7, 8), conv=padding_conv)
+                        expected=(5, 6, 7, 8))
         self.checkParam(widget, 'padding', ('5p', '6p', '7p', '8p'))
         self.checkParam(widget, 'padding', (), expected='')
 


### PR DESCRIPTION
Since gh-153513, `_tkinter` returns `int`, `float` and pixel objects for the corresponding Tcl object types on all Tk versions.

The tests for the Text `tabs` and ttk `padding` options therefore no longer need to expect string tuples on Tk older than 8.6.14.  This makes them fail on real Tk 8.6.13 (as seen on the buildbots), while passing on the newer Tk of most development machines.

Verified by relinking `_tkinter` against Tk 8.6.8, 8.6.9, 8.6.13, 8.6.14, 8.6.15, 8.6.18 and 9.1b1.

Fixes #153599.