### PR TITLE
gh-153625: rewrite with original filename in append mode for zipfile

### DIFF
--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -4827,17 +4827,16 @@ class OtherTests(unittest.TestCase):
             with self.assertRaisesRegex(zipfile.BadZipFile, 'Overlapped entries'):
                 zipf.read('a')
 
-    @mock.patch('os.sep', '\\')
-    @mock.patch('os.altsep', '/')
     def test_append_keep_filename(self):
         """Files loaded from an archive should keep original filename when
         rewritten to central directory in append mode."""
-        with zipfile.ZipFile(TESTFN, mode="w") as zipfp:
+        with mock.patch('os.sep', '/'), mock.patch('os.altsep', None), \
+             zipfile.ZipFile(TESTFN, mode="w") as zipfp:
             zinfo = zipfile.ZipInfo('MyFolder/My\\File.txt')
-            zinfo._orig_filename = 'MyFolder/My\\File.txt'
             zipfp.writestr(zinfo, 'foo')
 
-        with zipfile.ZipFile(TESTFN, "a") as zipfp:
+        with mock.patch('os.sep', '\\'), mock.patch('os.altsep', '/'), \
+             zipfile.ZipFile(TESTFN, "a") as zipfp:
             self.assertIsNone(zipfp.testzip())
             zi = zipfp.infolist()[0]
             self.assertEqual(zi.orig_filename, 'MyFolder/My\\File.txt')

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -4827,6 +4827,8 @@ class OtherTests(unittest.TestCase):
             with self.assertRaisesRegex(zipfile.BadZipFile, 'Overlapped entries'):
                 zipf.read('a')
 
+    @mock.patch('os.sep', '\\')
+    @mock.patch('os.altsep', '/')
     def test_append_keep_filename(self):
         """Files loaded from an archive should keep original filename when
         rewritten to central directory in append mode."""

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -4830,25 +4830,25 @@ class OtherTests(unittest.TestCase):
     def test_append_keep_filename(self):
         """Files loaded from an archive should keep original filename when
         rewritten to central directory in append mode."""
-        with mock.patch('os.sep', '/'), mock.patch('os.altsep', None), \
-             zipfile.ZipFile(TESTFN, mode="w") as zipfp:
-            zinfo = zipfile.ZipInfo('MyFolder/My\\File.txt')
-            zipfp.writestr(zinfo, 'foo')
+        with mock.patch('os.sep', '/'), mock.patch('os.altsep', None):
+            with zipfile.ZipFile(TESTFN, mode="w") as zipfp:
+                zinfo = zipfile.ZipInfo('MyFolder/My\\File.txt')
+                zipfp.writestr(zinfo, 'foo')
 
-        with mock.patch('os.sep', '\\'), mock.patch('os.altsep', '/'), \
-             zipfile.ZipFile(TESTFN, "a") as zipfp:
-            zi = zipfp.infolist()[0]
-            self.assertEqual(zi.orig_filename, 'MyFolder/My\\File.txt')
-            self.assertEqual(zi.filename, 'MyFolder/My/File.txt')
-            self.assertIsNone(zipfp.testzip())
-            # trigger archive rewriting
-            zipfp.comment = b''
+        with mock.patch('os.sep', '\\'), mock.patch('os.altsep', '/'):
+            with zipfile.ZipFile(TESTFN, "a") as zipfp:
+                zi = zipfp.infolist()[0]
+                self.assertEqual(zi.orig_filename, 'MyFolder/My\\File.txt')
+                self.assertEqual(zi.filename, 'MyFolder/My/File.txt')
+                self.assertIsNone(zipfp.testzip())
+                # trigger archive rewriting
+                zipfp.comment = b''
 
-        with zipfile.ZipFile(TESTFN, "r") as zipfp:
-            zi = zipfp.infolist()[0]
-            self.assertEqual(zi.orig_filename, 'MyFolder/My\\File.txt')
-            self.assertEqual(zi.filename, 'MyFolder/My/File.txt')
-            self.assertIsNone(zipfp.testzip())
+            with zipfile.ZipFile(TESTFN, "r") as zipfp:
+                zi = zipfp.infolist()[0]
+                self.assertEqual(zi.orig_filename, 'MyFolder/My\\File.txt')
+                self.assertEqual(zi.filename, 'MyFolder/My/File.txt')
+                self.assertIsNone(zipfp.testzip())
 
     def tearDown(self):
         unlink(TESTFN)

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -4837,18 +4837,18 @@ class OtherTests(unittest.TestCase):
 
         with mock.patch('os.sep', '\\'), mock.patch('os.altsep', '/'), \
              zipfile.ZipFile(TESTFN, "a") as zipfp:
-            self.assertIsNone(zipfp.testzip())
             zi = zipfp.infolist()[0]
             self.assertEqual(zi.orig_filename, 'MyFolder/My\\File.txt')
             self.assertEqual(zi.filename, 'MyFolder/My/File.txt')
+            self.assertIsNone(zipfp.testzip())
             # trigger archive rewriting
             zipfp.comment = b''
 
         with zipfile.ZipFile(TESTFN, "r") as zipfp:
-            self.assertIsNone(zipfp.testzip())
             zi = zipfp.infolist()[0]
             self.assertEqual(zi.orig_filename, 'MyFolder/My\\File.txt')
             self.assertEqual(zi.filename, 'MyFolder/My/File.txt')
+            self.assertIsNone(zipfp.testzip())
 
     def tearDown(self):
         unlink(TESTFN)

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -4827,6 +4827,28 @@ class OtherTests(unittest.TestCase):
             with self.assertRaisesRegex(zipfile.BadZipFile, 'Overlapped entries'):
                 zipf.read('a')
 
+    def test_append_keep_filename(self):
+        """Files loaded from an archive should keep original filename when
+        rewritten to central directory in append mode."""
+        with zipfile.ZipFile(TESTFN, mode="w") as zipfp:
+            zinfo = zipfile.ZipInfo('MyFolder/My\\File.txt')
+            zinfo._orig_filename = 'MyFolder/My\\File.txt'
+            zipfp.writestr(zinfo, 'foo')
+
+        with zipfile.ZipFile(TESTFN, "a") as zipfp:
+            self.assertIsNone(zipfp.testzip())
+            zi = zipfp.infolist()[0]
+            self.assertEqual(zi.orig_filename, 'MyFolder/My\\File.txt')
+            self.assertEqual(zi.filename, 'MyFolder/My/File.txt')
+            # trigger archive rewriting
+            zipfp.comment = b''
+
+        with zipfile.ZipFile(TESTFN, "r") as zipfp:
+            self.assertIsNone(zipfp.testzip())
+            zi = zipfp.infolist()[0]
+            self.assertEqual(zi.orig_filename, 'MyFolder/My\\File.txt')
+            self.assertEqual(zi.filename, 'MyFolder/My/File.txt')
+
     def tearDown(self):
         unlink(TESTFN)
         unlink(TESTFN2)

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -456,8 +456,6 @@ class ZipInfo:
     )
 
     def __init__(self, filename="NoName", date_time=(1980,1,1,0,0,0)):
-        self.orig_filename = None       # Original file name in archive
-
         # Terminate the file name at the first null byte and
         # ensure paths always use forward slashes as the directory separator.
         filename = _sanitize_filename(filename)
@@ -487,7 +485,11 @@ class ZipInfo:
         self.external_attr = 0          # External file attributes
         self.compress_size = 0          # Size of the compressed file
         self.file_size = 0              # Size of the uncompressed file
+
+        # Special internal attributes set by class ZipFile when read from an archive:
+        self._orig_filename = None      # Original file name in archive
         self._end_offset = None         # Start of the next local header or central directory
+
         # Other attributes are set by class ZipFile:
         # header_offset         Byte offset to the file header
         # CRC                   CRC-32 of the uncompressed file

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -432,7 +432,7 @@ class ZipInfo:
     """Class with attributes describing each file in the ZIP archive."""
 
     __slots__ = (
-        'orig_filename',
+        '_orig_filename',
         'filename',
         'date_time',
         'compress_type',
@@ -456,7 +456,7 @@ class ZipInfo:
     )
 
     def __init__(self, filename="NoName", date_time=(1980,1,1,0,0,0)):
-        self.orig_filename = filename   # Original file name in archive
+        self.orig_filename = None       # Original file name in archive
 
         # Terminate the file name at the first null byte and
         # ensure paths always use forward slashes as the directory separator.
@@ -491,6 +491,16 @@ class ZipInfo:
         # Other attributes are set by class ZipFile:
         # header_offset         Byte offset to the file header
         # CRC                   CRC-32 of the uncompressed file
+
+    @property
+    def orig_filename(self):
+        return (self._orig_filename if self._orig_filename is not None
+                else self.filename)
+
+    # Maintain backward compatibility in case someone sets it.
+    @orig_filename.setter
+    def orig_filename(self, value):
+        self._orig_filename = value
 
     # Maintain backward compatibility with the old protected attribute name.
     @property
@@ -579,9 +589,9 @@ class ZipInfo:
         else:
             encoding = 'cp437'
         try:
-            return self.filename.encode(encoding), self.flag_bits & ~_MASK_UTF_FILENAME
+            return self.orig_filename.encode(encoding), self.flag_bits & ~_MASK_UTF_FILENAME
         except UnicodeEncodeError:
-            return self.filename.encode('utf-8'), self.flag_bits | _MASK_UTF_FILENAME
+            return self.orig_filename.encode('utf-8'), self.flag_bits | _MASK_UTF_FILENAME
 
     def _decodeExtra(self, filename_crc):
         # Try to decode the extra field.
@@ -2056,6 +2066,7 @@ class ZipFile:
                 filename = filename.decode(self.metadata_encoding or 'cp437')
             # Create ZipInfo instance to store file information
             x = ZipInfo(filename)
+            x._orig_filename = filename
             x.extra = fp.read(centdir[_CD_EXTRA_FIELD_LENGTH])
             x.comment = fp.read(centdir[_CD_COMMENT_LENGTH])
             x.header_offset = centdir[_CD_LOCAL_HEADER_OFFSET]

--- a/Misc/NEWS.d/next/Library/2026-07-12-16-11-18.gh-issue-153625.-wpBTM.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-12-16-11-18.gh-issue-153625.-wpBTM.rst
@@ -1,0 +1,1 @@
+Fix an issue that an auto-sanitized filename corrupts a ZIP archive when rewritten to the central directory in append mode.


### PR DESCRIPTION
Fix an issue that auto-sanitized filename corrupts a ZIP archive when rewritten to the central directory in append mode.

`ZipInfo.orig_filename` is now only set when read from an archive; otherwise it fallbacks to `ZipInfo.filename`. When writing, `ZipInfo.orig_filename` rather than `ZipInfo.filename` is used to ensure that the identical original filename is written back.

A setter of `ZipInfo.orig_filename` is provided for backword compatibility, although it is not mean to be modified. (Actually, most `ZipInfo` attributes should not be modified. Though I leave it to future when a breaking change is well-prepared.)

<!-- gh-issue-number: gh-153625 -->
* Issue: gh-153625
<!-- /gh-issue-number -->
