### PR TITLE
gh-153631: Move to `macos-26` runner for iOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -367,11 +367,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: List simulators
-        run: xcrun simctl list
-
       - name: Build and test
-        run: python3 Platforms/Apple ci iOS --fast-ci --simulator 'iPhone 17e,OS=26.5'
+        run: python3 Platforms/Apple ci iOS --fast-ci
 
   build-emscripten:
     name: 'Emscripten'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -367,6 +367,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: List simulators
+        run: xcrun simctl list
+
       - name: Build and test
         run: python3 Platforms/Apple ci iOS --fast-ci --simulator 'iPhone 17e,OS=26.5'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -361,23 +361,14 @@ jobs:
     needs: build-context
     if: needs.build-context.outputs.run-ios == 'true'
     timeout-minutes: 60
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      # GitHub recommends explicitly selecting the desired Xcode version:
-      # https://github.com/actions/runner-images/issues/12541#issuecomment-3083850140
-      # This became a necessity as a result of
-      # https://github.com/actions/runner-images/issues/12541 and
-      # https://github.com/actions/runner-images/issues/12751.
-      - name: Select Xcode version
-        run: |
-          sudo xcode-select --switch /Applications/Xcode_15.4.app
-
       - name: Build and test
-        run: python3 Platforms/Apple ci iOS --fast-ci --simulator 'iPhone SE (3rd generation),OS=17.5'
+        run: python3 Platforms/Apple ci iOS --fast-ci --simulator 'iPhone 17e,OS=26.5'
 
   build-emscripten:
     name: 'Emscripten'

--- a/Platforms/Apple/testbed/__main__.py
+++ b/Platforms/Apple/testbed/__main__.py
@@ -271,8 +271,14 @@ def run_testbed(
     update_test_plan(location, platform, args)
     print(" done.")
 
+    # xcodebuild doesn't guarantee that the CoreSimulatorService daemon is
+    # running prior to using a simulator, but calling `xcrun simctl list` does.
+    # Determining the default simulator that *would* be used is a cheap action;
+    # so use that as a way to ensure that the CoreSimulatorService daemon is
+    # running.
+    default_simulator = select_simulator_device(platform)
     if simulator is None:
-        simulator = select_simulator_device(platform)
+        simulator = default_simulator
     print(f"Running test on {simulator}")
 
     xcode_test(

--- a/Platforms/Apple/testbed/__main__.py
+++ b/Platforms/Apple/testbed/__main__.py
@@ -74,12 +74,6 @@ def xcode_test(location: Path, platform: str, simulator: str, verbose: bool):
     ]
     verbosity_args = [] if verbose else ["-quiet"]
 
-    print("Diagnostic - show xcodebuild destinations...")
-    subprocess.run(
-        ["xcodebuild", "-scheme", f"{platform}Testbed", "-showdestinations"],
-        check=True,
-    )
-
     print("Building test project...")
     subprocess.run(
         ["xcodebuild", "build-for-testing"] + args + verbosity_args,

--- a/Platforms/Apple/testbed/__main__.py
+++ b/Platforms/Apple/testbed/__main__.py
@@ -74,6 +74,12 @@ def xcode_test(location: Path, platform: str, simulator: str, verbose: bool):
     ]
     verbosity_args = [] if verbose else ["-quiet"]
 
+    print("Diagnostic - show xcodebuild destinations...")
+    subprocess.run(
+        ["xcodebuild", "-scheme", f"{platform}Testbed", "-showdestinations"],
+        check=True,
+    )
+
     print("Building test project...")
     subprocess.run(
         ["xcodebuild", "build-for-testing"] + args + verbosity_args,


### PR DESCRIPTION
Switches CI configuration to use macos-26 for iOS builds. macOS-14 is now in the deprecation window (with full deprecation by November); other Apple workflows are already on macOS-26.

This was previously proposed in #145099, but had to be rolled back due to a stability issue in the workflow. I've now identified the source of the stability problem.

The iOS simulator is managed by a daemon (CoreSimulatorService); and when the daemon is starting (or re-starting), `xcodebuild` will report that there are no simulators. It appears that Xcode doesn't block on the availability of CoreSimulatorService - it just returns an empty list if the service isn't running.

You can verify this manually by running `python Platforms/Apple iOS ci --fast-ci` to build the framework and create a testbed project; then run:
```
sudo pkill -f CoreSimulatorService; xcodebuild -showdestinations -scheme iOSTestbed -project cross-build/iOS-testbed.1783905783081/iOSTestbed.xcodeproj
```
(substituting the testbed folder that was generated). In my testing (on an M5 MacBook), about 2 in 3 of those runs will fail, and only display the minimal iOS target list, not the full list of available devices.

However, if you run:
```
sudo pkill -f CoreSimulatorService; xcrun simctl list devices; xcodebuild -showdestinations -scheme iOSTestbed -project cross-build/iOS-testbed.1783905783081/iOSTestbed.xcodeproj
```
- that is, explicitly call `simctl` before calling `xcodebuild` - it may take several seconds for `simctl` to respond, but when it does, both simctl, and then and xcodebuild, will return a full list of devices.

When running the Platforms/Apple script providing an explicit simulator, the first simulator call that is made is to `xcodebuild` with that specific simulator. However, if you fall back to the "default" behavior, the script calls `simctl` to determine the available simulators, which blocks until `CoreSimulatorService` is running. 

As a side effect, it also means that the script is resilient to changes in simulator image. This will be a particular concern with the macOS-26 image, as Github has indicated that they're going to be more aggressive about updating the Xcode versions that are available, and more aggressive in pruning older versions. iOS 26.5 is the default today; it wasn't when the macOS-26 image was launched. Since there's no automated trigger for bumping Python's CI configuration, and there's a significant performance penalty to using a non-default simulator, using an automated discovery-based scheme seems prudent going forward.

I have now run the iOS CI step 15 times (on commit 078ed9a), and it has passed every time; see CI run history for details. Previously, it would always fail within at least 10 runs (see [this comment](https://github.com/python/cpython/pull/145099#issuecomment-3949972628))

I've also modified the testbed script to *always* determine the default simulator, even if that default isn't used; it's a cheap operation, but it should guarantee a simulator is available if someone *does* have an explicit simulator defined.

<!-- gh-issue-number: gh-153631 -->
* Issue: gh-153631
<!-- /gh-issue-number -->
