### PR TITLE
gh-153634: Raise csv.Error, not ValueError, from csv.Sniffer for an inconsistent guessed dialect

### DIFF
--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -264,6 +264,14 @@ class Sniffer:
         dialect.quotechar = quotechar or '"'
         dialect.skipinitialspace = skipinitialspace
 
+        # A guess can be inconsistent (for example delimiter == quotechar).
+        # Building a reader validates it; re-raise the _csv ValueError as a
+        # csv.Error so callers see the module's own exception type.
+        try:
+            reader(StringIO(), dialect)
+        except ValueError as e:
+            raise Error(str(e)) from None
+
         return dialect
 
 

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -264,9 +264,8 @@ class Sniffer:
         dialect.quotechar = quotechar or '"'
         dialect.skipinitialspace = skipinitialspace
 
-        # A guess can be inconsistent (for example delimiter == quotechar).
-        # Building a reader validates it; re-raise the _csv ValueError as a
-        # csv.Error so callers see the module's own exception type.
+        # A guessed dialect can be inconsistent (delimiter == quotechar);
+        # surface it as csv.Error, not a raw _csv ValueError.
         try:
             reader(StringIO(), dialect)
         except ValueError as e:

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1464,9 +1464,7 @@ ghi\0jkl
         self.assertIs(dialect.skipinitialspace, False)
 
     def test_sniff_delimiter_equals_quotechar(self):
-        # A sample that makes sniff() guess a dialect whose delimiter equals
-        # its quotechar is invalid; that must surface as csv.Error, not as a
-        # raw ValueError leaking from the _csv extension.
+        # An inconsistent guessed dialect must surface as csv.Error.
         sniffer = csv.Sniffer()
         for sample in ('"', '""', "''"):
             with self.subTest(sample=sample):

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1463,6 +1463,16 @@ ghi\0jkl
         self.assertEqual(dialect.quotechar, "'")
         self.assertIs(dialect.skipinitialspace, False)
 
+    def test_sniff_delimiter_equals_quotechar(self):
+        # A sample that makes sniff() guess a dialect whose delimiter equals
+        # its quotechar is invalid; that must surface as csv.Error, not as a
+        # raw ValueError leaking from the _csv extension.
+        sniffer = csv.Sniffer()
+        for sample in ('"', '""', "''"):
+            with self.subTest(sample=sample):
+                self.assertRaises(csv.Error, sniffer.sniff, sample)
+                self.assertRaises(csv.Error, sniffer.has_header, sample)
+
     def test_delimiters(self):
         sniffer = csv.Sniffer()
         dialect = sniffer.sniff(self.sample3)

--- a/Misc/NEWS.d/next/Library/2026-07-09-16-41-20.gh-issue-153634.27Fs4T.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-09-16-41-20.gh-issue-153634.27Fs4T.rst
@@ -1,0 +1,4 @@
+:meth:`csv.Sniffer.sniff` now raises :exc:`csv.Error` for an inconsistent
+guessed dialect, for example one whose delimiter equals its quote character,
+instead of returning it. :meth:`csv.Sniffer.has_header` now raises
+:exc:`csv.Error` instead of leaking a :exc:`ValueError`.

--- a/Misc/NEWS.d/next/Library/2026-07-09-16-41-20.gh-issue-153634.27Fs4T.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-09-16-41-20.gh-issue-153634.27Fs4T.rst
@@ -1,4 +1,4 @@
 :meth:`csv.Sniffer.sniff` now raises :exc:`csv.Error` for an inconsistent
-guessed dialect, for example one whose delimiter equals its quote character,
-instead of returning it. :meth:`csv.Sniffer.has_header` now raises
-:exc:`csv.Error` instead of leaking a :exc:`ValueError`.
+guessed dialect (one whose delimiter equals its quote character) instead of
+returning it. :meth:`csv.Sniffer.has_header` now raises :exc:`csv.Error`
+instead of leaking a :exc:`ValueError`.


### PR DESCRIPTION
`csv.Sniffer.sniff()` could return a dialect whose delimiter equals its quotechar, so using it (directly or via `has_header`) leaked a raw `ValueError` from `_csv` instead of `csv.Error`. Validate the guessed dialect before returning it and re-raise the `ValueError` as `csv.Error`; the throwaway reader validates the full `_csv` invariant set, so future `_guess_*` changes cannot silently return another invalid dialect.

<!-- gh-issue-number: gh-153634 -->
* Issue: gh-153634
<!-- /gh-issue-number -->
