### PR TITLE
gh-153636: Raise InvalidHeaderError for malformed GNU sparse pax numbers in tarfile

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1647,7 +1647,10 @@ class TarInfo(object):
     def _proc_gnusparse_01(self, next, pax_headers):
         """Process a GNU tar extended sparse header, version 0.1.
         """
-        sparse = [int(x) for x in pax_headers["GNU.sparse.map"].split(",")]
+        try:
+            sparse = [int(x) for x in pax_headers["GNU.sparse.map"].split(",")]
+        except ValueError:
+            raise InvalidHeaderError("invalid header")
         next.sparse = list(zip(sparse[::2], sparse[1::2]))
 
     def _proc_gnusparse_10(self, next, pax_headers, tarfile):
@@ -1657,12 +1660,18 @@ class TarInfo(object):
         sparse = []
         buf = tarfile.fileobj.read(BLOCKSIZE)
         fields, buf = buf.split(b"\n", 1)
-        fields = int(fields)
+        try:
+            fields = int(fields)
+        except ValueError:
+            raise InvalidHeaderError("invalid header")
         while len(sparse) < fields * 2:
             if b"\n" not in buf:
                 buf += tarfile.fileobj.read(BLOCKSIZE)
             number, buf = buf.split(b"\n", 1)
-            sparse.append(int(number))
+            try:
+                sparse.append(int(number))
+            except ValueError:
+                raise InvalidHeaderError("invalid header")
         next.offset_data = tarfile.fileobj.tell()
         next.sparse = list(zip(sparse[::2], sparse[1::2]))
 
@@ -1674,9 +1683,15 @@ class TarInfo(object):
             if keyword == "GNU.sparse.name":
                 setattr(self, "path", value)
             elif keyword == "GNU.sparse.size":
-                setattr(self, "size", int(value))
+                try:
+                    setattr(self, "size", int(value))
+                except ValueError:
+                    raise InvalidHeaderError("invalid header")
             elif keyword == "GNU.sparse.realsize":
-                setattr(self, "size", int(value))
+                try:
+                    setattr(self, "size", int(value))
+                except ValueError:
+                    raise InvalidHeaderError("invalid header")
             elif keyword in PAX_FIELDS:
                 if keyword in PAX_NUMBER_FIELDS:
                     try:

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -2436,9 +2436,8 @@ class PaxWriteTest(GNUWriteTest):
             tar.close()
 
     def _make_malformed_gnusparse_tar(self, pax_entries, following=b""):
-        # Build an in-memory tar whose pax extended ('x') header carries the
-        # given GNU.sparse.* records, followed by a regular file member (and
-        # optionally a leading data block for the sparse-1.0 map).
+        # Build an in-memory tar: a pax ('x') header with the given
+        # GNU.sparse.* records, then a file member (and any `following` data).
         def pax_record(key, value):
             kv = key.encode() + b"=" + value.encode() + b"\n"
             n = len(kv)
@@ -2472,9 +2471,8 @@ class PaxWriteTest(GNUWriteTest):
         return io.BytesIO(blocks)
 
     def test_pax_gnusparse_bad_number(self):
-        # A malformed GNU sparse number in a pax extended header is reported
-        # through InvalidHeaderError instead of a bare ValueError, so the
-        # reader stops cleanly like it does for the GNU sparse 0.0 format.
+        # A malformed GNU sparse number surfaces as InvalidHeaderError, not a
+        # bare ValueError, so the reader stops (getmembers() truncates).
         cases = [
             [("GNU.sparse.map", "1,notanumber")],       # sparse 0.1
             [("GNU.sparse.size", "notanumber")],

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -2435,6 +2435,77 @@ class PaxWriteTest(GNUWriteTest):
         finally:
             tar.close()
 
+    def _make_malformed_gnusparse_tar(self, pax_entries, following=b""):
+        # Build an in-memory tar whose pax extended ('x') header carries the
+        # given GNU.sparse.* records, followed by a regular file member (and
+        # optionally a leading data block for the sparse-1.0 map).
+        def pax_record(key, value):
+            kv = key.encode() + b"=" + value.encode() + b"\n"
+            n = len(kv)
+            p = len(str(n)) + 1 + n
+            while len(str(p)) + 1 + n != p:
+                p = len(str(p)) + 1 + n
+            return str(p).encode() + b" " + kv
+
+        def header(name, size, typeflag):
+            buf = bytearray(512)
+            buf[0:len(name)] = name
+            buf[100:108] = b"0000644\x00"
+            buf[108:116] = b"0000000\x00"
+            buf[116:124] = b"0000000\x00"
+            buf[124:136] = ("%011o\x00" % size).encode()
+            buf[136:148] = b"00000000000\x00"
+            buf[148:156] = b"        "
+            buf[156] = ord(typeflag)
+            buf[257:265] = b"ustar\x0000"
+            chksum = sum(buf) & 0o777777
+            buf[148:156] = ("%06o\x00 " % chksum).encode()
+            return bytes(buf)
+
+        records = b"".join(pax_record(k, v) for k, v in pax_entries)
+        blocks = header(b"././@PaxHeader", len(records), "x")
+        blocks += records + b"\x00" * (-len(records) % 512)
+        blocks += header(b"testfile", 0, "0")
+        if following:
+            blocks += following
+        blocks += b"\x00" * 1024
+        return io.BytesIO(blocks)
+
+    def test_pax_gnusparse_bad_number(self):
+        # A malformed GNU sparse number in a pax extended header is reported
+        # through InvalidHeaderError instead of a bare ValueError, so the
+        # reader stops cleanly like it does for the GNU sparse 0.0 format.
+        cases = [
+            [("GNU.sparse.map", "1,notanumber")],       # sparse 0.1
+            [("GNU.sparse.size", "notanumber")],
+            [("GNU.sparse.realsize", "notanumber")],
+        ]
+        for entries in cases:
+            with self.subTest(entries=entries):
+                fobj = self._make_malformed_gnusparse_tar(entries)
+                with tarfile.open(fileobj=fobj) as tar:
+                    self.assertEqual(tar.getmembers(), [])
+
+        for data in (b"notanumber\n", b"1\nnotanumber\n"):     # sparse 1.0
+            with self.subTest(data=data):
+                following = data + b"\x00" * (-len(data) % 512)
+                fobj = self._make_malformed_gnusparse_tar(
+                    [("GNU.sparse.major", "1"), ("GNU.sparse.minor", "0")],
+                    following=following)
+                with tarfile.open(fileobj=fobj) as tar:
+                    self.assertEqual(tar.getmembers(), [])
+
+    def test_pax_gnusparse_bad_number_direct(self):
+        # The parsing helpers themselves raise InvalidHeaderError, not
+        # ValueError, mirroring _proc_gnusparse_00.
+        ti = tarfile.TarInfo("x")
+        with self.assertRaises(tarfile.InvalidHeaderError):
+            ti._apply_pax_info({"GNU.sparse.size": "notanumber"},
+                               "utf-8", "strict")
+        with self.assertRaises(tarfile.InvalidHeaderError):
+            ti._apply_pax_info({"GNU.sparse.realsize": "notanumber"},
+                               "utf-8", "strict")
+
     def test_create_pax_header(self):
         # The ustar header should contain values that can be
         # represented reasonably, even if a better (e.g. higher

--- a/Misc/NEWS.d/next/Library/2026-07-09-00-00-00.gh-issue-153636.8pWrHC.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-09-00-00-00.gh-issue-153636.8pWrHC.rst
@@ -1,0 +1,3 @@
+:mod:`tarfile` now raises :exc:`tarfile.InvalidHeaderError` instead of a bare
+:exc:`ValueError` when a pax extended header contains a malformed GNU sparse
+number, matching the existing handling of the GNU sparse 0.0 format.

--- a/Misc/NEWS.d/next/Library/2026-07-09-00-00-00.gh-issue-153636.8pWrHC.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-09-00-00-00.gh-issue-153636.8pWrHC.rst
@@ -1,3 +1,3 @@
-:mod:`tarfile` now raises :exc:`tarfile.InvalidHeaderError` instead of a bare
+:mod:`tarfile` now raises ``InvalidHeaderError`` instead of a bare
 :exc:`ValueError` when a pax extended header contains a malformed GNU sparse
 number, matching the existing handling of the GNU sparse 0.0 format.


### PR DESCRIPTION
A malformed GNU sparse number in a pax extended header leaked a bare `ValueError` from `_proc_gnusparse_01`, `_proc_gnusparse_10`, and the `GNU.sparse.size`/`realsize` branches, unlike the GNU sparse 0.0 handler. Raise `InvalidHeaderError` from those sites, giving the GNU sparse family one behavior on a corrupt header.

<!-- gh-issue-number: gh-153636 -->
* Issue: gh-153636
<!-- /gh-issue-number -->
