### PR TITLE
gh-153020: Fix race condition on event_tstate in _tkinter

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-07-13-10-37-32.gh-issue-153020.eventTs.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-13-10-37-32.gh-issue-153020.eventTs.rst
@@ -1,0 +1,2 @@
+Fix a data race in :mod:`!_tkinter` input event handling in free-threaded
+builds.

--- a/Misc/NEWS.d/next/Library/2026-07-13-10-37-32.gh-issue-153020.eventTs.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-13-10-37-32.gh-issue-153020.eventTs.rst
@@ -1,2 +1,1 @@
-Fix a data race in :mod:`!_tkinter` input event handling in free-threaded
-builds.
+Fix a data race in :mod:`!_tkinter` input event handling under the :term:`free-threaded build`.

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -31,6 +31,7 @@ Copyright (C) 1994 Steen Lumholt.
 #endif
 
 #include "pycore_long.h"          // _PyLong_IsNegative()
+#include "pycore_pyatomic_ft_wrappers.h" // FT_ATOMIC_LOAD_PTR, FT_ATOMIC_STORE_PTR
 #include "pycore_unicodeobject.h" // _PyUnicode_AsUTF8String
 
 #ifdef MS_WINDOWS
@@ -3655,7 +3656,7 @@ EventHook(void)
     int tfile;
     stdin_ready = 0;
 #endif
-    PyEval_RestoreThread(event_tstate);
+    PyEval_RestoreThread(FT_ATOMIC_LOAD_PTR(event_tstate));
     errorInCmd = 0;
 #ifdef MS_WINDOWS
     hStdin = GetStdHandle(STD_INPUT_HANDLE);
@@ -3687,7 +3688,7 @@ EventHook(void)
 #endif
         Py_BEGIN_ALLOW_THREADS
         if(tcl_lock)PyThread_acquire_lock(tcl_lock, 1);
-        tcl_tstate = event_tstate;
+        tcl_tstate = FT_ATOMIC_LOAD_PTR(event_tstate);
 
         result = Tcl_DoOneEvent(TCL_DONT_WAIT);
 
@@ -3725,7 +3726,7 @@ EnableEventHook(void)
 {
 #ifdef WAIT_FOR_STDIN
     if (PyOS_InputHook == NULL) {
-        event_tstate = PyThreadState_Get();
+        FT_ATOMIC_STORE_PTR(event_tstate, PyThreadState_Get());
         PyOS_InputHook = EventHook;
     }
 #endif
@@ -3737,6 +3738,7 @@ DisableEventHook(void)
 #ifdef WAIT_FOR_STDIN
     if (Tk_GetNumMainWindows() == 0 && PyOS_InputHook == EventHook) {
         PyOS_InputHook = NULL;
+        FT_ATOMIC_STORE_PTR(event_tstate, NULL);
     }
 #endif
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
`event_tstate` in Modules/_tkinter.c is read by the EventHook thread and
written by the main thread, so they race. I load and store it with atomic
ops, and clear it to NULL in DisableEventHook before the PyThreadState is
released.

<!-- gh-issue-number: gh-153020 -->
* Issue: gh-153020
<!-- /gh-issue-number -->
