### PR TITLE
gh-153621: Expose raw libzstd error code in `ZstdError` messages

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-07-22-12-56-25.gh-issue-153621.0dccf5c6.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-22-12-56-25.gh-issue-153621.0dccf5c6.rst
@@ -1,0 +1,2 @@
+Include the raw libzstd error code in all :exc:`ZstdError` messages, making
+it easier for users to diagnose compression and decompression failures.

--- a/Modules/_zstd/_zstdmodule.c
+++ b/Modules/_zstd/_zstdmodule.c
@@ -67,45 +67,52 @@ set_zstd_error(const _zstd_state *state, error_type type, size_t zstd_ret)
     }
     switch (type) {
         case ERR_DECOMPRESS:
-            msg = "Unable to decompress Zstandard data: %s";
+            msg = "Unable to decompress Zstandard data: %s (error code %llu)";
             break;
         case ERR_COMPRESS:
-            msg = "Unable to compress Zstandard data: %s";
+            msg = "Unable to compress Zstandard data: %s (error code %llu)";
             break;
         case ERR_SET_PLEDGED_INPUT_SIZE:
-            msg = "Unable to set pledged uncompressed content size: %s";
+            msg = "Unable to set pledged uncompressed content size: %s "
+                  "(error code %llu)";
             break;
 
         case ERR_LOAD_D_DICT:
             msg = "Unable to load Zstandard dictionary or prefix for "
-                  "decompression: %s";
+                  "decompression: %s (error code %llu)";
             break;
         case ERR_LOAD_C_DICT:
             msg = "Unable to load Zstandard dictionary or prefix for "
-                  "compression: %s";
+                  "compression: %s (error code %llu)";
             break;
 
         case ERR_GET_C_BOUNDS:
-            msg = "Unable to get zstd compression parameter bounds: %s";
+            msg = "Unable to get zstd compression parameter bounds: %s "
+                  "(error code %llu)";
             break;
         case ERR_GET_D_BOUNDS:
-            msg = "Unable to get zstd decompression parameter bounds: %s";
+            msg = "Unable to get zstd decompression parameter bounds: %s "
+                  "(error code %llu)";
             break;
         case ERR_SET_C_LEVEL:
-            msg = "Unable to set zstd compression level: %s";
+            msg = "Unable to set zstd compression level: %s "
+                  "(error code %llu)";
             break;
 
         case ERR_TRAIN_DICT:
-            msg = "Unable to train the Zstandard dictionary: %s";
+            msg = "Unable to train the Zstandard dictionary: %s "
+                  "(error code %llu)";
             break;
         case ERR_FINALIZE_DICT:
-            msg = "Unable to finalize the Zstandard dictionary: %s";
+            msg = "Unable to finalize the Zstandard dictionary: %s "
+                  "(error code %llu)";
             break;
 
         default:
             Py_UNREACHABLE();
     }
-    PyErr_Format(state->ZstdError, msg, ZSTD_getErrorName(zstd_ret));
+    PyErr_Format(state->ZstdError, msg, ZSTD_getErrorName(zstd_ret),
+                 (unsigned long long)zstd_ret);
 }
 
 typedef struct {


### PR DESCRIPTION
Include the raw error code returned by libzstd in all ZstdError messages, making it easier for users to diagnose compression and decompression issues.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Include the raw error code returned by libzstd in all ZstdError messages, making it easier for users to diagnose compression and decompression issues.

  Closes #153621

<!-- gh-issue-number: gh-153621 -->
* Issue: gh-153621
<!-- /gh-issue-number -->
