### PR TITLE
gh-153550: Remove out-of-date page-number citations from tkinter docs

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -613,7 +613,7 @@ Packer options
 ^^^^^^^^^^^^^^
 
 For more extensive information on the packer and the options that it can take,
-see the man pages and page 183 of John Ousterhout's book.
+see the relevant man pages for details.
 
 anchor
    Anchor type.  Denotes where the packer is to place each content in its parcel.
@@ -772,7 +772,7 @@ color
    Colors can be given as the names of X colors in the rgb.txt file, or as strings
    representing RGB values in 4 bit: ``"#RGB"``, 8 bit: ``"#RRGGBB"``, 12 bit:
    ``"#RRRGGGBBB"``, or 16 bit: ``"#RRRRGGGGBBBB"`` ranges, where R,G,B here
-   represent any legal hex digit.  See page 160 of Ousterhout's book for details.
+   represent any legal hex digit.  See the Tk documentation for details.
 
 cursor
    The name of the mouse cursor to display while the pointer is over the widget.
@@ -856,8 +856,7 @@ sequence
    ``<modifier-modifier-type-detail>`` form (for example ``"<Enter>"`` or
    ``"<Control-Button-1>"``); application-defined virtual events use double angle
    brackets, as in ``"<<Paste>>"``.  (See the
-   :manpage:`bind(3tk)` man page, and page 201 of John Ousterhout's book,
-   :title-reference:`Tcl and the Tk Toolkit (2nd edition)`, for details).
+   :manpage:`bind(3tk)` man page for details).
 
 func
    is a Python function, taking one argument, to be invoked when the event occurs.

--- a/Modules/_zstd/_zstdmodule.c
+++ b/Modules/_zstd/_zstdmodule.c
@@ -67,45 +67,52 @@ set_zstd_error(const _zstd_state *state, error_type type, size_t zstd_ret)
     }
     switch (type) {
         case ERR_DECOMPRESS:
-            msg = "Unable to decompress Zstandard data: %s";
+            msg = "Unable to decompress Zstandard data: %s (error code %llu)";
             break;
         case ERR_COMPRESS:
-            msg = "Unable to compress Zstandard data: %s";
+            msg = "Unable to compress Zstandard data: %s (error code %llu)";
             break;
         case ERR_SET_PLEDGED_INPUT_SIZE:
-            msg = "Unable to set pledged uncompressed content size: %s";
+            msg = "Unable to set pledged uncompressed content size: %s "
+                  "(error code %llu)";
             break;
 
         case ERR_LOAD_D_DICT:
             msg = "Unable to load Zstandard dictionary or prefix for "
-                  "decompression: %s";
+                  "decompression: %s (error code %llu)";
             break;
         case ERR_LOAD_C_DICT:
             msg = "Unable to load Zstandard dictionary or prefix for "
-                  "compression: %s";
+                  "compression: %s (error code %llu)";
             break;
 
         case ERR_GET_C_BOUNDS:
-            msg = "Unable to get zstd compression parameter bounds: %s";
+            msg = "Unable to get zstd compression parameter bounds: %s "
+                  "(error code %llu)";
             break;
         case ERR_GET_D_BOUNDS:
-            msg = "Unable to get zstd decompression parameter bounds: %s";
+            msg = "Unable to get zstd decompression parameter bounds: %s "
+                  "(error code %llu)";
             break;
         case ERR_SET_C_LEVEL:
-            msg = "Unable to set zstd compression level: %s";
+            msg = "Unable to set zstd compression level: %s "
+                  "(error code %llu)";
             break;
 
         case ERR_TRAIN_DICT:
-            msg = "Unable to train the Zstandard dictionary: %s";
+            msg = "Unable to train the Zstandard dictionary: %s "
+                  "(error code %llu)";
             break;
         case ERR_FINALIZE_DICT:
-            msg = "Unable to finalize the Zstandard dictionary: %s";
+            msg = "Unable to finalize the Zstandard dictionary: %s "
+                  "(error code %llu)";
             break;
 
         default:
             Py_UNREACHABLE();
     }
-    PyErr_Format(state->ZstdError, msg, ZSTD_getErrorName(zstd_ret));
+    PyErr_Format(state->ZstdError, msg, ZSTD_getErrorName(zstd_ret),
+                 (unsigned long long)zstd_ret);
 }
 
 typedef struct {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Remove references to specific page numbers in Ousterhout's book
  ("page 160", "page 183", "page 201") from the tkinter documentation,
  as they refer to a single print edition and are not useful online.

  Partially addresses #153550

<!-- gh-issue-number: gh-153550 -->
* Issue: gh-153550
<!-- /gh-issue-number -->
