### PR TITLE
gh-153266: Add optional kiosk mode support to the webbrowser module

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -613,7 +613,7 @@ Packer options
 ^^^^^^^^^^^^^^
 
 For more extensive information on the packer and the options that it can take,
-see the man pages and page 183 of John Ousterhout's book.
+see the relevant man pages for details.
 
 anchor
    Anchor type.  Denotes where the packer is to place each content in its parcel.
@@ -772,7 +772,7 @@ color
    Colors can be given as the names of X colors in the rgb.txt file, or as strings
    representing RGB values in 4 bit: ``"#RGB"``, 8 bit: ``"#RRGGBB"``, 12 bit:
    ``"#RRRGGGBBB"``, or 16 bit: ``"#RRRRGGGGBBBB"`` ranges, where R,G,B here
-   represent any legal hex digit.  See page 160 of Ousterhout's book for details.
+   represent any legal hex digit.  See the Tk documentation for details.
 
 cursor
    The name of the mouse cursor to display while the pointer is over the widget.
@@ -856,8 +856,7 @@ sequence
    ``<modifier-modifier-type-detail>`` form (for example ``"<Enter>"`` or
    ``"<Control-Button-1>"``); application-defined virtual events use double angle
    brackets, as in ``"<<Paste>>"``.  (See the
-   :manpage:`bind(3tk)` man page, and page 201 of John Ousterhout's book,
-   :title-reference:`Tcl and the Tk Toolkit (2nd edition)`, for details).
+   :manpage:`bind(3tk)` man page for details).
 
 func
    is a Python function, taking one argument, to be invoked when the event occurs.

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -73,7 +73,7 @@ def get(using=None):
 # It is recommended one does "import webbrowser" and uses webbrowser.open(url)
 # instead of "from webbrowser import *".
 
-def open(url, new=0, autoraise=True):
+def open(url, new=0, autoraise=True, kiosk=False):
     """Display url using the default browser.
 
     If possible, open url in a location determined by new.
@@ -81,6 +81,9 @@ def open(url, new=0, autoraise=True):
     - 1: a new browser window.
     - 2: a new browser page ("tab").
     If possible, autoraise raises the window (the default) or not.
+
+    If kiosk is true, open the url in kiosk/full-screen mode
+    (supported by Chrome, Firefox, and Edge).
 
     If opening the browser succeeds, return True.
     If there is a problem, return False.
@@ -91,7 +94,7 @@ def open(url, new=0, autoraise=True):
                 register_standard_browsers()
     for name in _tryorder:
         browser = get(name)
-        if browser.open(url, new, autoraise):
+        if browser.open(url, new, autoraise, kiosk=kiosk):
             return True
     return False
 
@@ -155,7 +158,7 @@ class BaseBrowser:
         self.name = name
         self.basename = name
 
-    def open(self, url, new=0, autoraise=True):
+    def open(self, url, new=0, autoraise=True, kiosk=False):
         raise NotImplementedError
 
     def open_new(self, url):
@@ -185,11 +188,13 @@ class GenericBrowser(BaseBrowser):
             self.args = name[1:]
         self.basename = os.path.basename(self.name)
 
-    def open(self, url, new=0, autoraise=True):
+    def open(self, url, new=0, autoraise=True, kiosk=False):
         sys.audit("webbrowser.open", url)
         self._check_url(url)
         cmdline = [self.name] + [arg.replace("%s", url)
                                  for arg in self.args]
+        if kiosk:
+            cmdline.append("--kiosk")
         try:
             if sys.platform[:3] == 'win':
                 p = subprocess.Popen(cmdline)
@@ -204,11 +209,13 @@ class BackgroundBrowser(GenericBrowser):
     """Class for all browsers which are to be started in the
        background."""
 
-    def open(self, url, new=0, autoraise=True):
+    def open(self, url, new=0, autoraise=True, kiosk=False):
         cmdline = [self.name] + [arg.replace("%s", url)
                                  for arg in self.args]
         sys.audit("webbrowser.open", url)
         self._check_url(url)
+        if kiosk:
+            cmdline.append("--kiosk")
         try:
             if sys.platform[:3] == 'win':
                 p = subprocess.Popen(cmdline)
@@ -273,7 +280,7 @@ class UnixBrowser(BaseBrowser):
         else:
             return not p.wait()
 
-    def open(self, url, new=0, autoraise=True):
+    def open(self, url, new=0, autoraise=True, kiosk=False):
         sys.audit("webbrowser.open", url)
         if new == 0:
             action = self.remote_action
@@ -293,6 +300,8 @@ class UnixBrowser(BaseBrowser):
         args = [arg.replace("%action", action).replace("%s", url)
                 for arg in self.remote_args]
         args = [arg for arg in args if arg]
+        if kiosk:
+            args.append("--kiosk")
         success = self._invoke(args, True, autoraise, url)
         if not success:
             # remote invocation failed, try straight way
@@ -366,7 +375,7 @@ class Konqueror(BaseBrowser):
     for more information on the Konqueror remote-control interface.
     """
 
-    def open(self, url, new=0, autoraise=True):
+    def open(self, url, new=0, autoraise=True, kiosk=False):
         sys.audit("webbrowser.open", url)
         self._check_url(url)
         # XXX Currently I know no way to prevent KFM from opening a new win.
@@ -603,7 +612,7 @@ def register_standard_browsers():
 
 if sys.platform[:3] == "win":
     class WindowsDefault(BaseBrowser):
-        def open(self, url, new=0, autoraise=True):
+        def open(self, url, new=0, autoraise=True, kiosk=False):
             sys.audit("webbrowser.open", url)
             self._check_url(url)
             try:
@@ -671,7 +680,7 @@ if sys.platform == 'darwin':
             'brave browser':  'com.brave.Browser',
         }
 
-        def open(self, url, new=0, autoraise=True):
+        def open(self, url, new=0, autoraise=True, kiosk=False):
             sys.audit("webbrowser.open", url)
             self._check_url(url)
             if self.name == 'default':
@@ -696,7 +705,7 @@ if sys.platform == 'darwin':
             warnings._deprecated("webbrowser.MacOSXOSAScript", remove=(3, 17))
             super().__init__(name)
 
-        def open(self, url, new=0, autoraise=True):
+        def open(self, url, new=0, autoraise=True, kiosk=False):
             sys.audit("webbrowser.open", url)
             self._check_url(url)
             url = url.replace('"', '%22')
@@ -753,7 +762,7 @@ if sys.platform == "ios":
         from ctypes import c_void_p, c_char_p, c_ulong
 
     class IOSBrowser(BaseBrowser):
-        def open(self, url, new=0, autoraise=True):
+        def open(self, url, new=0, autoraise=True, kiosk=False):
             sys.audit("webbrowser.open", url)
             self._check_url(url)
             # If ctypes isn't available, we can't open a browser

--- a/Modules/_zstd/_zstdmodule.c
+++ b/Modules/_zstd/_zstdmodule.c
@@ -67,45 +67,52 @@ set_zstd_error(const _zstd_state *state, error_type type, size_t zstd_ret)
     }
     switch (type) {
         case ERR_DECOMPRESS:
-            msg = "Unable to decompress Zstandard data: %s";
+            msg = "Unable to decompress Zstandard data: %s (error code %llu)";
             break;
         case ERR_COMPRESS:
-            msg = "Unable to compress Zstandard data: %s";
+            msg = "Unable to compress Zstandard data: %s (error code %llu)";
             break;
         case ERR_SET_PLEDGED_INPUT_SIZE:
-            msg = "Unable to set pledged uncompressed content size: %s";
+            msg = "Unable to set pledged uncompressed content size: %s "
+                  "(error code %llu)";
             break;
 
         case ERR_LOAD_D_DICT:
             msg = "Unable to load Zstandard dictionary or prefix for "
-                  "decompression: %s";
+                  "decompression: %s (error code %llu)";
             break;
         case ERR_LOAD_C_DICT:
             msg = "Unable to load Zstandard dictionary or prefix for "
-                  "compression: %s";
+                  "compression: %s (error code %llu)";
             break;
 
         case ERR_GET_C_BOUNDS:
-            msg = "Unable to get zstd compression parameter bounds: %s";
+            msg = "Unable to get zstd compression parameter bounds: %s "
+                  "(error code %llu)";
             break;
         case ERR_GET_D_BOUNDS:
-            msg = "Unable to get zstd decompression parameter bounds: %s";
+            msg = "Unable to get zstd decompression parameter bounds: %s "
+                  "(error code %llu)";
             break;
         case ERR_SET_C_LEVEL:
-            msg = "Unable to set zstd compression level: %s";
+            msg = "Unable to set zstd compression level: %s "
+                  "(error code %llu)";
             break;
 
         case ERR_TRAIN_DICT:
-            msg = "Unable to train the Zstandard dictionary: %s";
+            msg = "Unable to train the Zstandard dictionary: %s "
+                  "(error code %llu)";
             break;
         case ERR_FINALIZE_DICT:
-            msg = "Unable to finalize the Zstandard dictionary: %s";
+            msg = "Unable to finalize the Zstandard dictionary: %s "
+                  "(error code %llu)";
             break;
 
         default:
             Py_UNREACHABLE();
     }
-    PyErr_Format(state->ZstdError, msg, ZSTD_getErrorName(zstd_ret));
+    PyErr_Format(state->ZstdError, msg, ZSTD_getErrorName(zstd_ret),
+                 (unsigned long long)zstd_ret);
 }
 
 typedef struct {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
dd a `kiosk` parameter to `webbrowser.open()` that enables
  kiosk/full-screen mode in supported browsers (Chrome, Firefox, Edge).

  Usage: webbrowser.open("https://example.com", kiosk=True)

  Closes #153266

<!-- gh-issue-number: gh-153266 -->
* Issue: gh-153266
<!-- /gh-issue-number -->
