### PR TITLE
[3.14] gh-148286: Fix UB in `ZstdDecompressor.unused_data` when a frame is decompressed in one call (GH-153258)

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-07-07-13-31-52.gh-issue-148286.-qu-em.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-07-13-31-52.gh-issue-148286.-qu-em.rst
@@ -1,0 +1,3 @@
+Fix undefined behavior in
+:attr:`compression.zstd.ZstdDecompressor.unused_data` when a complete frame
+was decompressed in a single call.

--- a/Modules/_zstd/decompressor.c
+++ b/Modules/_zstd/decompressor.c
@@ -594,9 +594,14 @@ _zstd_ZstdDecompressor_unused_data_get_impl(ZstdDecompressor *self)
     }
     else {
         if (self->unused_data == NULL) {
-            self->unused_data = PyBytes_FromStringAndSize(
-                                    self->input_buffer + self->in_begin,
-                                    self->in_end - self->in_begin);
+            if (self->input_buffer == NULL) {
+                self->unused_data = Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
+            }
+            else {
+                self->unused_data = PyBytes_FromStringAndSize(
+                                        self->input_buffer + self->in_begin,
+                                        self->in_end - self->in_begin);
+            }
             ret = self->unused_data;
             Py_XINCREF(ret);
         }


### PR DESCRIPTION
(cherry picked from commit adebb68153346043c0671fa5725d269c32cc40e4)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-148286 -->
* Issue: gh-148286
<!-- /gh-issue-number -->
