### PR TITLE
gh-153664: Fix reference leaks in cross-interpreter NotShareableError handling

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-13-23-59-45.gh-issue-153664.MQYdit.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-13-23-59-45.gh-issue-153664.MQYdit.rst
@@ -1,0 +1,2 @@
+Fix potential reference leaks in cross-interpreter ``NotShareableError``
+error handling.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-13-23-59-45.gh-issue-153664.MQYdit.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-13-23-59-45.gh-issue-153664.MQYdit.rst
@@ -1,2 +1,2 @@
-Fix potential reference leaks in cross-interpreter ``NotShareableError``
-error handling.
+Fix potential use-after-free and reference leaks in cross-interpreter
+``NotShareableError`` error handling.

--- a/Python/crossinterp_data_lookup.h
+++ b/Python/crossinterp_data_lookup.h
@@ -100,6 +100,7 @@ _PyXI_UnwrapNotShareableError(PyThreadState * tstate, _PyXI_failure *failure)
     if (failure != NULL) {
         _PyXI_errcode code = _PyXI_ERR_NOT_SHAREABLE;
         if (_PyXI_InitFailure(failure, code, exc) < 0) {
+            Py_DECREF(exc);
             return -1;
         }
     }

--- a/Python/crossinterp_exceptions.h
+++ b/Python/crossinterp_exceptions.h
@@ -83,6 +83,7 @@ _ensure_notshareableerror(PyThreadState *tstate,
             // A NotShareableError instance is already set.
             assert(cause == NULL);
             _PyErr_SetRaisedException(tstate, ctx);
+            return;
         }
     }
     else {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-153664 -->
* Issue: gh-153664
<!-- /gh-issue-number -->
