### PR TITLE
gh-153662: Fix crash when calling `io.TextIOWrapper.seek()` with malformed cookie

### DIFF
--- a/Lib/test/test_io/test_textio.py
+++ b/Lib/test/test_io/test_textio.py
@@ -1430,13 +1430,23 @@ class TextIOWrapperTest:
         data = b"1"
         raw = io.BytesIO(data)
         buf = io.BufferedReader(raw)
-        tio = io.TextIOWrapper(buf, encoding='utf_8')
+        tio = io.TextIOWrapper(buf, encoding='utf-8')
         # Set 'cookie.chars_to_skip' to INT_MIN
         COOKIE_VALUE = (100 << (12 * 8)) | (0x80 << (19 * 8))
         tio.read()
-        with self.assertRaises(OSError) as err:
+        with self.assertRaisesRegex(OSError, "can't restore logical file position"):
             tio.seek(COOKIE_VALUE)
-        self.assertEqual(str(err.exception), "can't restore logical file position")
+
+    def test_seek_reject_int_max_chars_to_skip(self):
+        data = b"1"
+        raw = io.BytesIO(data)
+        buf = io.BufferedReader(raw)
+        tio = io.TextIOWrapper(buf, encoding='utf-8')
+        # Set 'cookie.chars_to_skip' to INT_MAX
+        COOKIE_VALUE = (100 << (12 * 8)) | (0x7FFFFFFF << (16 * 8))
+        tio.read()
+        with self.assertRaisesRegex(OSError, "can't restore logical file position"):
+            tio.seek(COOKIE_VALUE)
 
 
 class MemviewBytesIO(io.BytesIO):

--- a/Lib/test/test_io/test_textio.py
+++ b/Lib/test/test_io/test_textio.py
@@ -1425,6 +1425,16 @@ class TextIOWrapperTest:
                 os.close(r)
             os.close(w)
 
+    def test_seek_reject_negative_chars_to_skip(self):
+        data = b"1"
+        raw = io.BytesIO(data)
+        buf = io.BufferedReader(raw)
+        tio = io.TextIOWrapper(buf, encoding='utf_8')
+        # Set 'cookie.chars_to_skip' to INT_MIN
+        COOKIE_VALUE = (100 << (12 * 8)) | (0x80 << (19 * 8))
+        tio.read()
+        with self.assertRaises(OSError):
+            tio.seek(COOKIE_VALUE)
 
 class MemviewBytesIO(io.BytesIO):
     '''A BytesIO object whose read method returns memoryviews

--- a/Lib/test/test_io/test_textio.py
+++ b/Lib/test/test_io/test_textio.py
@@ -1426,6 +1426,7 @@ class TextIOWrapperTest:
             os.close(w)
 
     def test_seek_reject_negative_chars_to_skip(self):
+        # See https://github.com/python/cpython/issues/153662
         data = b"1"
         raw = io.BytesIO(data)
         buf = io.BufferedReader(raw)
@@ -1433,8 +1434,10 @@ class TextIOWrapperTest:
         # Set 'cookie.chars_to_skip' to INT_MIN
         COOKIE_VALUE = (100 << (12 * 8)) | (0x80 << (19 * 8))
         tio.read()
-        with self.assertRaises(OSError):
+        with self.assertRaises(OSError) as err:
             tio.seek(COOKIE_VALUE)
+        self.assertEqual(str(err.exception), "can't restore logical file position")
+
 
 class MemviewBytesIO(io.BytesIO):
     '''A BytesIO object whose read method returns memoryviews

--- a/Lib/test/test_io/test_textio.py
+++ b/Lib/test/test_io/test_textio.py
@@ -1425,28 +1425,21 @@ class TextIOWrapperTest:
                 os.close(r)
             os.close(w)
 
-    def test_seek_reject_negative_chars_to_skip(self):
+    @support.subTests('cookie_value', [
+        # Set 'cookie.chars_to_skip' to INT_MIN
+        (100 << (12 * 8)) | (0x80 << (19 * 8)),
+        # Set 'cookie.chars_to_skip' to INT_MAX
+        (100 << (12 * 8)) | (0x7FFFFFFF << (16 * 8))
+    ])
+    def test_seek_reject_invalid_chars_to_skip(self, cookie_value):
         # See https://github.com/python/cpython/issues/153662
         data = b"1"
         raw = io.BytesIO(data)
         buf = io.BufferedReader(raw)
         tio = io.TextIOWrapper(buf, encoding='utf-8')
-        # Set 'cookie.chars_to_skip' to INT_MIN
-        COOKIE_VALUE = (100 << (12 * 8)) | (0x80 << (19 * 8))
         tio.read()
         with self.assertRaisesRegex(OSError, "can't restore logical file position"):
-            tio.seek(COOKIE_VALUE)
-
-    def test_seek_reject_int_max_chars_to_skip(self):
-        data = b"1"
-        raw = io.BytesIO(data)
-        buf = io.BufferedReader(raw)
-        tio = io.TextIOWrapper(buf, encoding='utf-8')
-        # Set 'cookie.chars_to_skip' to INT_MAX
-        COOKIE_VALUE = (100 << (12 * 8)) | (0x7FFFFFFF << (16 * 8))
-        tio.read()
-        with self.assertRaisesRegex(OSError, "can't restore logical file position"):
-            tio.seek(COOKIE_VALUE)
+            tio.seek(cookie_value)
 
 
 class MemviewBytesIO(io.BytesIO):

--- a/Misc/NEWS.d/next/Library/2026-07-13-23-47-14.gh-issue-153662.ei9ya3.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-13-23-47-14.gh-issue-153662.ei9ya3.rst
@@ -1,0 +1,1 @@
+:class:`io.TextIOWrapper`: Fix a rare crash when calling ``seek()`` with a malformed cookie.

--- a/Misc/NEWS.d/next/Library/2026-07-13-23-47-14.gh-issue-153662.ei9ya3.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-13-23-47-14.gh-issue-153662.ei9ya3.rst
@@ -1,1 +1,1 @@
-:class:`io.TextIOWrapper`: Fix a rare crash when calling ``seek()`` with a malformed cookie.
+Fix a crash when calling :meth:`io.TextIOWrapper.seek` with a malformed cookie.

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -2933,7 +2933,13 @@ _io_TextIOWrapper_tell_impl(textio *self)
 
     /* Fast search for an acceptable start point, close to our
        current pos */
-    skip_bytes = (Py_ssize_t) (self->b2cratio * chars_to_skip);
+    double skip_bytes_d = self->b2cratio * (double) chars_to_skip;
+    if (!(skip_bytes_d >= 0) || skip_bytes_d >= (double) PY_SSIZE_T_MAX) {
+        PyErr_SetString(PyExc_OverflowError,
+                        "chars_to_skip are too large");
+        goto fail;
+    }
+    skip_bytes = (Py_ssize_t) skip_bytes_d;
     skip_back = 1;
     assert(skip_bytes <= PyBytes_GET_SIZE(next_input));
     input = PyBytes_AS_STRING(next_input);

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -2781,7 +2781,8 @@ _io_TextIOWrapper_seek_impl(textio *self, PyObject *cookieObj, int whence)
         textiowrapper_set_decoded_chars(self, decoded);
 
         /* Skip chars_to_skip of the decoded characters. */
-        if (PyUnicode_GetLength(self->decoded_chars) < cookie.chars_to_skip) {
+        /* gh-153662: Reject negative chars_to_skip*/
+        if (cookie.chars_to_skip < 0 || PyUnicode_GetLength(self->decoded_chars) < cookie.chars_to_skip) {
             PyErr_SetString(PyExc_OSError, "can't restore logical file position");
             goto fail;
         }

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -2781,7 +2781,7 @@ _io_TextIOWrapper_seek_impl(textio *self, PyObject *cookieObj, int whence)
         textiowrapper_set_decoded_chars(self, decoded);
 
         /* Skip chars_to_skip of the decoded characters. */
-        /* gh-153662: Reject negative chars_to_skip*/
+        /* gh-153662: Reject negative chars_to_skip */
         if (cookie.chars_to_skip < 0 || PyUnicode_GetLength(self->decoded_chars) < cookie.chars_to_skip) {
             PyErr_SetString(PyExc_OSError, "can't restore logical file position");
             goto fail;


### PR DESCRIPTION


<!-- gh-issue-number: gh-153662 -->
* Issue: gh-153662
<!-- /gh-issue-number -->
