### PR TITLE
gh-153668: Temporarily disable unicodectype.c optimization on WinARM64 due to compiler bug

### DIFF
--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -40,6 +40,8 @@
     <!-- See https://developercommunity.visualstudio.com/t/Regression-in-MSVC-1433-1434-ARM64-co/10224361 -->
     <MSVCHasBrokenARM64Clamping Condition="$(_VCToolsVersion) == '14.34' or $(_VCToolsVersion) == '14.35'">true</MSVCHasBrokenARM64Clamping>
     <MSVCHasBrokenARM64SignExtension Condition="$(_VCToolsVersion) == '14.37'">true</MSVCHasBrokenARM64SignExtension>
+    <!-- See gh-153668 and https://developercommunity.visualstudio.com/t/ARM64-compiler-uses-excessive-memory-on/11120089 -->
+    <MSVCHasBrokenARM64UniDbOpt Condition="$(_VCToolsVersion) == '14.51'">true</MSVCHasBrokenARM64UniDbOpt>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -576,7 +576,10 @@
     <ClCompile Include="..\Objects\typeobject.c" />
     <ClCompile Include="..\Objects\typevarobject.c" />
     <ClCompile Include="..\Objects\unicode_format.c" />
-    <ClCompile Include="..\Objects\unicodectype.c" />
+    <ClCompile Include="..\Objects\unicodectype.c">
+      <!-- gh-153668: Temporarily disabled due to a compiler bug -->
+      <Optimization Condition="$(Platform) == 'ARM64' and $(MSVCHasBrokenARM64UniDbOpt) == 'true'">Disabled</Optimization>
+    </ClCompile>
     <ClCompile Include="..\Objects\unicode_formatter.c" />
     <ClCompile Include="..\Objects\unicode_writer.c" />
     <ClCompile Include="..\Objects\unicodeobject.c" />

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -578,7 +578,7 @@
     <ClCompile Include="..\Objects\unicode_format.c" />
     <ClCompile Include="..\Objects\unicodectype.c">
       <!-- gh-153668: Temporarily disabled due to a compiler bug -->
-      <Optimization Condition="$(Platform) == 'ARM64' and $(MSVCHasBrokenARM64UniDbOpt) == 'true'">Disabled</Optimization>
+      <Optimization Condition="$(Platform) == 'ARM64' and $(Configuration) == 'Release' and $(MSVCHasBrokenARM64UniDbOpt) == 'true'">Disabled</Optimization>
     </ClCompile>
     <ClCompile Include="..\Objects\unicode_formatter.c" />
     <ClCompile Include="..\Objects\unicode_writer.c" />


### PR DESCRIPTION


<!-- gh-issue-number: gh-153668 -->
* Issue: gh-153668
<!-- /gh-issue-number -->
