### PR TITLE
gh-152216: Silence expat compiler warnings

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1449,7 +1449,7 @@ Modules/expat/xmlrole.o: $(srcdir)/Modules/expat/xmlrole.c $(LIBEXPAT_HEADERS) $
 	$(CC) -c $(LIBEXPAT_CFLAGS) -o $@ $(srcdir)/Modules/expat/xmlrole.c
 
 Modules/expat/xmltok.o: $(srcdir)/Modules/expat/xmltok.c $(LIBEXPAT_HEADERS) $(PYTHON_HEADERS)
-	$(CC) -c $(LIBEXPAT_CFLAGS) -o $@ $(srcdir)/Modules/expat/xmltok.c
+	$(CC) -Wno-unreachable-code-fallthrough -c $(LIBEXPAT_CFLAGS) -o $@ $(srcdir)/Modules/expat/xmltok.c
 
 $(LIBEXPAT_A): $(LIBEXPAT_OBJS)
 	-rm -f $@


### PR DESCRIPTION
Silence expat compiler warnings on macOS with clang.

```c
In file included from ./Modules/expat/xmltok.c:309:
./Modules/expat/xmltok_impl.c:283:5: warning: fallthrough annotation in unreachable code [-Wunreachable-code-fallthrough]
  283 |     CHECK_NMSTRT_CASES(enc, ptr, end, nextTokPtr)
      |     ^
./Modules/expat/xmltok_impl.c:116:5: note: expanded from macro 'CHECK_NMSTRT_CASES'
  116 |     EXPAT_FALLTHROUGH;                                                         \
      |     ^
./Modules/expat/fallthrough.h:45:33: note: expanded from macro 'EXPAT_FALLTHROUGH'
   45 | #      define EXPAT_FALLTHROUGH __attribute__((fallthrough))
      |                                 ^
...
```

<!-- gh-issue-number: gh-152216 -->
* Issue: gh-152216
<!-- /gh-issue-number -->
