### PR TITLE
gh-139497: Clarify dataclass inheritance documentation

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -194,6 +194,9 @@ Module contents
      glossary entry for details.  Also see the
      :const:`KW_ONLY` section.
 
+     This setting only applies to fields defined in the class being decorated;
+     it does not affect inherited fields.
+
      Keyword-only fields are not included in :attr:`!__match_args__`.
 
     .. versionadded:: 3.10
@@ -681,6 +684,16 @@ must use :meth:`!object.__setattr__`.
 
 Inheritance
 -----------
+
+The :deco:`dataclass` decorator is not automatically applied to subclasses.
+If a subclass is not itself decorated, no new dataclass fields are collected
+and no dataclass methods are generated for it.  Instead, it inherits fields and
+methods through the normal method resolution order.  This can be significant
+with multiple dataclass bases because their fields are not combined.  Decorate
+the subclass to combine the fields of its dataclass bases as described below.
+Nevertheless, :func:`is_dataclass` considers an undecorated subclass of a
+dataclass to be a dataclass because it inherits dataclass metadata from a base
+class.
 
 When the dataclass is being created by the :deco:`dataclass` decorator,
 it looks through all of the class's base classes in reverse MRO (that


### PR DESCRIPTION
## Summary

Clarify that the `@dataclass` decorator is not automatically applied to
subclasses. Undecorated subclasses inherit dataclass fields and generated
methods through the normal MRO, so fields from multiple dataclass bases are not
combined unless the subclass is itself decorated.

Also clarify that `kw_only=True` applies only to fields defined by the class
being decorated and does not change inherited fields.

The existing reverse-MRO description already covers decorated subclasses, and
the inherited default-ordering error remains documented with the decorator, so
this change avoids duplicating those rules in the inheritance section.

I used Codex to help investigate the behavior and draft the wording. I reviewed and validated the change myself.

Closes #139497.

## Validation

- `make -C Doc check`
- `make -C Doc html` (Sphinx `--fail-on-warning`)
- Focused runtime proof on current `main` covering decorated and undecorated
  multiple inheritance, redecorated subclasses, and inherited fields under
  `kw_only=True`
