### PR TITLE
[3.14] gh-153631: Move to `macos-26` runner for iOS (GH-153632)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -387,23 +387,14 @@ jobs:
     needs: build-context
     if: needs.build-context.outputs.run-ios == 'true'
     timeout-minutes: 60
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      # GitHub recommends explicitly selecting the desired Xcode version:
-      # https://github.com/actions/runner-images/issues/12541#issuecomment-3083850140
-      # This became a necessity as a result of
-      # https://github.com/actions/runner-images/issues/12541 and
-      # https://github.com/actions/runner-images/issues/12751.
-      - name: Select Xcode version
-        run: |
-          sudo xcode-select --switch /Applications/Xcode_15.4.app
-
       - name: Build and test
-        run: python3 Apple ci iOS --fast-ci --simulator 'iPhone SE (3rd generation),OS=17.5'
+        run: python3 Apple ci iOS --fast-ci
 
   build-emscripten:
     name: 'Emscripten'

--- a/Apple/testbed/__main__.py
+++ b/Apple/testbed/__main__.py
@@ -271,8 +271,14 @@ def run_testbed(
     update_test_plan(location, platform, args)
     print(" done.")
 
+    # xcodebuild doesn't guarantee that the CoreSimulatorService daemon is
+    # running prior to using a simulator, but calling `xcrun simctl list` does.
+    # Determining the default simulator that *would* be used is a cheap action;
+    # so use that as a way to ensure that the CoreSimulatorService daemon is
+    # running.
+    default_simulator = select_simulator_device(platform)
     if simulator is None:
-        simulator = select_simulator_device(platform)
+        simulator = default_simulator
     print(f"Running test on {simulator}")
 
     xcode_test(


### PR DESCRIPTION
Switches iOS CI to use the macos-26 runner, and makes a small change to the iOS build script to improve build stability. xcodebuild doesn't guarantee that the CoreSimulatorService is running before starting a simulator. If the service isn't running, xcodebuild reports that no simulators are available, and fails to start the test app. However, simctl blocks until the simulator is available, and simctl is used to evaluate the default simulator. So - the iOS build script now unconditionally determines the default simulator, even if a specific simulator is requested.
(cherry picked from commit 2dc1a91af801ea896e21f6c6e6cc41f57e8268d9)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-153631 -->
* Issue: gh-153631
<!-- /gh-issue-number -->
