### PR TITLE
[3.13] gh-153631: Ensure iOS simulator is running before starting build (GH-153632)

### DIFF
--- a/iOS/testbed/__main__.py
+++ b/iOS/testbed/__main__.py
@@ -220,8 +220,14 @@ def run_testbed(simulator: str | None, args: list[str], verbose: bool = False):
     update_test_plan(location, args)
     print(" done.")
 
+    # xcodebuild doesn't guarantee that the CoreSimulatorService daemon is
+    # running prior to using a simulator, but calling `xcrun simctl list` does.
+    # Determining the default simulator that *would* be used is a cheap action;
+    # so use that as a way to ensure that the CoreSimulatorService daemon is
+    # running.
+    default_simulator = select_simulator_device()
     if simulator is None:
-        simulator = select_simulator_device()
+        simulator = default_simulator
     print(f"Running test on {simulator}")
 
     xcode_test(location, simulator=simulator, verbose=verbose)


### PR DESCRIPTION
Makes a small change to the iOS build script to improve build stability. xcodebuild doesn't guarantee that the CoreSimulatorService is running before starting a simulator. If the service isn't running, xcodebuild reports that no simulators are available, and fails to start the test app. However, simctl blocks until the simulator is available, and simctl is used to evaluate the default simulator. So - the iOS build script now unconditionally determines the default simulator, even if a specific simulator is requested. 
(cherry picked from commit 2dc1a91af801ea896e21f6c6e6cc41f57e8268d9)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-153631 -->
* Issue: gh-153631
<!-- /gh-issue-number -->
