### PR TITLE
gh-153677: Fix ValueError in http.cookiejar.http2time() for a strict-format fake month

### DIFF
--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -262,10 +262,16 @@ def http2time(text):
     m = STRICT_DATE_RE.search(text)
     if m:
         g = m.groups()
-        mon = MONTHS_LOWER.index(g[1].lower()) + 1
-        tt = (int(g[2]), mon, int(g[0]),
-              int(g[3]), int(g[4]), float(g[5]))
-        return _timegm(tt)
+        try:
+            mon = MONTHS_LOWER.index(g[1].lower()) + 1
+        except ValueError:
+            # The month field matched the pattern but is not a real month
+            # name, so fall through to the slower parser.
+            pass
+        else:
+            tt = (int(g[2]), mon, int(g[0]),
+                  int(g[3]), int(g[4]), float(g[5]))
+            return _timegm(tt)
 
     # No, we need some messy parsing...
 

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -265,8 +265,7 @@ def http2time(text):
         try:
             mon = MONTHS_LOWER.index(g[1].lower()) + 1
         except ValueError:
-            # The month field matched the pattern but is not a real month
-            # name, so fall through to the slower parser.
+            # Not a real month name; fall through to the slower parser.
             pass
         else:
             tt = (int(g[2]), mon, int(g[0]),

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -121,6 +121,11 @@ class DateTimeTests(unittest.TestCase):
             '08-01-3697739',
             '09 Feb 19942632 22:23:32 GMT',
             'Wed, 09 Feb 1994834 22:23:32 GMT',
+            # Strictly formatted string with a non-existent month name.  The
+            # month field matches the STRICT_DATE_RE fast path but is not a
+            # real month, and must not leak a ValueError.
+            'Wed, 09 Foo 1994 22:23:32 GMT',
+            'Mon, 01 Aaa 2000 00:00:00 GMT',
         ])
     def test_http2time_garbage(self, test):
         self.assertIsNone(http2time(test))

--- a/Misc/NEWS.d/next/Library/2026-07-13-10-30-00.gh-issue-153677.dIxjOG.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-13-10-30-00.gh-issue-153677.dIxjOG.rst
@@ -1,0 +1,3 @@
+:func:`!http.cookiejar.http2time` now returns ``None`` instead of raising
+:exc:`ValueError` when the date string matches its strict fast-path pattern
+but names a month that does not exist. Patch by tonghuaroot.

--- a/Misc/NEWS.d/next/Library/2026-07-13-10-30-00.gh-issue-153677.dIxjOG.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-13-10-30-00.gh-issue-153677.dIxjOG.rst
@@ -1,3 +1,3 @@
 :func:`!http.cookiejar.http2time` now returns ``None`` instead of raising
-:exc:`ValueError` when the date string matches its strict fast-path pattern
-but names a month that does not exist. Patch by tonghuaroot.
+:exc:`ValueError` for a strictly-formatted date with a non-existent month
+name. Patch by tonghuaroot.


### PR DESCRIPTION
`http2time()` documents that it returns `None` for an unrecognized date
format, but the `STRICT_DATE_RE` fast path raised a raw `ValueError` when
the month field matched the pattern but named a non-existent month (for
example `Foo`), because `MONTHS_LOWER.index()` was called unguarded. The
slower parser already returns `None` for the same input.

Guard the fast-path month lookup and fall through to the slower parser on
failure; valid months are unaffected. This restores the "returns `None`,
never raises" contract established by gh-60385 for a different code path.


<!-- gh-issue-number: gh-153677 -->
* Issue: gh-153677
<!-- /gh-issue-number -->
