### PR TITLE
gh-153679: Raise ZipImportError for an invalid UTF-8 file name in zipimport

### DIFF
--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -1088,7 +1088,9 @@ class BadFileZipImportTestCase(unittest.TestCase):
         os_helper.unlink(TESTMOD)
         with open(TESTMOD, 'wb') as fp:
             fp.write(cdh + eocd)
-        self.assertZipFailure(TESTMOD)
+        with self.assertRaises(zipimport.ZipImportError) as cm:
+            zipimport.zipimporter(TESTMOD)
+        self.assertIsInstance(cm.exception.__cause__, UnicodeDecodeError)
 
     # XXX: disabled until this works on Big-endian machines
     def _testBogusZipFile(self):

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -1074,6 +1074,24 @@ class BadFileZipImportTestCase(unittest.TestCase):
         fp.close()
         self.assertZipFailure(TESTMOD)
 
+    def testInvalidUTF8FileName(self):
+        # A central directory entry that sets the UTF-8 file name flag (0x800)
+        # but stores bytes that are not valid UTF-8 must raise ZipImportError
+        # rather than leaking a UnicodeDecodeError.
+        UTF8_FLAG = 0x800
+        name = b'\xff\xfe\xff'
+        cdh = b'PK\x01\x02' + struct.pack(
+            '<HHHHHHIIIHHHHHII',
+            20, 20, UTF8_FLAG, 0, 0, 0, 0, 50, 100,
+            len(name), 0, 0, 0, 0, 0, 0)
+        cdh += name
+        eocd = b'PK\x05\x06' + struct.pack(
+            '<HHHHIIH', 0, 0, 1, 1, len(cdh), 0, 0)
+        os_helper.unlink(TESTMOD)
+        with open(TESTMOD, 'wb') as fp:
+            fp.write(cdh + eocd)
+        self.assertZipFailure(TESTMOD)
+
     # XXX: disabled until this works on Big-endian machines
     def _testBogusZipFile(self):
         os_helper.unlink(TESTMOD)

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -1075,9 +1075,7 @@ class BadFileZipImportTestCase(unittest.TestCase):
         self.assertZipFailure(TESTMOD)
 
     def testInvalidUTF8FileName(self):
-        # A central directory entry that sets the UTF-8 file name flag (0x800)
-        # but stores bytes that are not valid UTF-8 must raise ZipImportError
-        # rather than leaking a UnicodeDecodeError.
+        # A UTF-8-flagged file name that is not valid UTF-8 raises ZipImportError.
         UTF8_FLAG = 0x800
         name = b'\xff\xfe\xff'
         cdh = b'PK\x01\x02' + struct.pack(

--- a/Lib/zipimport.py
+++ b/Lib/zipimport.py
@@ -427,7 +427,12 @@ def _read_directory(archive):
 
                 if flags & 0x800:
                     # UTF-8 file names extension
-                    name = name.decode()
+                    try:
+                        name = name.decode()
+                    except UnicodeDecodeError:
+                        raise ZipImportError(
+                            f"can't decode file name in Zip file: {archive!r}",
+                            path=archive)
                 else:
                     # Historical ZIP filename encoding
                     try:

--- a/Lib/zipimport.py
+++ b/Lib/zipimport.py
@@ -429,10 +429,10 @@ def _read_directory(archive):
                     # UTF-8 file names extension
                     try:
                         name = name.decode()
-                    except UnicodeDecodeError:
+                    except UnicodeDecodeError as exc:
                         raise ZipImportError(
                             f"can't decode file name in Zip file: {archive!r}",
-                            path=archive)
+                            path=archive) from exc
                 else:
                     # Historical ZIP filename encoding
                     try:

--- a/Misc/NEWS.d/next/Library/2026-07-13-00-10-00.gh-issue-153679.RJ2WGB.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-13-00-10-00.gh-issue-153679.RJ2WGB.rst
@@ -1,4 +1,3 @@
 :class:`zipimport.zipimporter` now raises :exc:`zipimport.ZipImportError`
-instead of :exc:`UnicodeDecodeError` when a central directory entry sets the
-UTF-8 file name flag but stores a file name that is not valid UTF-8.
-Patch by tonghuaroot.
+instead of :exc:`UnicodeDecodeError` for a UTF-8-flagged file name that is not
+valid UTF-8. Patch by tonghuaroot.

--- a/Misc/NEWS.d/next/Library/2026-07-13-00-10-00.gh-issue-153679.RJ2WGB.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-13-00-10-00.gh-issue-153679.RJ2WGB.rst
@@ -1,0 +1,4 @@
+:class:`zipimport.zipimporter` now raises :exc:`zipimport.ZipImportError`
+instead of :exc:`UnicodeDecodeError` when a central directory entry sets the
+UTF-8 file name flag but stores a file name that is not valid UTF-8.
+Patch by tonghuaroot.


### PR DESCRIPTION
`zipimport.zipimporter()` is documented to raise `ZipImportError` for an
invalid archive, but `_read_directory()` leaked a raw `UnicodeDecodeError`
when a central directory entry set the UTF-8 file name flag (`0x800`) but
stored bytes that are not valid UTF-8: the UTF-8 branch called `name.decode()`
unguarded, while the sibling non-UTF-8 branch already handles
`UnicodeDecodeError`.

Guard the UTF-8 decode and raise `ZipImportError`, matching the documented
contract and every other corruption path in the function.


<!-- gh-issue-number: gh-153679 -->
* Issue: gh-153679
<!-- /gh-issue-number -->
