### PR TITLE
gh-153692: Raise wave.Error for a truncated fmt chunk in wave.open

### DIFF
--- a/Lib/test/test_wave.py
+++ b/Lib/test/test_wave.py
@@ -333,6 +333,13 @@ class WaveLowLevelTest(unittest.TestCase):
         with self.assertRaisesRegex(wave.Error, 'bad sample width'):
             wave.open(io.BytesIO(b))
 
+    def test_read_truncated_fmt_chunk(self):
+        b = b'RIFF' + struct.pack('<L', 24) + b'WAVE'
+        b += b'fmt ' + struct.pack('<L', 16)
+        b += struct.pack('<HHLLH', 1, 1, 11025, 11025, 1)
+        with self.assertRaisesRegex(wave.Error, 'fmt chunk is truncated'):
+            wave.open(io.BytesIO(b))
+
     def test_open_in_write_raises(self):
         # gh-136523: Wave_write.__del__ should not throw
         with support.catch_unraisable_exception() as cm:

--- a/Lib/wave.py
+++ b/Lib/wave.py
@@ -278,7 +278,10 @@ class Wave_read:
                 break
             chunkname = chunk.getname()
             if chunkname == b'fmt ':
-                self._read_fmt_chunk(chunk)
+                try:
+                    self._read_fmt_chunk(chunk)
+                except EOFError:
+                    raise Error('fmt chunk is truncated') from None
                 self._fmt_chunk_read = 1
             elif chunkname == b'data':
                 if not self._fmt_chunk_read:

--- a/Misc/NEWS.d/next/Library/2026-07-13-10-43-04.gh-issue-153692.ouFZC9.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-13-10-43-04.gh-issue-153692.ouFZC9.rst
@@ -1,0 +1,2 @@
+:func:`wave.open` now raises :exc:`wave.Error` instead of :exc:`EOFError` when
+the ``fmt `` chunk of a WAV file is truncated.  Patch by tonghuaroot.

--- a/Misc/NEWS.d/next/Library/2026-07-13-10-43-04.gh-issue-153692.ouFZC9.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-13-10-43-04.gh-issue-153692.ouFZC9.rst
@@ -1,2 +1,2 @@
 :func:`wave.open` now raises :exc:`wave.Error` instead of :exc:`EOFError` when
-the ``fmt `` chunk of a WAV file is truncated.  Patch by tonghuaroot.
+the ``fmt`` chunk of a WAV file is truncated. Patch by tonghuaroot.


### PR DESCRIPTION
`wave.open(f, 'rb')` is documented to raise `wave.Error` for a file that
violates the WAV format, but `Wave_read.initfp()` let the `EOFError` raised by
`_read_fmt_chunk()` on a truncated `fmt ` chunk escape raw. Wrap that call so a
truncated fmt chunk raises `wave.Error`, matching every other malformed-input
path in the module.


<!-- gh-issue-number: gh-153692 -->
* Issue: gh-153692
<!-- /gh-issue-number -->
