### PR TITLE
gh-153695: Fix sqlite3.Row.__hash__ with an unhashable value

### DIFF
--- a/Lib/test/test_sqlite3/test_factory.py
+++ b/Lib/test/test_sqlite3/test_factory.py
@@ -239,6 +239,17 @@ class RowFactoryTests(MemoryDatabaseMixin, unittest.TestCase):
 
         self.assertEqual(hash(row_1), hash(row_2))
 
+    def test_sqlite_row_hash_unhashable(self):
+        # An unhashable value must raise TypeError, not SystemError.
+        sqlite.register_converter("LST", lambda b: [1, 2, 3])
+        self.addCleanup(sqlite.converters.pop, "LST", None)
+        with memory_database(detect_types=sqlite.PARSE_DECLTYPES) as con:
+            con.row_factory = sqlite.Row
+            con.execute("create table t(x LST)")
+            con.execute("insert into t values(?)", (b"x",))
+            row = con.execute("select x from t").fetchone()
+            self.assertRaisesRegex(TypeError, "unhashable", hash, row)
+
     def test_sqlite_row_as_sequence(self):
         # Checks if the row object can act like a sequence.
         row = self.con.execute("select 1 as a, 2 as b").fetchone()

--- a/Misc/NEWS.d/next/Library/2026-07-14-19-45-21.gh-issue-153695.UYdZJZ.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-14-19-45-21.gh-issue-153695.UYdZJZ.rst
@@ -1,0 +1,2 @@
+Hashing a :class:`sqlite3.Row` that contains an unhashable value now raises
+:exc:`TypeError` instead of :exc:`SystemError`. Patch by tonghuaroot.

--- a/Modules/_sqlite/row.c
+++ b/Modules/_sqlite/row.c
@@ -232,7 +232,15 @@ static Py_hash_t
 pysqlite_row_hash(PyObject *op)
 {
     pysqlite_Row *self = _pysqlite_Row_CAST(op);
-    return PyObject_Hash(self->description) ^ PyObject_Hash(self->data);
+    Py_hash_t hash_description = PyObject_Hash(self->description);
+    if (hash_description == -1) {
+        return -1;
+    }
+    Py_hash_t hash_data = PyObject_Hash(self->data);
+    if (hash_data == -1) {
+        return -1;
+    }
+    return hash_description ^ hash_data;
 }
 
 static PyObject *


### PR DESCRIPTION
`sqlite3.Row.__hash__` did not check the `-1` error return of `PyObject_Hash`,
so hashing a row that holds an unhashable value raised `SystemError` instead of
`TypeError`. Check each hash and propagate the exception.


<!-- gh-issue-number: gh-153695 -->
* Issue: gh-153695
<!-- /gh-issue-number -->
