### PR TITLE
gh-153128: Preserve once warnings across filter changes

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -242,6 +242,16 @@ class FilterTests(BaseTest):
                                     42)
             self.assertEqual(len(w), 0)
 
+    def test_once_after_filter_change(self):
+        with self.module.catch_warnings(record=True) as w:
+            self.module.resetwarnings()
+            message = "FilterTests.test_once_after_filter_change"
+            self.module.filterwarnings("once", message, UserWarning)
+            self.module.warn(message, UserWarning)
+            self.module.filterwarnings("ignore", "unrelated")
+            self.module.warn(message, UserWarning)
+            self.assertEqual(len(w), 1)
+
     def test_filter_module(self):
         MS_WINDOWS = (sys.platform == 'win32')
         with self.module.catch_warnings(record=True) as w:

--- a/Misc/NEWS.d/next/Library/2026-07-14-21-30-00.gh-issue-153128.Xm2QvA.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-14-21-30-00.gh-issue-153128.Xm2QvA.rst
@@ -1,0 +1,3 @@
+Fix the C implementation of :mod:`warnings` so the ``"once"`` action remains
+suppressed after unrelated warning filters are changed, matching the pure
+Python implementation.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -574,11 +574,34 @@ get_filter(PyInterpreterState *interp, PyObject *category,
 
 
 static int
-already_warned(PyInterpreterState *interp, PyObject *registry, PyObject *key,
-               int should_set)
+already_warned_in_registry(PyObject *registry, PyObject *key, int should_set)
 {
     PyObject *already_warned;
 
+    if (key == NULL)
+        return -1;
+
+    if (PyDict_GetItemRef(registry, key, &already_warned) < 0) {
+        return -1;
+    }
+    if (already_warned != NULL) {
+        int rc = PyObject_IsTrue(already_warned);
+        Py_DECREF(already_warned);
+        if (rc != 0)
+            return rc;
+    }
+
+    /* This warning wasn't found in the registry, set it. */
+    if (should_set)
+        return PyDict_SetItem(registry, key, Py_True);
+    return 0;
+}
+
+
+static int
+already_warned(PyInterpreterState *interp, PyObject *registry, PyObject *key,
+               int should_set)
+{
     if (key == NULL)
         return -1;
 
@@ -607,22 +630,8 @@ already_warned(PyInterpreterState *interp, PyObject *registry, PyObject *key,
         }
         Py_DECREF(version_obj);
     }
-    else {
-        if (PyDict_GetItemRef(registry, key, &already_warned) < 0) {
-            return -1;
-        }
-        if (already_warned != NULL) {
-            int rc = PyObject_IsTrue(already_warned);
-            Py_DECREF(already_warned);
-            if (rc != 0)
-                return rc;
-        }
-    }
 
-    /* This warning wasn't found in the registry, set it. */
-    if (should_set)
-        return PyDict_SetItem(registry, key, Py_True);
-    return 0;
+    return already_warned_in_registry(registry, key, should_set);
 }
 
 static int
@@ -639,6 +648,22 @@ update_registry(PyInterpreterState *interp, PyObject *registry, PyObject *text,
 
     rc = already_warned(interp, registry, altkey, 1);
     Py_XDECREF(altkey);
+    return rc;
+}
+
+
+static int
+update_once_registry(PyInterpreterState *interp, PyObject *text,
+                     PyObject *category)
+{
+    PyObject *registry = get_once_registry(interp);
+    if (registry == NULL) {
+        return -1;
+    }
+
+    PyObject *key = _PyTuple_FromPair(text, category);
+    int rc = already_warned_in_registry(registry, key, 1);
+    Py_XDECREF(key);
     return rc;
 }
 
@@ -854,13 +879,8 @@ warn_explicit(PyThreadState *tstate, PyObject *category, PyObject *message,
         }
 
         if (_PyUnicode_EqualToASCIIString(action, "once")) {
-            if (registry == NULL || registry == Py_None) {
-                registry = get_once_registry(interp);
-                if (registry == NULL)
-                    goto cleanup;
-            }
             /* WarningsState.once_registry[(text, category)] = 1 */
-            rc = update_registry(interp, registry, text, category, 0);
+            rc = update_once_registry(interp, text, category);
         }
         else if (_PyUnicode_EqualToASCIIString(action, "module")) {
             /* registry[(text, category, 0)] = 1 */


### PR DESCRIPTION
## Summary

- keep the C implementation's `"once"` warning tracking in the global once registry
- make that registry independent of warning filter version changes, matching `_py_warnings`
- add a shared regression test for the C and pure Python implementations
- add a Library NEWS entry

The C implementation previously reused the per-module warning registry whenever one was available. That registry is deliberately cleared when the filter version changes, so adding even an unrelated filter caused a warning governed by `"once"` to be emitted again. The pure Python implementation stores the `(text, category)` key in `onceregistry`, which is not filter-versioned.

This change factors the key lookup/update logic from the versioned registry helper and uses it with the global once registry. `"default"` and `"module"` tracking remain versioned as before.

Fixes #153128.

## Tests

- `PCbuild/build.bat -p x64 -c Debug`
- `PCbuild/amd64/python_d.exe -m unittest -v test.test_warnings.CFilterTests.test_once_after_filter_change test.test_warnings.PyFilterTests.test_once_after_filter_change`
- `PCbuild/amd64/python_d.exe -m test -v test_warnings`
- `PCbuild/amd64/python_d.exe -X context_aware_warnings=1 -m test test_warnings`
- `PCbuild/amd64/python_d.exe -m test -R 3:3 test_warnings`
- `PCbuild/amd64/python_d.exe Tools/patchcheck/patchcheck.py`

## AI assistance

OpenAI Codex was used to assist with duplicate research, reproduction, root-cause analysis, the C implementation and regression test, and local verification. The code and this PR description were prepared with that assistance; this PR is submitted as a draft for review.

<!-- gh-issue-number: gh-153128 -->
* Issue: gh-153128
<!-- /gh-issue-number -->