### PR TITLE
gh-153313: Work around string decoding bug in emcc 6.0.2

### DIFF
--- a/configure
+++ b/configure
@@ -9802,6 +9802,7 @@ fi
     as_fn_append LINKFORSHARED " -sEXPORTED_FUNCTIONS=_main,_Py_Version,__PyRuntime,_PyGILState_GetThisThreadState,__PyEM_EMSCRIPTEN_TRAMPOLINE_OFFSET"
     as_fn_append LINKFORSHARED " -sSTACK_SIZE=5MB"
         as_fn_append LINKFORSHARED " -sTEXTDECODER=2"
+        as_fn_append LINKFORSHARED " -sGROWABLE_ARRAYBUFFERS=0"
 
     if test "x$enable_wasm_dynamic_linking" = xyes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -2410,6 +2410,8 @@ AS_CASE([$ac_sys_system],
     AS_VAR_APPEND([LINKFORSHARED], [" -sSTACK_SIZE=5MB"])
     dnl Avoid bugs in JS fallback string decoding path
     AS_VAR_APPEND([LINKFORSHARED], [" -sTEXTDECODER=2"])
+    dnl workaround for emscripten#27241, can remove when we update to emscripten 6.0.3
+    AS_VAR_APPEND([LINKFORSHARED], [" -sGROWABLE_ARRAYBUFFERS=0"])
 
     AS_VAR_IF([enable_wasm_dynamic_linking], [yes], [
       AS_VAR_APPEND([LINKFORSHARED], [" -sMAIN_MODULE"])


### PR DESCRIPTION
Resolves #153313. Can remove once we update to emcc 6.0.3. Upstream issue:
https://github.com/emscripten-core/emscripten/issues/27241

<!-- gh-issue-number: gh-153313 -->
* Issue: gh-153313
<!-- /gh-issue-number -->
