### PR TITLE
gh-153313: Run Emscripten PyRepl test in CI

### DIFF
--- a/.github/workflows/reusable-emscripten.yml
+++ b/.github/workflows/reusable-emscripten.yml
@@ -77,3 +77,5 @@ jobs:
       run: python3 Platforms/emscripten pythoninfo-host
     - name: "Test"
       run: python3 Platforms/emscripten run --test
+    - name: "Test Repl"
+      run: Platforms/emscripten/browser_test/run_test.sh

--- a/Platforms/emscripten/browser_test/package-lock.json
+++ b/Platforms/emscripten/browser_test/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@playwright/test": "^1.54.1",
+        "@playwright/test": "^1.61.1",
         "@types/node": "^24.12.0",
         "get-port-cli": "^3.0.0",
         "http-server": "^14.1.1",
-        "playwright": "^1.54.1"
+        "playwright": "^1.61.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -40,12 +40,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -892,12 +892,12 @@
       "license": "ISC"
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/Platforms/emscripten/browser_test/package.json
+++ b/Platforms/emscripten/browser_test/package.json
@@ -10,10 +10,10 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@playwright/test": "^1.54.1",
+    "@playwright/test": "^1.61.1",
     "@types/node": "^24.12.0",
     "get-port-cli": "^3.0.0",
     "http-server": "^14.1.1",
-    "playwright": "^1.54.1"
+    "playwright": "^1.61.1"
   }
 }

--- a/Platforms/emscripten/browser_test/run_test.sh
+++ b/Platforms/emscripten/browser_test/run_test.sh
@@ -2,10 +2,12 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 rm -f test_log.txt
-echo "Installing node packages" | tee test_log.txt
+echo "Installing node packages" | tee -a test_log.txt
 npm ci >> test_log.txt 2>&1
-echo "Installing playwright browsers" | tee test_log.txt
+echo "Installing playwright browsers" | tee -a test_log.txt
 npx playwright install 2>> test_log.txt
-export PORT=$(npx get-port-cli)
-echo "Running tests with webserver on port $PORT" | tee test_log.txt
-CI=1 npx playwright test | tee test_log.txt
+# Disable color so FORCE_COLOR=1 (set in CI) doesn't wrap the port number in
+# ANSI escape codes, which would produce an invalid baseURL in Playwright.
+export PORT=$(FORCE_COLOR=0 npx get-port-cli)
+echo "Running tests with webserver on port $PORT" | tee -a test_log.txt
+CI=1 npx playwright test | tee -a test_log.txt


### PR DESCRIPTION
To avoid having to rely on the buildbot for PyRepl test.

This adds only 30 seconds to execution time so it's definitely worth it.

<!-- gh-issue-number: gh-153313 -->
* Issue: gh-153313
<!-- /gh-issue-number -->
