### PR TITLE
gh-153702: Prevent writing improper extra fields to local file entry by `zipfile`

### DIFF
--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -1191,6 +1191,8 @@ class StoredTestZip64InSmallFiles(AbstractTestZip64InSmallFiles,
 
     def test_generated_extra_in_local_entry(self):
         """Should not write duplicated or improper fields to local file entry."""
+        comment = '\u4e00'.encode('utf-8')
+
         # zip64
         fh = io.BytesIO()
         with zipfile.ZipFile(fh, 'w') as zh:
@@ -1200,7 +1202,7 @@ class StoredTestZip64InSmallFiles(AbstractTestZip64InSmallFiles,
                 struct.pack('<HHQQ', 0x0001, 16, 0, 0) +
                 # unicode comment
                 struct.pack('<HHBL5s', 0x6375, 10, 1,
-                            zipfile.crc32(b'\u4e00'), b'\u4e00') +
+                            zipfile.crc32(comment), comment) +
                 # invalid tail
                 b'zzz'
             )
@@ -1224,7 +1226,7 @@ class StoredTestZip64InSmallFiles(AbstractTestZip64InSmallFiles,
                 struct.pack('<HHQQ', 0x0001, 16, 0, 0) +
                 # unicode comment
                 struct.pack('<HHBL5s', 0x6375, 10, 1,
-                            zipfile.crc32(b'\u4e00'), b'\u4e00') +
+                            zipfile.crc32(comment), comment) +
                 # invalid tail
                 b'zzz'
             )

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -1189,6 +1189,53 @@ class StoredTestZip64InSmallFiles(AbstractTestZip64InSmallFiles,
                     self.assertEqual(zinfo.header_offset, expected_header_offset)
                     self.assertEqual(zf.read(zinfo), expected_content)
 
+    def test_generated_extra_in_local_entry(self):
+        """Should not write duplicated or improper fields to local file entry."""
+        # zip64
+        fh = io.BytesIO()
+        with zipfile.ZipFile(fh, 'w') as zh:
+            zinfo = zipfile.ZipInfo('strfile')
+            zinfo.extra = (
+                # zip64
+                struct.pack('<HHQQ', 0x0001, 16, 0, 0) +
+                # unicode comment
+                struct.pack('<HHBL5s', 0x6375, 10, 1,
+                            zipfile.crc32(b'\u4e00'), b'\u4e00') +
+                # invalid tail
+                b'zzz'
+            )
+            zh.writestr(zinfo, self.data)
+
+        fh.seek(zinfo.header_offset)
+        entry = fh.read(zh.start_dir - zinfo.header_offset - zinfo.compress_size)
+        header = struct.unpack_from(zipfile.structFileHeader, entry)
+        extra = entry[-header[zipfile._FH_EXTRA_FIELD_LENGTH]:]
+        self.assertEqual(extra, (
+            struct.pack('<HHQQ', 0x0001, 16, 25889, 25889) +
+            b'zzz'
+        ))
+
+        # no zip64
+        fh = io.BytesIO()
+        with zipfile.ZipFile(fh, 'w') as zh:
+            zinfo = zipfile.ZipInfo('strfile')
+            zinfo.extra = (
+                # zip64
+                struct.pack('<HHQQ', 0x0001, 16, 0, 0) +
+                # unicode comment
+                struct.pack('<HHBL5s', 0x6375, 10, 1,
+                            zipfile.crc32(b'\u4e00'), b'\u4e00') +
+                # invalid tail
+                b'zzz'
+            )
+            zh.writestr(zinfo, 'foo')
+
+        fh.seek(zinfo.header_offset)
+        entry = fh.read(zh.start_dir - zinfo.header_offset - zinfo.compress_size)
+        header = struct.unpack_from(zipfile.structFileHeader, entry)
+        extra = entry[-header[zipfile._FH_EXTRA_FIELD_LENGTH]:]
+        self.assertEqual(extra, b'zzz')
+
     def test_force_zip64(self):
         """Test that forcing zip64 extensions correctly notes this in the zip file"""
 

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -541,7 +541,7 @@ class ZipInfo:
             compress_size = self.compress_size
             file_size = self.file_size
 
-        extra = self.extra
+        extra = self._get_local_extra()
 
         min_version = 0
         if zip64 is None:
@@ -550,8 +550,11 @@ class ZipInfo:
             zip64 = file_size > ZIP64_LIMIT or compress_size > ZIP64_LIMIT
         if zip64:
             fmt = '<HHQQ'
-            extra = extra + struct.pack(fmt,
-                                        1, struct.calcsize(fmt)-4, file_size, compress_size)
+            extra = struct.pack(
+                fmt, 1, struct.calcsize(fmt)-4,
+                file_size, compress_size
+            ) + extra
+
             file_size = 0xffffffff
             compress_size = 0xffffffff
             min_version = ZIP64_VERSION
@@ -627,6 +630,14 @@ class ZipInfo:
                     raise BadZipFile('Corrupt unicode path extra field (0x7075): invalid utf-8 bytes') from e
 
             extra = extra[ln+4:]
+
+    def _get_local_extra(self):
+        return _Extra.strip(self.extra, (
+            # should be added on demand later
+            0x0001,  # Zip64
+            # should only exist in central directory
+            0x6375,  # Unicode Comment
+        ))
 
     @classmethod
     def from_file(cls, filename, arcname=None, *, strict_timestamps=True):

--- a/Misc/NEWS.d/next/Library/2026-07-14-22-25-00.gh-issue-153702.000000.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-14-22-25-00.gh-issue-153702.000000.rst
@@ -1,0 +1,3 @@
+Fix an issue where duplicated or improper extra fields were written to
+the local file entry if :attr:`ZipInfo.extra <zipfile.ZipInfo.extra>`
+had them.


### PR DESCRIPTION
Strip improper extra fields before writing to the local file entry.

Add on-demand fields by prepending rather than appending.

<!-- gh-issue-number: gh-153702 -->
* Issue: gh-153702
<!-- /gh-issue-number -->
