### PR TITLE
[3.14] gh-149816: Fix UAF in Modules/_pickle.c (GH-150024)

### DIFF
--- a/Lib/test/test_free_threading/test_pickle.py
+++ b/Lib/test/test_free_threading/test_pickle.py
@@ -40,5 +40,39 @@ class TestPickleFreeThreading(unittest.TestCase):
         with threading_helper.start_threads(threads):
             pass
 
+    def test_pickle_dumps_with_concurrent_list_mutations(self):
+        # gh-149816: Pickling a list while another thread mutates it
+        # used to be a UAF in free-threaded mode. batch_list_exact()
+        # used PyList_GET_ITEM (borrowed) followed by Py_INCREF, and a
+        # concurrent replace/pop could free the item between those two
+        # operations.
+        shared = [list(range(20)) for _ in range(50)]
+
+        def dumper():
+            for _ in range(1000):
+                try:
+                    pickle.dumps(shared)
+                except (RuntimeError, IndexError):
+                    pass
+
+        def mutator():
+            for i in range(1000):
+                idx = i % 50
+                shared[idx] = list(range(i % 20))
+                if i % 10 == 0:
+                    try:
+                        shared.pop()
+                    except IndexError:
+                        pass
+                    shared.append([i])
+
+        threads = []
+        for _ in range(10):
+            threads.append(threading.Thread(target=dumper))
+        threads.append(threading.Thread(target=mutator))
+
+        with threading_helper.start_threads(threads):
+            pass
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2026-05-18-12-42-31.gh-issue-149816.F98iME.rst
+++ b/Misc/NEWS.d/next/Library/2026-05-18-12-42-31.gh-issue-149816.F98iME.rst
@@ -1,0 +1,2 @@
+Fix a potential use after free condition in :func:`pickle.dumps` in free-threaded
+mode when serializing lists.

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3092,7 +3092,7 @@ static int
 batch_list_exact(PickleState *state, PicklerObject *self, PyObject *obj)
 {
     PyObject *item = NULL;
-    Py_ssize_t this_batch, total;
+    Py_ssize_t this_batch, total, list_size;
 
     const char append_op = APPEND;
     const char appends_op = APPENDS;
@@ -3102,9 +3102,14 @@ batch_list_exact(PickleState *state, PicklerObject *self, PyObject *obj)
     assert(self->proto > 0);
     assert(PyList_CheckExact(obj));
 
-    if (PyList_GET_SIZE(obj) == 1) {
-        item = PyList_GET_ITEM(obj, 0);
-        Py_INCREF(item);
+    list_size = PyList_GET_SIZE(obj);
+
+    if (list_size == 1) {
+        item = PyList_GetItemRef(obj, 0);
+        if (item == NULL) {
+            _PyErr_FormatNote("when serializing %T item 0", obj);
+            return -1;
+        }
         int err = save(state, self, item, 0);
         Py_DECREF(item);
         if (err < 0) {
@@ -3123,8 +3128,11 @@ batch_list_exact(PickleState *state, PicklerObject *self, PyObject *obj)
         if (_Pickler_Write(self, &mark_op, 1) < 0)
             return -1;
         while (total < PyList_GET_SIZE(obj)) {
-            item = PyList_GET_ITEM(obj, total);
-            Py_INCREF(item);
+            item = PyList_GetItemRef(obj, total);
+            if (item == NULL) {
+                _PyErr_FormatNote("when serializing %T item %zd", obj, total);
+                return -1;
+            }
             int err = save(state, self, item, 0);
             Py_DECREF(item);
             if (err < 0) {
@@ -3137,8 +3145,14 @@ batch_list_exact(PickleState *state, PicklerObject *self, PyObject *obj)
         }
         if (_Pickler_Write(self, &appends_op, 1) < 0)
             return -1;
+        if (PyList_GET_SIZE(obj) != list_size) {
+            PyErr_Format(
+                PyExc_RuntimeError,
+                "list changed size during iteration");
+            return -1;
+        }
 
-    } while (total < PyList_GET_SIZE(obj));
+    } while (total < list_size);
 
     return 0;
 }


### PR DESCRIPTION
gh-149816: Fix UAF in Modules/_pickle.c (GH-150024)

Backport note: 3.14's `batch_list_exact()` has the single-item fast path before the batch loop; main moved it inside the loop, which changes the emitted pickle byte stream (APPEND vs MARK ... APPENDS for a trailing single item). To avoid changing 3.14's pickle output, 3.14's structure was kept and only the fix applied: the borrowed PyList_GET_ITEM() + Py_INCREF() became PyList_GetItemRef(), and the list changed size during iteration RuntimeError check was added after each batch. The upstream regression test (test_pickle_dumps_with_concurrent_list_mutations) tolerates RuntimeError/IndexError and passes unchanged.


(cherry picked from commit d095ceb0f420a22353271a8adaf5a83433d018e5)

Co-authored-by: Alexey Katsman <alex2007508@gmail.com>
Co-authored-by: Gregory P. Smith <68491+gpshead@users.noreply.github.com>