### PR TITLE
gh-152075: Avoid lock contention in _Py_Specialize_LoadGlobal under free threading (gh-153720)

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-14-20-19-48.gh-issue-152075.V9Rwhp.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-14-20-19-48.gh-issue-152075.V9Rwhp.rst
@@ -1,0 +1,2 @@
+Reduced lock contention during LOAD_GLOBAL bytecode specialization under
+free threading.

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1457,6 +1457,14 @@ _Py_Specialize_LoadGlobal(
     PyObject *globals, PyObject *builtins,
     _Py_CODEUNIT *instr, PyObject *name)
 {
+#ifdef Py_GIL_DISABLED
+    if (PyMutex_IsLocked(&globals->ob_mutex) || PyMutex_IsLocked(&builtins->ob_mutex)) {
+        // Skip specialization if either dictionary is locked to avoid lock
+        // contention.
+        unspecialize(instr);
+        return;
+    }
+#endif
     Py_BEGIN_CRITICAL_SECTION2(globals, builtins);
     specialize_load_global_lock_held(globals, builtins, instr, name);
     Py_END_CRITICAL_SECTION2();


### PR DESCRIPTION
Under high thread concurrency in free-threaded builds, `_Py_Specialize_LoadGlobal`suffers from lock contention when acquiring the critical section mutexes for the `globals` and `builtins` dictionaries during bytecode specialization.

This PR skips LOAD_GLOBAL bytecode specialization if acquiring the two object mutexes would block.

<!-- gh-issue-number: gh-152075 -->
* Issue: gh-152075
<!-- /gh-issue-number -->
