### PR TITLE
gh-153729: Fix sqlite3 iterdump() for populated virtual tables

### DIFF
--- a/Lib/sqlite3/dump.py
+++ b/Lib/sqlite3/dump.py
@@ -77,6 +77,8 @@ def _iterdump(connection, *, filter=None):
                       _quote_value(table_name),
                       _quote_value(sql),
                   ))
+            # Rows live in the shadow tables, dumped separately.
+            continue
         else:
             yield('{0};'.format(sql))
 

--- a/Lib/test/test_sqlite3/test_dump.py
+++ b/Lib/test/test_sqlite3/test_dump.py
@@ -1,6 +1,9 @@
 # Author: Paul Kippes <kippesp@gmail.com>
 
+import sqlite3
 import unittest
+
+from test.support.os_helper import TESTFN, unlink
 
 from .util import memory_database
 from .util import MemoryDatabaseMixin
@@ -245,6 +248,34 @@ class DumpTests(MemoryDatabaseMixin, unittest.TestCase):
         self.cu.execute("CREATE VIRTUAL TABLE test USING fts4(example)")
         actual = list(self.cx.iterdump())
         self.assertEqual(expected, actual)
+
+    @requires_virtual_table("fts4")
+    def test_dump_virtual_table_data_roundtrip(self):
+        # gh-153729: a populated virtual table must round-trip through iterdump().
+        self.addCleanup(unlink, TESTFN)
+        with sqlite3.connect(TESTFN) as src:
+            src.execute("CREATE VIRTUAL TABLE test USING fts4(example)")
+            src.execute("INSERT INTO test(example) VALUES('hello world')")
+            src.execute("INSERT INTO test(example) VALUES('second row')")
+            src.commit()
+            script = "".join(src.iterdump())
+
+        # The virtual table's own rows are not dumped as INSERT statements
+        # (the data is preserved via the shadow tables instead).
+        self.assertNotIn('INSERT INTO "test"', script)
+
+        restored_path = f"{TESTFN}.restored"
+        self.addCleanup(unlink, restored_path)
+        with sqlite3.connect(restored_path) as dst:
+            # Defensive mode blocks writable_schema writes to sqlite_master.
+            dst.setconfig(sqlite3.SQLITE_DBCONFIG_DEFENSIVE, False)
+            dst.setconfig(sqlite3.SQLITE_DBCONFIG_WRITABLE_SCHEMA, True)
+            dst.executescript(script)
+        with sqlite3.connect(restored_path) as restored:
+            rows = restored.execute(
+                "SELECT example FROM test ORDER BY docid"
+            ).fetchall()
+        self.assertEqual(rows, [("hello world",), ("second row",)])
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_sqlite3/test_dump.py
+++ b/Lib/test/test_sqlite3/test_dump.py
@@ -2,6 +2,7 @@
 
 import sqlite3
 import unittest
+from contextlib import closing
 
 from test.support.os_helper import TESTFN, unlink
 
@@ -253,7 +254,7 @@ class DumpTests(MemoryDatabaseMixin, unittest.TestCase):
     def test_dump_virtual_table_data_roundtrip(self):
         # gh-153729: a populated virtual table must round-trip through iterdump().
         self.addCleanup(unlink, TESTFN)
-        with sqlite3.connect(TESTFN) as src:
+        with closing(sqlite3.connect(TESTFN)) as src:
             src.execute("CREATE VIRTUAL TABLE test USING fts4(example)")
             src.execute("INSERT INTO test(example) VALUES('hello world')")
             src.execute("INSERT INTO test(example) VALUES('second row')")
@@ -266,12 +267,12 @@ class DumpTests(MemoryDatabaseMixin, unittest.TestCase):
 
         restored_path = f"{TESTFN}.restored"
         self.addCleanup(unlink, restored_path)
-        with sqlite3.connect(restored_path) as dst:
+        with closing(sqlite3.connect(restored_path)) as dst:
             # Defensive mode blocks writable_schema writes to sqlite_master.
             dst.setconfig(sqlite3.SQLITE_DBCONFIG_DEFENSIVE, False)
             dst.setconfig(sqlite3.SQLITE_DBCONFIG_WRITABLE_SCHEMA, True)
             dst.executescript(script)
-        with sqlite3.connect(restored_path) as restored:
+        with closing(sqlite3.connect(restored_path)) as restored:
             rows = restored.execute(
                 "SELECT example FROM test ORDER BY docid"
             ).fetchall()

--- a/Misc/NEWS.d/next/Library/2026-07-14-10-00-00.gh-issue-153729.p3yD9r.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-14-10-00-00.gh-issue-153729.p3yD9r.rst
@@ -1,0 +1,3 @@
+:meth:`sqlite3.Connection.iterdump` no longer emits ``INSERT`` statements for
+a virtual table's own rows, which previously made restoring the dump raise
+:exc:`sqlite3.OperationalError`.  Patch by tonghuaroot.


### PR DESCRIPTION
`iterdump()` dumped a virtual table's own rows as `INSERT` statements on top of
its schema. Those rows live in the shadow tables (dumped separately) and replay
before the module is instantiated, so restoring the dump raised
`sqlite3.OperationalError`. Skip the per-row dump for virtual tables, matching
the SQLite shell's `.dump`.


<!-- gh-issue-number: gh-153729 -->
* Issue: gh-153729
<!-- /gh-issue-number -->
