### PR TITLE
gh-153731: Handle NUL and lone surrogate in sqlite3 CLI REPL

### DIFF
--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -24,18 +24,25 @@ def execute(c, sql, suppress_errors=True, theme=theme_no_color):
     'sql' is the SQL string to execute.
     """
 
-    try:
-        for row in c.execute(sql):
-            print(row)
-    except sqlite3.Error as e:
-        t = theme.traceback
-        tp = type(e).__name__
+    error = None
+    if "\0" in sql:
+        # A NUL makes c.execute() raise a broad ValueError; pre-check it.
+        error = ValueError("embedded null character")
+    else:
         try:
-            tp += f" ({e.sqlite_errorname})"
+            for row in c.execute(sql):
+                print(row)
+        except (sqlite3.Error, UnicodeEncodeError) as e:  # or a lone surrogate
+            error = e
+    if error is not None:
+        t = theme.traceback
+        tp = type(error).__name__
+        try:
+            tp += f" ({error.sqlite_errorname})"
         except AttributeError:
             pass
         print(
-            f"{t.type}{tp}{t.reset}: {t.message}{e}{t.reset}", file=sys.stderr
+            f"{t.type}{tp}{t.reset}: {t.message}{error}{t.reset}", file=sys.stderr
         )
         if not suppress_errors:
             sys.exit(1)

--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -80,14 +80,20 @@ class SqliteInteractiveConsole(InteractiveConsole):
                     self.write(f'{t.type}Error{t.reset}: {t.message}unknown '
                                f'command: "{unknown}"{t.reset}\n')
         else:
-            try:
-                complete = sqlite3.complete_statement(source)
-            # NUL -> ValueError, lone surrogate -> UnicodeEncodeError; keep
-            # narrow so real bugs still surface.
-            except (ValueError, UnicodeEncodeError) as e:
+            error = None
+            if "\0" in source:
+                # A NUL makes complete_statement() raise a broad ValueError;
+                # pre-check it so ValueError from other code still surfaces.
+                error = ValueError("embedded null character")
+            else:
+                try:
+                    complete = sqlite3.complete_statement(source)
+                except UnicodeEncodeError as e:  # a lone surrogate
+                    error = e
+            if error is not None:
                 t = theme.traceback
-                self.write(f"{t.type}{type(e).__name__}{t.reset}: "
-                           f"{t.message}{e}{t.reset}\n")
+                self.write(f"{t.type}{type(error).__name__}{t.reset}: "
+                           f"{t.message}{error}{t.reset}\n")
                 return False
             if not complete:
                 return True

--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -41,9 +41,8 @@ def execute(c, sql, suppress_errors=True, theme=theme_no_color):
             tp += f" ({error.sqlite_errorname})"
         except AttributeError:
             pass
-        print(
-            f"{t.type}{tp}{t.reset}: {t.message}{error}{t.reset}", file=sys.stderr
-        )
+        print(f"{t.type}{tp}{t.reset}: {t.message}{error}{t.reset}",
+              file=sys.stderr)
         if not suppress_errors:
             sys.exit(1)
 

--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -80,7 +80,16 @@ class SqliteInteractiveConsole(InteractiveConsole):
                     self.write(f'{t.type}Error{t.reset}: {t.message}unknown '
                                f'command: "{unknown}"{t.reset}\n')
         else:
-            if not sqlite3.complete_statement(source):
+            try:
+                complete = sqlite3.complete_statement(source)
+            # NUL -> ValueError, lone surrogate -> UnicodeEncodeError; keep
+            # narrow so real bugs still surface.
+            except (ValueError, UnicodeEncodeError) as e:
+                t = theme.traceback
+                self.write(f"{t.type}{type(e).__name__}{t.reset}: "
+                           f"{t.message}{e}{t.reset}\n")
+                return False
+            if not complete:
                 return True
             execute(self._cur, source, theme=theme)
         return False

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -69,6 +69,16 @@ class CommandLineInterface(unittest.TestCase):
         stderr = self.expect_failure(":memory:", "sel")
         self.assertIn("OperationalError (SQLITE_ERROR)", stderr)
 
+    def test_cli_execute_null_byte(self):
+        stderr = self.expect_failure(":memory:", "SELECT '\0';")
+        self.assertNotIn("Traceback (most recent call last)", stderr)
+        self.assertIn("ValueError: ", stderr)
+
+    def test_cli_execute_lone_surrogate(self):
+        stderr = self.expect_failure(":memory:", "SELECT '\udc80';")
+        self.assertNotIn("Traceback (most recent call last)", stderr)
+        self.assertIn("UnicodeEncodeError: ", stderr)
+
     def test_cli_on_disk_db(self):
         self.addCleanup(unlink, TESTFN)
         out = self.expect_success(TESTFN, "create table t(t)")

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -189,6 +189,28 @@ class InteractiveSession(unittest.TestCase):
         self.assertEqual(out.count(self.PS1), 2)
         self.assertEqual(out.count(self.PS2), 0)
 
+    def test_interact_null_byte(self):
+        # NUL byte -> ValueError from complete_statement().
+        out, err = self.run_cli(commands=("SELECT '\0';", "SELECT 1;"))
+        self.assertIn(self.MEMORY_DB_MSG, err)
+        self.assertNotIn("Traceback (most recent call last)", err)
+        self.assertIn("ValueError: ", err)
+        self.assertIn("(1,)\n", out)
+        self.assertEndsWith(out, self.PS1)
+        self.assertEqual(out.count(self.PS1), 3)
+        self.assertEqual(out.count(self.PS2), 0)
+
+    def test_interact_lone_surrogate(self):
+        # Lone surrogate -> UnicodeEncodeError from complete_statement().
+        out, err = self.run_cli(commands=("SELECT '\udc80';", "SELECT 1;"))
+        self.assertIn(self.MEMORY_DB_MSG, err)
+        self.assertNotIn("Traceback (most recent call last)", err)
+        self.assertIn("UnicodeEncodeError: ", err)
+        self.assertIn("(1,)\n", out)
+        self.assertEndsWith(out, self.PS1)
+        self.assertEqual(out.count(self.PS1), 3)
+        self.assertEqual(out.count(self.PS2), 0)
+
     def test_interact_on_disk_file(self):
         self.addCleanup(unlink, TESTFN)
 

--- a/Misc/NEWS.d/next/Library/2026-07-14-19-41-38.gh-issue-153731.ctLI83.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-14-19-41-38.gh-issue-153731.ctLI83.rst
@@ -1,0 +1,4 @@
+Fix the :mod:`sqlite3` command-line interface so that an input line
+containing an embedded null character or a lone surrogate no longer crashes
+the interactive shell; an error is now printed and the shell continues.
+Patch by tonghuaroot.


### PR DESCRIPTION
In the `python -m sqlite3` REPL, `complete_statement()` raises `ValueError`
(embedded NUL) or `UnicodeEncodeError` (lone surrogate), neither of which is a
`sqlite3.Error`, so a single such input line crashed the shell. Catch these two
and print an error, keeping the REPL running like the other error paths.


<!-- gh-issue-number: gh-153731 -->
* Issue: gh-153731
<!-- /gh-issue-number -->
