### PR TITLE
gh-61481: Document that memoryview, range, and slice cannot be subclassed

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1292,6 +1292,8 @@ are always available.  They are listed here in alphabetical order.
    Return a "memory view" object created from the given argument.  See
    :ref:`typememoryview` for more information.
 
+   This class cannot be subclassed.
+
 
 .. function:: min(iterable, /, *, key=None)
               min(iterable, /, *, default, key=None)
@@ -1749,6 +1751,8 @@ are always available.  They are listed here in alphabetical order.
    Rather than being a function, :class:`range` is actually an immutable
    sequence type, as documented in :ref:`typesseq-range` and :ref:`typesseq`.
 
+   This class cannot be subclassed.
+
 
 .. function:: repr(object, /)
 
@@ -1919,6 +1923,8 @@ are always available.  They are listed here in alphabetical order.
 
    See :func:`itertools.islice` for an alternate version that returns an
    :term:`iterator`.
+
+   This class cannot be subclassed.
 
    .. attribute:: slice.start
                   slice.stop


### PR DESCRIPTION
Among the built-in classes that can't be subclassed, only `bool` documents it. `memoryview`, `range`, and `slice` behave the same but say nothing, so it can only be found out by trying. Add the same note to those three.

The wording mirrors the existing `bool` entry, minus the "further" that applies only to `bool` (which subclasses `int`). Confirmed at tip: subclassing each raises `TypeError` (they lack `Py_TPFLAGS_BASETYPE`), while `int` and `list` allow it.

This is the note the issue author proposed, and the thread confirmed all four are intentional rather than oversights. The `types` module classes mentioned in the issue are documented separately and are out of scope here.


<!-- gh-issue-number: gh-61481 -->
* Issue: gh-61481
<!-- /gh-issue-number -->
