### PR TITLE
gh-140746: Fix Thread.start() hanging when the thread dies during bootstrap

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -567,7 +567,10 @@ since it is impossible to detect the termination of alien threads.
       of control.
 
       This method will raise a :exc:`RuntimeError` if called more than once
-      on the same thread object.
+      on the same thread object.  It also raises :exc:`RuntimeError` if the
+      new thread terminates before it has fully started, which can happen
+      under memory pressure (for example when a :exc:`MemoryError` occurs
+      while the thread is bootstrapping).
 
       If supported, set the operating system thread name to
       :attr:`threading.Thread.name`. The name can be truncated depending on the
@@ -575,6 +578,10 @@ since it is impossible to detect the termination of alien threads.
 
       .. versionchanged:: 3.14
          Set the operating system thread name.
+
+      .. versionchanged:: next
+         :exc:`RuntimeError` is now raised if the thread dies before it has
+         fully started; previously this method could hang forever.
 
    .. method:: run()
 

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1505,6 +1505,55 @@ class ThreadTests(BaseTestCase):
         self.assertEqual(err, b"")
         self.assertEqual(out.strip(), b"Exiting...")
 
+    def test_start_thread_dies_in_bootstrap(self):
+        # gh-140746: if the newly spawned thread dies before signalling
+        # that it has started (e.g. a MemoryError while calling _bootstrap),
+        # Thread.start() must raise instead of hanging forever.
+        class BrokenBootstrapThread(threading.Thread):
+            def _bootstrap(self):
+                # Simulates a failure before self._started.set(): the
+                # C-level thread_run() catches the exception and the
+                # thread exits without ever signalling startup.
+                raise MemoryError('out of memory during bootstrap')
+
+        t = BrokenBootstrapThread(target=lambda: None)
+        with support.catch_unraisable_exception():
+            with self.assertRaisesRegex(RuntimeError,
+                                        "thread failed to start"):
+                t.start()
+        self.assertFalse(t.is_alive())
+        self.assertNotIn(t, threading._limbo)
+        self.assertNotIn(t, threading.enumerate())
+
+    def test_start_thread_dies_in_bootstrap_inner(self):
+        # gh-140746: same as above with the failure inside
+        # _bootstrap_inner(), before self._started.set().
+        t = threading.Thread(target=lambda: None)
+        with (support.catch_unraisable_exception(),
+              mock.patch.object(t, '_set_ident',
+                                side_effect=MemoryError('no memory'))):
+            with self.assertRaisesRegex(RuntimeError,
+                                        "thread failed to start"):
+                t.start()
+        self.assertFalse(t.is_alive())
+        self.assertNotIn(t, threading._limbo)
+        self.assertNotIn(t, threading.enumerate())
+
+    def test_start_thread_exits_in_bootstrap(self):
+        # gh-140746: SystemExit is silently ignored by the C-level
+        # thread_run(); it must not make Thread.start() hang either.
+        class ExitingBootstrapThread(threading.Thread):
+            def _bootstrap(self):
+                raise SystemExit
+
+        t = ExitingBootstrapThread(target=lambda: None)
+        with self.assertRaisesRegex(RuntimeError, "thread failed to start"):
+            t.start()
+        self.assertFalse(t.is_alive())
+        self.assertNotIn(t, threading._limbo)
+        self.assertNotIn(t, threading.enumerate())
+
+
 class ThreadJoinOnShutdown(BaseTestCase):
 
     def _run_and_join(self, script):

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1144,7 +1144,21 @@ class Thread:
             with _active_limbo_lock:
                 del _limbo[self]
             raise
-        self._started.wait()  # Will set ident and native_id
+        # Wait for the thread to signal that it has started (this also
+        # ensures that ident and native_id are set).  Waiting on the
+        # Python-level _started event alone can hang forever: if the thread
+        # dies during its bootstrap (e.g. a MemoryError while calling
+        # _bootstrap), _started is never set.  The C-level event is also
+        # notified when the thread exits, so this wait cannot hang
+        # (see gh-140746).
+        self._os_thread_handle._wait_for_started()
+        if not self._started.is_set():
+            # The thread terminated before signalling that it started: it
+            # never ran and never will.  Clean up and fail loudly rather
+            # than returning a dead, half-initialized thread.
+            with _active_limbo_lock:
+                del _limbo[self]
+            raise RuntimeError("thread failed to start")
 
     def run(self):
         """Method representing the thread's activity.
@@ -1205,6 +1219,9 @@ class Thread:
                 self._set_native_id()
             self._set_os_name()
             self._started.set()
+            # Signal the C-level event *after* _started so that a waiter
+            # woken by it always observes _started as set (gh-140746).
+            self._os_thread_handle._set_started()
             with _active_limbo_lock:
                 _active[self._ident] = self
                 del _limbo[self]

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-15-10-00-00.gh-issue-140746.limThd.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-15-10-00-00.gh-issue-140746.limThd.rst
@@ -1,0 +1,5 @@
+Fix :meth:`threading.Thread.start` hanging forever when the new thread dies
+before signalling that it has started, for instance when a
+:exc:`MemoryError` is raised during the thread's bootstrap under memory
+pressure. :meth:`!Thread.start` now raises :exc:`RuntimeError` in that case
+and the dead thread no longer lingers in :func:`threading.enumerate`.

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -146,6 +146,14 @@ typedef struct {
     // for a more detailed explanation.
     PyEvent thread_is_exiting;
 
+    // Set by the thread when its Python-level bootstrap has signalled
+    // startup (see threading.Thread._bootstrap_inner), or on thread exit
+    // if the bootstrap terminated before doing so.  threading.Thread.start()
+    // waits on this event rather than on the Python-level started event
+    // alone, so that it cannot hang forever if the thread dies during its
+    // bootstrap (e.g. a MemoryError, see gh-140746).
+    PyEvent thread_started;
+
     // Serializes calls to `join` and `set_done`.
     _PyOnceFlag once;
 
@@ -232,6 +240,7 @@ ThreadHandle_new(void)
     self->os_handle = 0;
     self->has_os_handle = 0;
     self->thread_is_exiting = (PyEvent){0};
+    self->thread_started = (PyEvent){0};
     self->mutex = (PyMutex){_Py_UNLOCKED};
     self->once = (_PyOnceFlag){0};
     self->state = THREAD_HANDLE_NOT_STARTED;
@@ -323,6 +332,7 @@ _PyThread_AfterFork(struct _pythread_runtime_state *state)
         handle->once = (_PyOnceFlag){_Py_ONCE_INITIALIZED};
         handle->mutex = (PyMutex){_Py_UNLOCKED};
         _PyEvent_Notify(&handle->thread_is_exiting);
+        _PyEvent_Notify(&handle->thread_started);
         llist_remove(node);
         remove_from_shutdown_handles(handle);
     }
@@ -408,6 +418,12 @@ thread_run(void *boot_raw)
 exit:
     // Don't need to wait for this thread anymore
     remove_from_shutdown_handles(handle);
+
+    // gh-140746: Unblock any thread waiting in Thread.start().  If the
+    // bootstrap function terminated before signalling startup (e.g. a
+    // MemoryError while calling it), this is the only notification the
+    // waiter will get.  If startup was already signalled, this is a no-op.
+    _PyEvent_Notify(&handle->thread_started);
 
     _PyEvent_Notify(&handle->thread_is_exiting);
     ThreadHandle_decref(handle);
@@ -709,6 +725,28 @@ PyThreadHandleObject_join(PyObject *op, PyObject *args)
 }
 
 static PyObject *
+PyThreadHandleObject_set_started(PyObject *op, PyObject *Py_UNUSED(dummy))
+{
+    PyThreadHandleObject *self = PyThreadHandleObject_CAST(op);
+    _PyEvent_Notify(&self->handle->thread_started);
+    Py_RETURN_NONE;
+}
+
+static PyObject *
+PyThreadHandleObject_wait_for_started(PyObject *op, PyObject *Py_UNUSED(dummy))
+{
+    PyThreadHandleObject *self = PyThreadHandleObject_CAST(op);
+    while (!PyEvent_WaitTimed(&self->handle->thread_started, -1,
+                              /*detach=*/1)) {
+        // Interrupted
+        if (Py_MakePendingCalls() < 0) {
+            return NULL;
+        }
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *
 PyThreadHandleObject_is_done(PyObject *op, PyObject *Py_UNUSED(dummy))
 {
     PyThreadHandleObject *self = PyThreadHandleObject_CAST(op);
@@ -741,6 +779,9 @@ static PyGetSetDef ThreadHandle_getsetlist[] = {
 static PyMethodDef ThreadHandle_methods[] = {
     {"join", PyThreadHandleObject_join, METH_VARARGS, NULL},
     {"_set_done", PyThreadHandleObject_set_done, METH_NOARGS, NULL},
+    {"_set_started", PyThreadHandleObject_set_started, METH_NOARGS, NULL},
+    {"_wait_for_started", PyThreadHandleObject_wait_for_started,
+     METH_NOARGS, NULL},
     {"is_done", PyThreadHandleObject_is_done, METH_NOARGS, NULL},
     {0, 0}
 };


### PR DESCRIPTION
## Problem

`Thread.start()` waits for the new thread with a bare `self._started.wait()`. If the new thread dies before `_bootstrap_inner()` reaches `self._started.set()`; typically a `MemoryError` raised while the C-level `thread_run()` calls `_bootstrap` under memory pressure (the interpreter prints `Exception ignored in thread started by ...`), or a `SystemExit` which `thread_run()` clears silently → the event is never set and the parent blocks **forever**. The dead thread also lingers in `threading._limbo`, so it stays visible in `threading.enumerate()` while `is_alive()` is `False`.

Any threaded server whose dispatcher thread spawns per-request threads (e.g. `socketserver.ThreadingMixIn`) freezes permanently the first time this fires. This was detected in production on Python 3.12: workers stopped serving after a burst of `MemoryError`s, with `kill -3` stack dumps showing the dispatcher thread blocked in `Thread.start()` → `self._started.wait()`, the request thread perpetually in its *initial* state, and no corresponding OS thread. Full investigation in gh-140746 (also reported by Patroni).

## Reproducer

Deterministic: simulates the `MemoryError` that `thread_run()` swallows while calling `_bootstrap` (the same C code path, `PyObject_Call()` returning `NULL`):

```python
import threading

class BrokenBootstrapThread(threading.Thread):
    # Simulates a MemoryError raised before _started.set(): thread_run()
    # catches it ("Exception ignored in thread started by ...") and the
    # thread exits without ever signalling startup.
    def _bootstrap(self):
        raise MemoryError

t = BrokenBootstrapThread(target=lambda: None)
t.start()   # unpatched: hangs here forever
print("started fine:", t.is_alive())
```

Unpatched (reproduced on 3.12.11 and main): prints the "Exception ignored" traceback, then `start()` blocks forever. With this PR: `start()` raises `RuntimeError: thread failed to start` and the thread is removed from `_limbo`. The organic reproducer from the issue (progressively lowering `RLIMIT_DATA` until a real `MemoryError` lands in the thread's bootstrap) also hangs unpatched and fails cleanly with this PR after ~1300 progressively-starved thread starts.

## Fix

Add a C-level `thread_started` `PyEvent` to `ThreadHandle`, mirroring the existing `thread_is_exiting`:

- `_bootstrap_inner()` notifies it (via `handle._set_started()`) right *after* `self._started.set()`, so a waiter woken by the child always observes `_started` as set;
- `thread_run()` notifies it unconditionally on its exit path — covering a failed `PyObject_Call` of `_bootstrap`, the silent `SystemExit` case, and the `_PyThreadState_MustExit()` early exit during finalization. `_PyEvent_Notify()` is allocation-free C and a no-op on an already-set event, so this is safe on every exit path.

`Thread.start()` waits on the C event (`_wait_for_started()`: GIL released, interruptible via `Py_MakePendingCalls()`) and then checks `_started`: set means the thread started normally (identical behavior to today); unset means the thread died before starting and never will run, so `start()` removes it from `_limbo` and raises `RuntimeError("thread failed to start")`. No timeout, no polling, no new handle states.


## Validation

Environment: Ubuntu 24.04 x86-64 (Linux 6.17), gcc 13.3.0; main built both `--with-pydebug` and `--disable-gil`; stock 3.12.11 as the unpatched baseline.

- Both reproducers above: hang unpatched, clean `RuntimeError` + `_limbo` cleanup with this PR (both builds).
- End-to-end: a `ThreadingTCPServer` whose request thread dies in bootstrap freezes permanently unpatched; with this PR, `handle_error()` logs the `RuntimeError` and the server keeps serving.
- Test suites (both builds): `test_threading`, `test_thread`, `test_threadedtempfile`, `test_thread_local_bytecode`, `test_socketserver -u all`, `test_concurrent_futures.test_thread_pool`, `test_queue` — all pass.
- Three regression tests added: `MemoryError` in `_bootstrap`, `MemoryError` in `_bootstrap_inner`, and `SystemExit` in `_bootstrap`.