### PR TITLE
Shut down leaked executors in `test_interpreter_pool`

### DIFF
--- a/Lib/test/test_concurrent_futures/test_interpreter_pool.py
+++ b/Lib/test/test_concurrent_futures/test_interpreter_pool.py
@@ -129,12 +129,12 @@ class InterpreterPoolExecutorTest(
             """
         os.write(w, b'\0')
 
-        executor = self.executor_type(initializer=initscript)
-        before_init = os.read(r, 100)
-        fut = executor.submit(script)
-        after_init = read_msg(r)
-        fut.result()
-        after_run = read_msg(r)
+        with self.executor_type(initializer=initscript) as executor:
+            before_init = os.read(r, 100)
+            fut = executor.submit(script)
+            after_init = read_msg(r)
+            fut.result()
+            after_run = read_msg(r)
 
         self.assertEqual(before_init, b'\0')
         self.assertEqual(after_init, msg1)
@@ -150,11 +150,11 @@ class InterpreterPoolExecutorTest(
         r, w = self.pipe()
         os.write(w, b'\0')
 
-        executor = self.executor_type(
-                initializer=write_msg, initargs=(w, msg))
-        before = os.read(r, 100)
-        executor.submit(mul, 10, 10)
-        after = read_msg(r)
+        with self.executor_type(
+                initializer=write_msg, initargs=(w, msg)) as executor:
+            before = os.read(r, 100)
+            executor.submit(mul, 10, 10)
+            after = read_msg(r)
 
         self.assertEqual(before, b'\0')
         self.assertEqual(after, msg)
@@ -260,11 +260,10 @@ class InterpreterPoolExecutorTest(
             import os
             os.write({w}, __name__.encode('utf-8') + b'\\0')
             """
-        executor = self.executor_type()
-
-        fut = executor.submit(script)
-        res = fut.result()
-        after = read_msg(r)
+        with self.executor_type() as executor:
+            fut = executor.submit(script)
+            res = fut.result()
+            after = read_msg(r)
 
         self.assertEqual(after, b'__main__')
         self.assertIs(res, None)
@@ -278,25 +277,24 @@ class InterpreterPoolExecutorTest(
             spam += 1
             return spam
 
-        executor = self.executor_type()
+        with self.executor_type() as executor:
+            fut = executor.submit(task1)
+            with self.assertRaises(_interpreters.NotShareableError):
+                fut.result()
 
-        fut = executor.submit(task1)
-        with self.assertRaises(_interpreters.NotShareableError):
-            fut.result()
-
-        fut = executor.submit(task2)
-        with self.assertRaises(_interpreters.NotShareableError):
-            fut.result()
+            fut = executor.submit(task2)
+            with self.assertRaises(_interpreters.NotShareableError):
+                fut.result()
 
     def test_submit_local_instance(self):
         class Spam:
             def __init__(self):
                 self.value = True
 
-        executor = self.executor_type()
-        fut = executor.submit(Spam)
-        with self.assertRaises(_interpreters.NotShareableError):
-            fut.result()
+        with self.executor_type() as executor:
+            fut = executor.submit(Spam)
+            with self.assertRaises(_interpreters.NotShareableError):
+                fut.result()
 
     def test_submit_instance_method(self):
         class Spam:
@@ -304,15 +302,15 @@ class InterpreterPoolExecutorTest(
                 return True
         spam = Spam()
 
-        executor = self.executor_type()
-        fut = executor.submit(spam.run)
-        with self.assertRaises(_interpreters.NotShareableError):
-            fut.result()
+        with self.executor_type() as executor:
+            fut = executor.submit(spam.run)
+            with self.assertRaises(_interpreters.NotShareableError):
+                fut.result()
 
     def test_submit_func_globals(self):
-        executor = self.executor_type()
-        fut = executor.submit(get_current_name)
-        name = fut.result()
+        with self.executor_type() as executor:
+            fut = executor.submit(get_current_name)
+            name = fut.result()
 
         self.assertEqual(name, __name__)
         self.assertNotEqual(name, '__main__')


### PR DESCRIPTION
Several tests created an `InterpreterPoolExecutor` and never shut it down, so their worker threads were only cleaned up whenever the garbage collector happened to destroy the abandoned executor. On the slow buildbot that took longer than the 1-second limit `threading_cleanup()` allows in `tearDown`, for example in [this run](https://buildbot.python.org/#/builders/2237/builds/37):

```
test_submit_func_globals (test.test_concurrent_futures.test_interpreter_pool.InterpreterPoolExecutorTest.test_submit_func_globals) ... Warning -- threading_cleanup() failed to clean up threads in 1.0 seconds
Warning --   before: thread count=0, dangling=1
Warning --   after: thread count=1, dangling=2
Warning -- Dangling thread: <Thread(InterpreterPoolExecutor-57_0, stopped 273622737248)>
Warning -- Dangling thread: <_MainThread(MainThread, started 273774698528)>
test_submit_local_instance (test.test_concurrent_futures.test_interpreter_pool.InterpreterPoolExecutorTest.test_submit_local_instance) ... Warning -- threading_cleanup() failed to clean up threads in 1.0 seconds
Warning --   before: thread count=0, dangling=1
Warning --   after: thread count=1, dangling=2
Warning -- Dangling thread: <Thread(InterpreterPoolExecutor-62_0, stopped 273622737248)>
Warning -- Dangling thread: <_MainThread(MainThread, started 273774698528)>
Re-running test.test_concurrent_futures.test_interpreter_pool in verbose mode
```
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
