### PR TITLE
gh-146011: Fix use-after-free in `signaldict_repr` after deletion

### DIFF
--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -4147,6 +4147,15 @@ class ContextFlags:
 @requires_cdecimal
 class CContextFlags(ContextFlags, unittest.TestCase):
     decimal = C
+
+    def test_signaldict_repr(self):
+        Context = self.decimal.Context
+        ctx = Context(prec=7)
+        mapping = ctx.flags
+        del ctx
+        with self.assertRaises(ValueError):
+            repr(mapping)
+
 class PyContextFlags(ContextFlags, unittest.TestCase):
     decimal = P
 

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -4153,7 +4153,7 @@ class CContextFlags(ContextFlags, unittest.TestCase):
         ctx = Context(prec=7)
         mapping = ctx.flags
         del ctx
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, 'invalid signal dict'):
             repr(mapping)
 
 class PyContextFlags(ContextFlags, unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2026-07-15-21-56-40.gh-issue-146011.nWmHif.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-15-21-56-40.gh-issue-146011.nWmHif.rst
@@ -1,2 +1,2 @@
-Fix a heap-use-after-free in the C implementation of :mod:`decimal` 
+Fix a heap-use-after-free in the C implementation of :mod:`decimal`
 when calling :func:`repr` after deleting the :class:`~decimal.Context`.

--- a/Misc/NEWS.d/next/Library/2026-07-15-21-56-40.gh-issue-146011.nWmHif.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-15-21-56-40.gh-issue-146011.nWmHif.rst
@@ -1,0 +1,2 @@
+Fix a heap-use-after-free in the C implementation of :mod:`decimal` 
+when calling :func:`repr` after deleting the :class:`~decimal.Context`.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -1502,8 +1502,7 @@ context_clear(PyObject *op)
     /* Since traps and flags hold a borrowed reference to the
        flags stored in the context object, these references need
        to be cleared when the context object is deallocated
-       because other objects could hold references to the
-       traps and/or flags objects. See gh-146011. */
+       because traps and flags can survive. See gh-146011. */
     PyDecSignalDictObject *traps = _PyDecSignalDictObject_CAST(self->traps);
     PyDecSignalDictObject *flags = _PyDecSignalDictObject_CAST(self->flags);
 

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -1501,8 +1501,14 @@ context_clear(PyObject *op)
     PyDecContextObject *self = _PyDecContextObject_CAST(op);
     PyDecSignalDictObject *traps = _PyDecSignalDictObject_CAST(self->traps);
     PyDecSignalDictObject *flags = _PyDecSignalDictObject_CAST(self->flags);
-    traps->flags = NULL;
-    flags->flags = NULL;
+
+    if (traps != NULL) {
+        traps->flags = NULL;
+    }
+    if (flags != NULL) {
+        flags->flags = NULL;
+    }
+
     Py_CLEAR(self->traps);
     Py_CLEAR(self->flags);
     return 0;

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -1499,6 +1499,10 @@ static int
 context_clear(PyObject *op)
 {
     PyDecContextObject *self = _PyDecContextObject_CAST(op);
+    PyDecSignalDictObject *traps = _PyDecSignalDictObject_CAST(self->traps);
+    PyDecSignalDictObject *flags = _PyDecSignalDictObject_CAST(self->flags);
+    traps->flags = NULL;
+    flags->flags = NULL;
     Py_CLEAR(self->traps);
     Py_CLEAR(self->flags);
     return 0;

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -1499,6 +1499,11 @@ static int
 context_clear(PyObject *op)
 {
     PyDecContextObject *self = _PyDecContextObject_CAST(op);
+    /* Since traps and flags hold a borrowed reference to the
+       flags stored in the context object, these references need
+       to be cleared when the context object is deallocated
+       because other objects could hold references to the
+       traps and/or flags objects. See gh-146011. */
     PyDecSignalDictObject *traps = _PyDecSignalDictObject_CAST(self->traps);
     PyDecSignalDictObject *flags = _PyDecSignalDictObject_CAST(self->flags);
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146011 -->
* Issue: gh-146011
<!-- /gh-issue-number -->
