### PR TITLE
gh-153785: Generate `AttributeError` messages from context

### DIFF
--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -220,7 +220,6 @@ The following exceptions are the exceptions that are usually raised.
    .. versionchanged:: 3.10
       Added the :attr:`name` and :attr:`obj` attributes.
 
-
 .. exception:: EOFError
 
    Raised when the :func:`input` function hits an end-of-file condition (EOF)

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -215,17 +215,11 @@ The following exceptions are the exceptions that are usually raised.
 
       The object that was accessed for the named attribute.
 
-   When possible, :attr:`name` and :attr:`obj` are set automatically
-   for failed attribute lookups.
+   When possible, :attr:`name` and :attr:`obj` are set automatically.
 
    .. versionchanged:: 3.10
       Added the :attr:`name` and :attr:`obj` attributes.
 
-   .. versionchanged:: next
-      The default error message is now generated from :attr:`name` and
-      :attr:`obj` when both attributes are set and the exception was
-      constructed with no positional arguments, or with a single positional
-      argument equal to :attr:`name`.
 
 .. exception:: EOFError
 

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -215,8 +215,17 @@ The following exceptions are the exceptions that are usually raised.
 
       The object that was accessed for the named attribute.
 
+   When possible, :attr:`name` and :attr:`obj` are set automatically
+   for failed attribute lookups.
+
    .. versionchanged:: 3.10
       Added the :attr:`name` and :attr:`obj` attributes.
+
+   .. versionchanged:: next
+      The default error message is now generated from :attr:`name` and
+      :attr:`obj` when both attributes are set and the exception was
+      constructed with no positional arguments, or with a single positional
+      argument equal to :attr:`name`.
 
 .. exception:: EOFError
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2074,7 +2074,6 @@ class AttributeErrorTests(unittest.TestCase):
             getattr(RaiseCustom(), "missing3")
         self.assertEqual(str(cm.exception), "custom")
 
-
     def test_module_getattr_error_message(self):
         mod1 = ModuleType("raisewithname")
         def raise_with_name(name):

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2153,7 +2153,8 @@ class AttributeErrorTests(unittest.TestCase):
         self.assertIs(cm.exception.obj, custom_mod)
         self.assertEqual(cm.exception.name, "missing3")
 
-        nameless_mod = ModuleType.__new__(ModuleType)
+        nameless_mod = ModuleType("forgettable")
+        del nameless_mod.__dict__["__name__"]
         nameless_mod.__getattr__ = raise_with_name
         with self.assertRaises(AttributeError) as cm:
             getattr(nameless_mod, "missing4")

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2063,8 +2063,13 @@ class AttributeErrorTests(unittest.TestCase):
             def __getattr__(self, name):
                 raise AttributeError
 
+        class RaiseCustom:
+            def __getattr__(self, name):
+                raise AttributeError("custom")
+
         self._test_generated_message(RaiseWithName(), "missing1")
         self._test_generated_message(BareRaise(), "missing2")
+        self._test_generated_message(RaiseCustom(), "custom")
 
     def test_module_getattr_attribute_error_message(self):
         mod1 = ModuleType("raisewithname")
@@ -2077,8 +2082,14 @@ class AttributeErrorTests(unittest.TestCase):
             raise AttributeError
         mod2.__getattr__ = bare_raise
 
+        mod3 = ModuleType("bareraise")
+        def raise_custom(name):
+            raise AttributeError("custom")
+        mod3.__getattr__ = raise_custom
+
         self._test_generated_message(mod1, "missing3")
         self._test_generated_message(mod2, "missing4")
+        self._test_generated_message(mod3, "custom")
 
     # Note: name suggestion tests live in `test_traceback`.
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2069,7 +2069,11 @@ class AttributeErrorTests(unittest.TestCase):
 
         self._test_generated_message(RaiseWithName(), "missing1")
         self._test_generated_message(BareRaise(), "missing2")
-        self._test_generated_message(RaiseCustom(), "custom")
+
+        with self.assertRaises(AttributeError) as cm:
+            getattr(RaiseCustom(), "missing3")
+        self.assertEqual(str(cm.exception), "custom")
+
 
     def test_module_getattr_error_message(self):
         mod1 = ModuleType("raisewithname")
@@ -2089,7 +2093,10 @@ class AttributeErrorTests(unittest.TestCase):
 
         self._test_generated_message(mod1, "missing3")
         self._test_generated_message(mod2, "missing4")
-        self._test_generated_message(mod3, "custom")
+
+        with self.assertRaises(AttributeError) as cm:
+            getattr(mod3, "missing3")
+        self.assertEqual(str(cm.exception), "custom")
 
     # Note: name suggestion tests live in `test_traceback`.
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2048,12 +2048,6 @@ class AttributeErrorTests(unittest.TestCase):
             self.assertEqual("bluch", exc.name)
             self.assertEqual(obj, exc.obj)
 
-    def _test_generated_message(self, obj, name):
-        with self.assertRaises(AttributeError) as cm:
-            getattr(obj, name)
-        self.assertEqual(str(cm.exception),
-                         f"{obj!r} has no attribute {name!r}")
-
     def test_getattr_error_message(self):
         class RaiseWithName:
             def __getattr__(self, name):
@@ -2067,8 +2061,15 @@ class AttributeErrorTests(unittest.TestCase):
             def __getattr__(self, name):
                 raise AttributeError("custom")
 
-        self._test_generated_message(RaiseWithName(), "missing1")
-        self._test_generated_message(BareRaise(), "missing2")
+        with self.assertRaises(AttributeError) as cm:
+            getattr(RaiseWithName(), "missing1")
+        self.assertEqual(str(cm.exception),
+                         "'RaiseWithName' object has no attribute 'missing1'")
+
+        with self.assertRaises(AttributeError) as cm:
+            getattr(BareRaise(), "missing2")
+        self.assertEqual(str(cm.exception),
+                         "'BareRaise' object has no attribute 'missing2'")
 
         with self.assertRaises(AttributeError) as cm:
             getattr(RaiseCustom(), "missing3")
@@ -2090,8 +2091,15 @@ class AttributeErrorTests(unittest.TestCase):
             raise AttributeError("custom")
         mod3.__getattr__ = raise_custom
 
-        self._test_generated_message(mod1, "missing4")
-        self._test_generated_message(mod2, "missing5")
+        with self.assertRaises(AttributeError) as cm:
+            getattr(mod1, "missing4")
+        self.assertEqual(str(cm.exception),
+                         "module 'raisewithname' has no attribute 'missing4'")
+
+        with self.assertRaises(AttributeError) as cm:
+            getattr(mod2, "missing5")
+        self.assertEqual(str(cm.exception),
+                         "module 'bareraise' has no attribute 'missing5'")
 
         with self.assertRaises(AttributeError) as cm:
             getattr(mod3, "missing6")

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2162,6 +2162,15 @@ class AttributeErrorTests(unittest.TestCase):
         self.assertIs(cm.exception.obj, nameless_mod)
         self.assertEqual(cm.exception.name, "missing4")
 
+        nameless_mod = ModuleType("broken")
+        nameless_mod.__dict__["__name__"] = 10j
+        nameless_mod.__getattr__ = raise_with_name
+        with self.assertRaises(AttributeError) as cm:
+            getattr(nameless_mod, "missing4")
+        self.assertEqual(str(cm.exception), "module has no attribute 'missing4'")
+        self.assertIs(cm.exception.obj, nameless_mod)
+        self.assertEqual(cm.exception.name, "missing4")
+
     # Note: name suggestion tests live in `test_traceback`.
 
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2076,36 +2076,36 @@ class AttributeErrorTests(unittest.TestCase):
         self.assertEqual(str(cm.exception), "custom")
 
     def test_module_getattr_error_message(self):
-        mod1 = ModuleType("raisewithname")
+        raisewithname_mod = ModuleType("raisewithname")
         def raise_with_name(name):
             raise AttributeError(name)
-        mod1.__getattr__ = raise_with_name
+        raisewithname_mod.__getattr__ = raise_with_name
         with self.assertRaises(AttributeError) as cm:
-            getattr(mod1, "missing1")
+            getattr(raisewithname_mod, "missing1")
         self.assertEqual(str(cm.exception),
                          "module 'raisewithname' has no attribute 'missing1'")
 
-        mod2 = ModuleType("bareraise")
+        bareraise_mod = ModuleType("bareraise")
         def bare_raise(name):
             raise AttributeError
-        mod2.__getattr__ = bare_raise
+        bareraise_mod.__getattr__ = bare_raise
         with self.assertRaises(AttributeError) as cm:
-            getattr(mod2, "missing2")
+            getattr(bareraise_mod, "missing2")
         self.assertEqual(str(cm.exception),
                          "module 'bareraise' has no attribute 'missing2'")
 
-        mod3 = ModuleType("custom")
+        custom_mod = ModuleType("custom")
         def raise_custom(name):
             raise AttributeError("custom")
-        mod3.__getattr__ = raise_custom
+        custom_mod.__getattr__ = raise_custom
         with self.assertRaises(AttributeError) as cm:
-            getattr(mod3, "missing3")
+            getattr(custom_mod, "missing3")
         self.assertEqual(str(cm.exception), "custom")
 
-        mod4 = ModuleType.__new__(ModuleType)
-        mod4.__getattr__ = raise_with_name
+        nameless_mod = ModuleType.__new__(ModuleType)
+        nameless_mod.__getattr__ = raise_with_name
         with self.assertRaises(AttributeError) as cm:
-            getattr(mod4, "missing4")
+            getattr(nameless_mod, "missing4")
         self.assertEqual(str(cm.exception), "module has no attribute 'missing4'")
 
     # Note: name suggestion tests live in `test_traceback`.

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -10,6 +10,7 @@ import errno
 from codecs import BOM_UTF8
 from itertools import product
 from textwrap import dedent
+from types import ModuleType
 
 from test.support import (captured_stderr, check_impl_detail,
                           cpython_only, gc_collect,
@@ -2046,6 +2047,38 @@ class AttributeErrorTests(unittest.TestCase):
         except AttributeError as exc:
             self.assertEqual("bluch", exc.name)
             self.assertEqual(obj, exc.obj)
+
+    def _test_generated_message(self, obj, name):
+        with self.assertRaises(AttributeError) as cm:
+            getattr(obj, name)
+        self.assertEqual(str(cm.exception),
+                         f"{obj!r} has no attribute {name!r}")
+
+    def test_getattr_error_message(self):
+        class RaiseWithName:
+            def __getattr__(self, name):
+                raise AttributeError(name)
+
+        class BareRaise:
+            def __getattr__(self, name):
+                raise AttributeError
+
+        self._test_generated_message(RaiseWithName(), "missing1")
+        self._test_generated_message(BareRaise(), "missing2")
+
+    def test_module_getattr_attribute_error_message(self):
+        mod1 = ModuleType("raisewithname")
+        def raise_with_name(name):
+            raise AttributeError(name)
+        mod1.__getattr__ = raise_with_name
+
+        mod2 = ModuleType("bareraise")
+        def bare_raise(name):
+            raise AttributeError
+        mod2.__getattr__ = bare_raise
+
+        self._test_generated_message(mod1, "missing3")
+        self._test_generated_message(mod2, "missing4")
 
     # Note: name suggestion tests live in `test_traceback`.
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2054,16 +2054,16 @@ class AttributeErrorTests(unittest.TestCase):
                 raise AttributeError(name)
         with self.assertRaises(AttributeError) as cm:
             getattr(RaiseWithName(), "missing1")
-        self.assertEqual(str(cm.exception),
-                         "'RaiseWithName' object has no attribute 'missing1'")
+        self.assertRegex(str(cm.exception),
+                         r"'.+\.RaiseWithName' object has no attribute 'missing1'")
 
         class BareRaise:
             def __getattr__(self, name):
                 raise AttributeError
         with self.assertRaises(AttributeError) as cm:
             getattr(BareRaise(), "missing2")
-        self.assertEqual(str(cm.exception),
-                         "'BareRaise' object has no attribute 'missing2'")
+        self.assertRegex(str(cm.exception),
+                         r"'.+\.BareRaise' object has no attribute 'missing2'")
 
         class RaiseCustom:
             def __getattr__(self, name):

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2094,7 +2094,7 @@ class AttributeErrorTests(unittest.TestCase):
         self._test_generated_message(mod2, "missing4")
 
         with self.assertRaises(AttributeError) as cm:
-            getattr(mod3, "missing3")
+            getattr(mod3, "missing5")
         self.assertEqual(str(cm.exception), "custom")
 
     # Note: name suggestion tests live in `test_traceback`.

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2049,21 +2049,24 @@ class AttributeErrorTests(unittest.TestCase):
             self.assertEqual(obj, exc.obj)
 
     def test_getattr_error_message(self):
+        def fqn(type):
+            return f'{type.__module__}.{type.__qualname__}'
+
         class RaiseWithName:
             def __getattr__(self, name):
                 raise AttributeError(name)
         with self.assertRaises(AttributeError) as cm:
             getattr(RaiseWithName(), "missing1")
-        self.assertRegex(str(cm.exception),
-                         r"'.+\.RaiseWithName' object has no attribute 'missing1'")
+        self.assertEqual(str(cm.exception),
+                         f"'{fqn(RaiseWithName)}' object has no attribute 'missing1'")
 
         class BareRaise:
             def __getattr__(self, name):
                 raise AttributeError
         with self.assertRaises(AttributeError) as cm:
             getattr(BareRaise(), "missing2")
-        self.assertRegex(str(cm.exception),
-                         r"'.+\.BareRaise' object has no attribute 'missing2'")
+        self.assertEqual(str(cm.exception),
+                         f"'{fqn(BareRaise)}' object has no attribute 'missing2'")
 
         class RaiseCustom:
             def __getattr__(self, name):

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2053,23 +2053,23 @@ class AttributeErrorTests(unittest.TestCase):
             def __getattr__(self, name):
                 raise AttributeError(name)
 
-        class BareRaise:
-            def __getattr__(self, name):
-                raise AttributeError
-
-        class RaiseCustom:
-            def __getattr__(self, name):
-                raise AttributeError("custom")
-
         with self.assertRaises(AttributeError) as cm:
             getattr(RaiseWithName(), "missing1")
         self.assertEqual(str(cm.exception),
                          "'RaiseWithName' object has no attribute 'missing1'")
 
+        class BareRaise:
+            def __getattr__(self, name):
+                raise AttributeError
+
         with self.assertRaises(AttributeError) as cm:
             getattr(BareRaise(), "missing2")
         self.assertEqual(str(cm.exception),
                          "'BareRaise' object has no attribute 'missing2'")
+
+        class RaiseCustom:
+            def __getattr__(self, name):
+                raise AttributeError("custom")
 
         with self.assertRaises(AttributeError) as cm:
             getattr(RaiseCustom(), "missing3")
@@ -2080,29 +2080,26 @@ class AttributeErrorTests(unittest.TestCase):
         def raise_with_name(name):
             raise AttributeError(name)
         mod1.__getattr__ = raise_with_name
+        with self.assertRaises(AttributeError) as cm:
+            getattr(mod1, "missing1")
+        self.assertEqual(str(cm.exception),
+                         "module 'raisewithname' has no attribute 'missing1'")
 
         mod2 = ModuleType("bareraise")
         def bare_raise(name):
             raise AttributeError
         mod2.__getattr__ = bare_raise
+        with self.assertRaises(AttributeError) as cm:
+            getattr(mod2, "missing2")
+        self.assertEqual(str(cm.exception),
+                         "module 'bareraise' has no attribute 'missing2'")
 
         mod3 = ModuleType("custom")
         def raise_custom(name):
             raise AttributeError("custom")
         mod3.__getattr__ = raise_custom
-
         with self.assertRaises(AttributeError) as cm:
-            getattr(mod1, "missing4")
-        self.assertEqual(str(cm.exception),
-                         "module 'raisewithname' has no attribute 'missing4'")
-
-        with self.assertRaises(AttributeError) as cm:
-            getattr(mod2, "missing5")
-        self.assertEqual(str(cm.exception),
-                         "module 'bareraise' has no attribute 'missing5'")
-
-        with self.assertRaises(AttributeError) as cm:
-            getattr(mod3, "missing6")
+            getattr(mod3, "missing3")
         self.assertEqual(str(cm.exception), "custom")
 
     # Note: name suggestion tests live in `test_traceback`.

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2090,11 +2090,11 @@ class AttributeErrorTests(unittest.TestCase):
             raise AttributeError("custom")
         mod3.__getattr__ = raise_custom
 
-        self._test_generated_message(mod1, "missing3")
-        self._test_generated_message(mod2, "missing4")
+        self._test_generated_message(mod1, "missing4")
+        self._test_generated_message(mod2, "missing5")
 
         with self.assertRaises(AttributeError) as cm:
-            getattr(mod3, "missing5")
+            getattr(mod3, "missing6")
         self.assertEqual(str(cm.exception), "custom")
 
     # Note: name suggestion tests live in `test_traceback`.

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2082,7 +2082,7 @@ class AttributeErrorTests(unittest.TestCase):
             raise AttributeError
         mod2.__getattr__ = bare_raise
 
-        mod3 = ModuleType("bareraise")
+        mod3 = ModuleType("custom")
         def raise_custom(name):
             raise AttributeError("custom")
         mod3.__getattr__ = raise_custom

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2071,7 +2071,7 @@ class AttributeErrorTests(unittest.TestCase):
         self._test_generated_message(BareRaise(), "missing2")
         self._test_generated_message(RaiseCustom(), "custom")
 
-    def test_module_getattr_attribute_error_message(self):
+    def test_module_getattr_error_message(self):
         mod1 = ModuleType("raisewithname")
         def raise_with_name(name):
             raise AttributeError(name)

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2055,25 +2055,34 @@ class AttributeErrorTests(unittest.TestCase):
         class RaiseWithName:
             def __getattr__(self, name):
                 raise AttributeError(name)
+        obj = RaiseWithName()
         with self.assertRaises(AttributeError) as cm:
-            getattr(RaiseWithName(), "missing1")
+            getattr(obj, "missing1")
         self.assertEqual(str(cm.exception),
                          f"'{fqn(RaiseWithName)}' object has no attribute 'missing1'")
+        self.assertIs(cm.exception.obj, obj)
+        self.assertEqual(cm.exception.name, "missing1")
 
         class BareRaise:
             def __getattr__(self, name):
                 raise AttributeError
+        obj = BareRaise()
         with self.assertRaises(AttributeError) as cm:
-            getattr(BareRaise(), "missing2")
+            getattr(obj, "missing2")
         self.assertEqual(str(cm.exception),
                          f"'{fqn(BareRaise)}' object has no attribute 'missing2'")
+        self.assertIs(cm.exception.obj, obj)
+        self.assertEqual(cm.exception.name, "missing2")
 
         class RaiseCustom:
             def __getattr__(self, name):
                 raise AttributeError("custom")
+        obj = RaiseCustom()
         with self.assertRaises(AttributeError) as cm:
-            getattr(RaiseCustom(), "missing3")
+            getattr(obj, "missing3")
         self.assertEqual(str(cm.exception), "custom")
+        self.assertIs(cm.exception.obj, obj)
+        self.assertEqual(cm.exception.name, "missing3")
 
     def test_module_getattr_error_message(self):
         raisewithname_mod = ModuleType("raisewithname")
@@ -2084,6 +2093,8 @@ class AttributeErrorTests(unittest.TestCase):
             getattr(raisewithname_mod, "missing1")
         self.assertEqual(str(cm.exception),
                          "module 'raisewithname' has no attribute 'missing1'")
+        self.assertIs(cm.exception.obj, raisewithname_mod)
+        self.assertEqual(cm.exception.name, "missing1")
 
         bareraise_mod = ModuleType("bareraise")
         def bare_raise(name):
@@ -2093,6 +2104,8 @@ class AttributeErrorTests(unittest.TestCase):
             getattr(bareraise_mod, "missing2")
         self.assertEqual(str(cm.exception),
                          "module 'bareraise' has no attribute 'missing2'")
+        self.assertIs(cm.exception.obj, bareraise_mod)
+        self.assertEqual(cm.exception.name, "missing2")
 
         custom_mod = ModuleType("custom")
         def raise_custom(name):
@@ -2101,12 +2114,16 @@ class AttributeErrorTests(unittest.TestCase):
         with self.assertRaises(AttributeError) as cm:
             getattr(custom_mod, "missing3")
         self.assertEqual(str(cm.exception), "custom")
+        self.assertIs(cm.exception.obj, custom_mod)
+        self.assertEqual(cm.exception.name, "missing3")
 
         nameless_mod = ModuleType.__new__(ModuleType)
         nameless_mod.__getattr__ = raise_with_name
         with self.assertRaises(AttributeError) as cm:
             getattr(nameless_mod, "missing4")
         self.assertEqual(str(cm.exception), "module has no attribute 'missing4'")
+        self.assertIs(cm.exception.obj, nameless_mod)
+        self.assertEqual(cm.exception.name, "missing4")
 
     # Note: name suggestion tests live in `test_traceback`.
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2102,6 +2102,12 @@ class AttributeErrorTests(unittest.TestCase):
             getattr(mod3, "missing3")
         self.assertEqual(str(cm.exception), "custom")
 
+        mod4 = ModuleType.__new__(ModuleType)
+        mod4.__getattr__ = raise_with_name
+        with self.assertRaises(AttributeError) as cm:
+            getattr(mod4, "missing4")
+        self.assertEqual(str(cm.exception), "module has no attribute 'missing4'")
+
     # Note: name suggestion tests live in `test_traceback`.
 
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2084,6 +2084,42 @@ class AttributeErrorTests(unittest.TestCase):
         self.assertIs(cm.exception.obj, obj)
         self.assertEqual(cm.exception.name, "missing3")
 
+    def test_class_getattr_error_message(self):
+        def fqn(type):
+            return f'{type.__module__}.{type.__qualname__}'
+
+        class MetaclassRaiseWithName(type):
+            def __getattr__(self, name):
+                raise AttributeError(name)
+        cls = MetaclassRaiseWithName("spam", (), {})
+        with self.assertRaises(AttributeError) as cm:
+            getattr(cls, "missing1")
+        self.assertEqual(str(cm.exception),
+                         f"type object '{fqn(cls)}' has no attribute 'missing1'")
+        self.assertIs(cm.exception.obj, cls)
+        self.assertEqual(cm.exception.name, "missing1")
+
+        class MetaclassBareRaise(type):
+            def __getattr__(self, name):
+                raise AttributeError
+        cls = MetaclassBareRaise("eggs", (), {})
+        with self.assertRaises(AttributeError) as cm:
+            getattr(cls, "missing2")
+        self.assertEqual(str(cm.exception),
+                         f"type object '{fqn(cls)}' has no attribute 'missing2'")
+        self.assertIs(cm.exception.obj, cls)
+        self.assertEqual(cm.exception.name, "missing2")
+
+        class MetaclassRaiseCustom(type):
+            def __getattr__(self, name):
+                raise AttributeError("custom")
+        cls = MetaclassRaiseCustom("ham", (), {})
+        with self.assertRaises(AttributeError) as cm:
+            getattr(cls, "missing3")
+        self.assertEqual(str(cm.exception), "custom")
+        self.assertIs(cm.exception.obj, cls)
+        self.assertEqual(cm.exception.name, "missing3")
+
     def test_module_getattr_error_message(self):
         raisewithname_mod = ModuleType("raisewithname")
         def raise_with_name(name):

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2052,7 +2052,6 @@ class AttributeErrorTests(unittest.TestCase):
         class RaiseWithName:
             def __getattr__(self, name):
                 raise AttributeError(name)
-
         with self.assertRaises(AttributeError) as cm:
             getattr(RaiseWithName(), "missing1")
         self.assertEqual(str(cm.exception),
@@ -2061,7 +2060,6 @@ class AttributeErrorTests(unittest.TestCase):
         class BareRaise:
             def __getattr__(self, name):
                 raise AttributeError
-
         with self.assertRaises(AttributeError) as cm:
             getattr(BareRaise(), "missing2")
         self.assertEqual(str(cm.exception),
@@ -2070,7 +2068,6 @@ class AttributeErrorTests(unittest.TestCase):
         class RaiseCustom:
             def __getattr__(self, name):
                 raise AttributeError("custom")
-
         with self.assertRaises(AttributeError) as cm:
             getattr(RaiseCustom(), "missing3")
         self.assertEqual(str(cm.exception), "custom")

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-16-02-50-01.gh-issue-153785.fJqPKC.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-16-02-50-01.gh-issue-153785.fJqPKC.rst
@@ -1,0 +1,4 @@
+The default error message is now generated from ``name`` and
+``obj`` attributes of :exc:`AttributeError` when both are set and
+the exception was constructed with no positional arguments, or with
+a single positional argument equal to :attr:`name`. Patch by Bartosz Sławecki.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-16-02-50-01.gh-issue-153785.fJqPKC.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-16-02-50-01.gh-issue-153785.fJqPKC.rst
@@ -1,4 +1,4 @@
-The default error message is now generated from ``name`` and
-``obj`` attributes of :exc:`AttributeError` when both are set and
-the exception was constructed with no positional arguments, or with
-a single positional argument equal to :attr:`name`. Patch by Bartosz Sławecki.
+The default error message is now generated from ``name`` and ``obj`` attributes
+of :exc:`AttributeError` when both are set and the exception was constructed with
+no positional arguments, or with a single positional argument equal to :attr:`name`.
+Patch by Bartosz Sławecki.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-16-02-50-01.gh-issue-153785.fJqPKC.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-16-02-50-01.gh-issue-153785.fJqPKC.rst
@@ -1,4 +1,4 @@
-The default error message is now generated from ``name`` and ``obj`` attributes
-of :exc:`AttributeError` when both are set and the exception was constructed with
+:exc:`AttributeError`: The default error message is now generated from ``name``
+and ``obj`` attributes when both are set and the exception was constructed with
 no positional arguments, or with a single positional argument equal to ``name``.
 Patch by Bartosz Sławecki.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-16-02-50-01.gh-issue-153785.fJqPKC.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-16-02-50-01.gh-issue-153785.fJqPKC.rst
@@ -1,4 +1,4 @@
 The default error message is now generated from ``name`` and ``obj`` attributes
 of :exc:`AttributeError` when both are set and the exception was constructed with
-no positional arguments, or with a single positional argument equal to :attr:`name`.
+no positional arguments, or with a single positional argument equal to ``name``.
 Patch by Bartosz Sławecki.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2722,7 +2722,6 @@ AttributeError_str(PyObject *op)
     }
     Py_END_CRITICAL_SECTION();
     return ret;
-
 }
 
 static int

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2738,6 +2738,9 @@ AttributeError_str(PyObject *op)
         } else {
             result = PyUnicode_FromFormat("module has no attribute '%U'", name);
         }
+    } else if (PyType_Check(obj)) {
+        result = PyUnicode_FromFormat("type object '%N' has no attribute '%U'",
+                                      _PyType_CAST(obj), name);
     } else {
         result = PyUnicode_FromFormat("'%T' object has no attribute '%U'",
                                       obj, name);

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2743,18 +2743,18 @@ AttributeError_str(PyObject *op)
             goto done;
         }
         if (modname && PyUnicode_Check(modname)) {
-            result = PyUnicode_FromFormat("module '%U' has no attribute '%U'",
+            result = PyUnicode_FromFormat("module %R has no attribute %R",
                                           modname, name);
             Py_DECREF(modname);
         } else {
             Py_XDECREF(modname);
-            result = PyUnicode_FromFormat("module has no attribute '%U'", name);
+            result = PyUnicode_FromFormat("module has no attribute %R", name);
         }
     } else if (PyType_Check(obj)) {
-        result = PyUnicode_FromFormat("type object '%N' has no attribute '%U'",
+        result = PyUnicode_FromFormat("type object '%N' has no attribute %R",
                                       obj, name);
     } else {
-        result = PyUnicode_FromFormat("'%T' object has no attribute '%U'",
+        result = PyUnicode_FromFormat("'%T' object has no attribute %R",
                                       obj, name);
     }
 done:

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2706,18 +2706,14 @@ static PyObject *
 AttributeError_str(PyObject *op)
 {
     PyAttributeErrorObject *self = PyAttributeErrorObject_CAST(op);
-    if (
-        self->obj
-        && self->name
-        && (!PyTuple_GET_SIZE(self->args)
-            || (PyTuple_GET_SIZE(self->args) == 1
-                && PyUnicode_Equal(PyTuple_GET_ITEM(self->args, 0), self->name))
-        )
-    ) {
-        return PyUnicode_FromFormat("%R has no attribute '%U'",
-                                    self->obj, self->name);
+    if (!self->obj || !self->name || PyTuple_GET_SIZE(self->args) > 1
+        || (PyTuple_GET_SIZE(self->args) == 1 &&
+            !PyUnicode_Equal(PyTuple_GET_ITEM(self->args, 0), self->name)))
+    {
+        return BaseException_str(op);
     }
-    return BaseException_str(op);
+    return PyUnicode_FromFormat("%R has no attribute '%U'",
+                                self->obj, self->name);
 }
 
 static int

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2708,6 +2708,7 @@ AttributeError_str(PyObject *op)
     PyAttributeErrorObject *self = PyAttributeErrorObject_CAST(op);
     if (
         self->obj
+        && self->name
         && (!PyTuple_GET_SIZE(self->args)
         || (PyTuple_GET_SIZE(self->args) == 1
             && PyUnicode_Equal(PyTuple_GET_ITEM(self->args, 0), self->name))

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2738,8 +2738,8 @@ AttributeError_str(PyObject *op)
             result = PyUnicode_FromFormat("module has no attribute '%U'", name);
         }
     } else {
-        result = PyUnicode_FromFormat("'%.200s' object has no attribute '%U'",
-                                      Py_TYPE(obj)->tp_name, name);
+        result = PyUnicode_FromFormat("'%T' object has no attribute '%U'",
+                                      obj, name);
     }
     Py_DECREF(obj);
     Py_DECREF(name);

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2709,12 +2709,13 @@ AttributeError_str(PyObject *op)
     PyObject *arg, *obj = NULL, *name;
 
     Py_BEGIN_CRITICAL_SECTION(self);
-    if (self->obj && self->name && PyUnicode_Check(self->name)
+    if (
+        self->obj && self->name && PyUnicode_Check(self->name)
         && ((PyTuple_GET_SIZE(self->args) == 1
              && PyUnicode_Check(arg = PyTuple_GET_ITEM(self->args, 0))
              && PyUnicode_Equal(arg, self->name))
-            || PyTuple_GET_SIZE(self->args) == 0))
-    {
+            || PyTuple_GET_SIZE(self->args) == 0)
+    ) {
         obj = Py_NewRef(self->obj);
         name = Py_NewRef(self->name);
     }

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2706,23 +2706,29 @@ static PyObject *
 AttributeError_str(PyObject *op)
 {
     PyAttributeErrorObject *self = PyAttributeErrorObject_CAST(op);
-    PyObject *ret = NULL, *arg;
+    PyObject *arg, *obj = NULL, *name;
+
     Py_BEGIN_CRITICAL_SECTION(self);
-    if (
-        self->obj && self->name && PyUnicode_Check(self->name)
+    if (self->obj && self->name && PyUnicode_Check(self->name)
         && ((PyTuple_GET_SIZE(self->args) == 1
              && PyUnicode_Check(arg = PyTuple_GET_ITEM(self->args, 0))
              && PyUnicode_Equal(arg, self->name))
-            || PyTuple_GET_SIZE(self->args) == 0)
-    ) {
-        ret = PyUnicode_FromFormat("%R has no attribute '%U'",
-                                   self->obj, self->name);
+            || PyTuple_GET_SIZE(self->args) == 0))
+    {
+        obj = Py_NewRef(self->obj);
+        name = Py_NewRef(self->name);
     }
     Py_END_CRITICAL_SECTION();
-    if (!ret) {
-        ret = BaseException_str(op);
+
+    if (!obj) {
+        return BaseException_str(op);
     }
-    return ret;
+
+    PyObject *result = PyUnicode_FromFormat("%R has no attribute '%U'",
+                                            obj, name);
+    Py_DECREF(obj);
+    Py_DECREF(name);
+    return result;
 }
 
 static int

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2710,10 +2710,10 @@ AttributeError_str(PyObject *op)
     Py_BEGIN_CRITICAL_SECTION(self);
     if (
         !self->obj || !self->name || !PyUnicode_Check(self->name)
-        || PyTuple_GET_SIZE(self->args) > 1
         || (PyTuple_GET_SIZE(self->args) == 1
             && PyUnicode_Check(arg = PyTuple_GET_ITEM(self->args, 0))
             && !PyUnicode_Equal(arg, self->name))
+        || PyTuple_GET_SIZE(self->args) != 0
     ) {
         ret = BaseException_str(op);
     }

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2706,21 +2706,22 @@ static PyObject *
 AttributeError_str(PyObject *op)
 {
     PyAttributeErrorObject *self = PyAttributeErrorObject_CAST(op);
-    PyObject *ret, *arg;
+    PyObject *ret = NULL, *arg;
     Py_BEGIN_CRITICAL_SECTION(self);
     if (
-        !self->obj || !self->name || !PyUnicode_Check(self->name)
-        || (PyTuple_GET_SIZE(self->args) == 1
-            && PyUnicode_Check(arg = PyTuple_GET_ITEM(self->args, 0))
-            && !PyUnicode_Equal(arg, self->name))
-        || PyTuple_GET_SIZE(self->args) != 0
+        self->obj && self->name && PyUnicode_Check(self->name)
+        && ((PyTuple_GET_SIZE(self->args) == 1
+             && PyUnicode_Check(arg = PyTuple_GET_ITEM(self->args, 0))
+             && PyUnicode_Equal(arg, self->name))
+            || PyTuple_GET_SIZE(self->args) == 0)
     ) {
-        ret = BaseException_str(op);
-    } else {
         ret = PyUnicode_FromFormat("%R has no attribute '%U'",
                                    self->obj, self->name);
     }
     Py_END_CRITICAL_SECTION();
+    if (!ret) {
+        ret = BaseException_str(op);
+    }
     return ret;
 }
 

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2718,7 +2718,7 @@ AttributeError_str(PyObject *op)
         ret = BaseException_str(op);
     } else {
         ret = PyUnicode_FromFormat("%R has no attribute '%U'",
-                                    self->obj, self->name);
+                                   self->obj, self->name);
     }
     Py_END_CRITICAL_SECTION();
     return ret;

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2738,8 +2738,8 @@ AttributeError_str(PyObject *op)
             result = PyUnicode_FromFormat("module has no attribute '%U'", name);
         }
     } else {
-        result = PyUnicode_FromFormat("'%T' object has no attribute '%U'",
-                                      obj, name);
+        result = PyUnicode_FromFormat("'%.200s' object has no attribute '%U'",
+                                      Py_TYPE(obj)->tp_name, name);
     }
     Py_DECREF(obj);
     Py_DECREF(name);

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -14,6 +14,7 @@
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"      // struct _PyErr_SetRaisedException
 #include "pycore_tuple.h"         // _PyTuple_FromPair
+#include "pycore_unicodeobject.h" // _PyUnicode_Equal()
 
 #include "osdefs.h"               // SEP
 #include "clinic/exceptions.c.h"
@@ -2713,7 +2714,7 @@ AttributeError_str(PyObject *op)
         self->obj && self->name && PyUnicode_Check(self->name)
         && ((PyTuple_GET_SIZE(self->args) == 1
              && PyUnicode_Check(arg = PyTuple_GET_ITEM(self->args, 0))
-             && PyUnicode_Equal(arg, self->name))
+             && _PyUnicode_Equal(arg, self->name))
             || PyTuple_GET_SIZE(self->args) == 0)
     ) {
         obj = Py_NewRef(self->obj);

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2708,7 +2708,14 @@ static PyObject *
 AttributeError_str(PyObject *op)
 {
     PyAttributeErrorObject *self = PyAttributeErrorObject_CAST(op);
-    PyObject *arg, *obj = NULL, *name;
+    PyObject *arg;  // borrowed ref
+    PyObject *obj = NULL, *name = NULL;
+
+     /* .name and .obj are set automatically when attribute lookup fails, so
+        synthesize a more informative message from them when the caller
+        didn't supply a meaningful one of their own -- that is, when args is
+        empty, or contains only the attribute name.  Otherwise, use the
+        message the caller gave. */
 
     Py_BEGIN_CRITICAL_SECTION(self);
     if (

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2702,6 +2702,23 @@ AttributeError_dealloc(PyObject *self)
     Py_TYPE(self)->tp_free(self);
 }
 
+static PyObject *
+AttributeError_str(PyObject *op)
+{
+    PyAttributeErrorObject *self = PyAttributeErrorObject_CAST(op);
+    if (
+        self->obj
+        && (!PyTuple_GET_SIZE(self->args)
+        || (PyTuple_GET_SIZE(self->args) == 1
+            && PyUnicode_Equal(PyTuple_GET_ITEM(self->args, 0), self->name))
+        )
+    ) {
+        return PyUnicode_FromFormat("%R has no attribute '%U'",
+                                    self->obj, self->name);
+    }
+    return BaseException_str(op);
+}
+
 static int
 AttributeError_traverse(PyObject *op, visitproc visit, void *arg)
 {
@@ -2770,7 +2787,7 @@ static PyMethodDef AttributeError_methods[] = {
 ComplexExtendsException(PyExc_Exception, AttributeError,
                         AttributeError, 0,
                         AttributeError_methods, AttributeError_members,
-                        0, BaseException_str, 0, "Attribute not found.");
+                        0, AttributeError_str, 0, "Attribute not found.");
 
 /*
  *    SyntaxError extends Exception

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2726,8 +2726,21 @@ AttributeError_str(PyObject *op)
         return BaseException_str(op);  /* re-acquires lock */
     }
 
-    PyObject *result = PyUnicode_FromFormat("%.200R has no attribute '%U'",
-                                            obj, name);
+    PyObject *result;
+    if (PyModule_Check(obj)) {
+        PyModuleObject *mod = _PyModule_CAST(obj);
+        /* In a typical case, module's __name__ is examined instead. */
+        if (mod->md_name) {
+            result = PyUnicode_FromFormat("module '%U' has no attribute '%U'",
+                                          mod->md_name,
+                                          name);
+        } else {
+            result = PyUnicode_FromFormat("module has no attribute '%U'", name);
+        }
+    } else {
+        result = PyUnicode_FromFormat("'%.200s' object has no attribute '%U'",
+                                      Py_TYPE(obj)->tp_name, name);
+    }
     Py_DECREF(obj);
     Py_DECREF(name);
     return result;

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -11,6 +11,7 @@
 #include "pycore_exceptions.h"    // struct _Py_exc_state
 #include "pycore_initconfig.h"
 #include "pycore_modsupport.h"    // _PyArg_NoKeywords()
+#include "pycore_moduleobject.h"  // _PyModule_CAST()
 #include "pycore_object.h"
 #include "pycore_pyerrors.h"      // struct _PyErr_SetRaisedException
 #include "pycore_tuple.h"         // _PyTuple_FromPair

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2710,8 +2710,8 @@ AttributeError_str(PyObject *op)
         self->obj
         && self->name
         && (!PyTuple_GET_SIZE(self->args)
-        || (PyTuple_GET_SIZE(self->args) == 1
-            && PyUnicode_Equal(PyTuple_GET_ITEM(self->args, 0), self->name))
+            || (PyTuple_GET_SIZE(self->args) == 1
+                && PyUnicode_Equal(PyTuple_GET_ITEM(self->args, 0), self->name))
         )
     ) {
         return PyUnicode_FromFormat("%R has no attribute '%U'",

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2722,7 +2722,7 @@ AttributeError_str(PyObject *op)
     Py_END_CRITICAL_SECTION();
 
     if (!obj) {
-        return BaseException_str(op);
+        return BaseException_str(op);  /* re-acquires lock */
     }
 
     PyObject *result = PyUnicode_FromFormat("%.200R has no attribute '%U'",

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2741,16 +2741,17 @@ AttributeError_str(PyObject *op)
         if (PyDict_GetItemRef(mod->md_dict, &_Py_ID(__name__), &modname) < 0) {
             goto error;
         }
-        if (modname) {
+        if (modname && PyUnicode_Check(modname)) {
             result = PyUnicode_FromFormat("module '%U' has no attribute '%U'",
                                           modname, name);
             Py_DECREF(modname);
         } else {
+            Py_XDECREF(modname);
             result = PyUnicode_FromFormat("module has no attribute '%U'", name);
         }
     } else if (PyType_Check(obj)) {
         result = PyUnicode_FromFormat("type object '%N' has no attribute '%U'",
-                                      _PyType_CAST(obj), name);
+                                      obj, name);
     } else {
         result = PyUnicode_FromFormat("'%T' object has no attribute '%U'",
                                       obj, name);

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2725,7 +2725,7 @@ AttributeError_str(PyObject *op)
         return BaseException_str(op);
     }
 
-    PyObject *result = PyUnicode_FromFormat("%R has no attribute '%U'",
+    PyObject *result = PyUnicode_FromFormat("%.200R has no attribute '%U'",
                                             obj, name);
     Py_DECREF(obj);
     Py_DECREF(name);

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2727,14 +2727,17 @@ AttributeError_str(PyObject *op)
         return BaseException_str(op);  /* re-acquires lock */
     }
 
-    PyObject *result;
+    PyObject *result = NULL;
     if (PyModule_Check(obj)) {
         PyModuleObject *mod = _PyModule_CAST(obj);
-        /* In a typical case, module's __name__ is examined instead. */
-        if (mod->md_name) {
+        PyObject *modname;
+        if (PyDict_GetItemRef(mod->md_dict, &_Py_ID(__name__), &modname) < 0) {
+            goto error;
+        }
+        if (modname) {
             result = PyUnicode_FromFormat("module '%U' has no attribute '%U'",
-                                          mod->md_name,
-                                          name);
+                                          modname, name);
+            Py_DECREF(modname);
         } else {
             result = PyUnicode_FromFormat("module has no attribute '%U'", name);
         }
@@ -2745,6 +2748,7 @@ AttributeError_str(PyObject *op)
         result = PyUnicode_FromFormat("'%T' object has no attribute '%U'",
                                       obj, name);
     }
+error:
     Py_DECREF(obj);
     Py_DECREF(name);
     return result;

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2716,8 +2716,7 @@ AttributeError_str(PyObject *op)
         || PyTuple_GET_SIZE(self->args) != 0
     ) {
         ret = BaseException_str(op);
-    }
-    else {
+    } else {
         ret = PyUnicode_FromFormat("%R has no attribute '%U'",
                                     self->obj, self->name);
     }

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2706,14 +2706,24 @@ static PyObject *
 AttributeError_str(PyObject *op)
 {
     PyAttributeErrorObject *self = PyAttributeErrorObject_CAST(op);
-    if (!self->obj || !self->name || PyTuple_GET_SIZE(self->args) > 1
+    PyObject *ret, *arg;
+    Py_BEGIN_CRITICAL_SECTION(self);
+    if (
+        !self->obj || !self->name || !PyUnicode_Check(self->name)
+        || PyTuple_GET_SIZE(self->args) > 1
         || (PyTuple_GET_SIZE(self->args) == 1
-            && !PyUnicode_Equal(PyTuple_GET_ITEM(self->args, 0), self->name)))
-    {
-        return BaseException_str(op);
+            && PyUnicode_Check(arg = PyTuple_GET_ITEM(self->args, 0))
+            && !PyUnicode_Equal(arg, self->name))
+    ) {
+        ret = BaseException_str(op);
     }
-    return PyUnicode_FromFormat("%R has no attribute '%U'",
-                                self->obj, self->name);
+    else {
+        ret = PyUnicode_FromFormat("%R has no attribute '%U'",
+                                    self->obj, self->name);
+    }
+    Py_END_CRITICAL_SECTION();
+    return ret;
+
 }
 
 static int

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2707,8 +2707,8 @@ AttributeError_str(PyObject *op)
 {
     PyAttributeErrorObject *self = PyAttributeErrorObject_CAST(op);
     if (!self->obj || !self->name || PyTuple_GET_SIZE(self->args) > 1
-        || (PyTuple_GET_SIZE(self->args) == 1 &&
-            !PyUnicode_Equal(PyTuple_GET_ITEM(self->args, 0), self->name)))
+        || (PyTuple_GET_SIZE(self->args) == 1
+            && !PyUnicode_Equal(PyTuple_GET_ITEM(self->args, 0), self->name)))
     {
         return BaseException_str(op);
     }

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2731,6 +2731,7 @@ AttributeError_str(PyObject *op)
     Py_END_CRITICAL_SECTION();
 
     if (!obj) {
+        assert(!name);
         return BaseException_str(op);  /* re-acquires lock */
     }
 
@@ -2739,7 +2740,7 @@ AttributeError_str(PyObject *op)
         PyModuleObject *mod = _PyModule_CAST(obj);
         PyObject *modname;
         if (PyDict_GetItemRef(mod->md_dict, &_Py_ID(__name__), &modname) < 0) {
-            goto error;
+            goto done;
         }
         if (modname && PyUnicode_Check(modname)) {
             result = PyUnicode_FromFormat("module '%U' has no attribute '%U'",
@@ -2756,7 +2757,7 @@ AttributeError_str(PyObject *op)
         result = PyUnicode_FromFormat("'%T' object has no attribute '%U'",
                                       obj, name);
     }
-error:
+done:
     Py_DECREF(obj);
     Py_DECREF(name);
     return result;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
I think this is the best place to do this. We do the same trick in `KeyError`.

This also fixed issue #143811 that motivated the current one.

<!-- gh-issue-number: gh-153785 -->
* Issue: gh-153785
<!-- /gh-issue-number -->
