### PR TITLE
gh-153792: Fix urllib.request digest auth crash on a malformed challenge

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -1722,6 +1722,31 @@ class HandlerTests(unittest.TestCase):
         opener.add_handler(http_handler)
         self.assertRaises(ValueError, opener.open, "http://www.example.com")
 
+    def test_digest_auth_malformed_challenge(self):
+        # A malformed WWW-Authenticate digest challenge must make the handler
+        # decline (return None) rather than crash with a raw exception.
+        handler = urllib.request.HTTPDigestAuthHandler(None)
+        req = Request("http://www.example.com/")
+        for challenge in (
+            "Digest realm",   # parse_keqv_list: no '=' -> ValueError
+            "Digest realm=",  # parse_keqv_list: empty value -> IndexError
+            "Digest",         # auth.split(' ', 1) -> ValueError
+        ):
+            with self.subTest(challenge=challenge):
+                self.assertIsNone(handler.retry_http_digest_auth(req, challenge))
+
+        # Through the public opener.open() path the raw exception must not
+        # escape; the unhandled 401 surfaces as HTTPError instead.
+        opener = OpenerDirector()
+        opener.add_handler(urllib.request.HTTPDigestAuthHandler(None))
+        opener.add_handler(urllib.request.HTTPDefaultErrorHandler())
+        opener.add_handler(MockHTTPHandlerRedirect(
+            401, "WWW-Authenticate: Digest realm\r\n\r\n"))
+        with self.assertRaises(urllib.error.HTTPError) as cm:
+            opener.open("http://www.example.com/")
+        self.assertEqual(cm.exception.code, 401)
+        cm.exception.close()
+
     def test_unsupported_auth_basic_handler(self):
         # While using BasicAuthHandler
         opener = OpenerDirector()

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1093,8 +1093,12 @@ class AbstractDigestAuthHandler:
                                  " the following scheme: '%s'" % scheme)
 
     def retry_http_digest_auth(self, req, auth):
-        token, challenge = auth.split(' ', 1)
-        chal = parse_keqv_list(filter(None, parse_http_list(challenge)))
+        try:
+            token, challenge = auth.split(' ', 1)
+            chal = parse_keqv_list(filter(None, parse_http_list(challenge)))
+        except (ValueError, IndexError):
+            # A malformed challenge cannot be used to authenticate.
+            return None
         auth = self.get_authorization(req, chal)
         if auth:
             auth_val = 'Digest %s' % auth

--- a/Misc/NEWS.d/next/Library/2026-07-16-10-00-00.gh-issue-153792.Hs9Mk4.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-16-10-00-00.gh-issue-153792.Hs9Mk4.rst
@@ -1,0 +1,3 @@
+Fix :class:`urllib.request.HTTPDigestAuthHandler` raising :exc:`ValueError` or
+:exc:`IndexError` for a malformed ``WWW-Authenticate`` digest challenge. Patch
+by tonghuaroot.


### PR DESCRIPTION
A malformed server-controlled `WWW-Authenticate: Digest` challenge made `HTTPDigestAuthHandler` raise a bare `ValueError` or `IndexError` out of `urlopen()`. Guard the two parse statements in `retry_http_digest_auth` and decline (return `None`) a challenge that cannot be parsed, as the handler already does for a 40x it cannot handle. `get_authorization` stays outside the guard so a real bug there is not masked.

<!-- gh-issue-number: gh-153792 -->
* Issue: gh-153792
<!-- /gh-issue-number -->
