### PR TITLE
gh-153797: Fix possible crash when re-importing extension modules after OOM

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-16-10-12-32.gh-issue-153797.VqQ8r1.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-16-10-12-32.gh-issue-153797.VqQ8r1.rst
@@ -1,0 +1,2 @@
+Fix a crash that could occur after an out-of-memory error when re-importing
+an extension module.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-16-10-12-32.gh-issue-153797.VqQ8r1.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-16-10-12-32.gh-issue-153797.VqQ8r1.rst
@@ -1,2 +1,1 @@
-Fix a crash that could occur after an out-of-memory error when re-importing
-an extension module.
+Fix a fatal error in debug builds when re-importing a single-phase extension module fails with :exc:MemoryError: the cleanup path removed the module from :data:sys.modules while the exception was still set.

--- a/Python/import.c
+++ b/Python/import.c
@@ -2008,7 +2008,7 @@ reload_singlephase_extension(PyThreadState *tstate,
 
     Py_ssize_t index = _get_cached_module_index(cached);
     if (_modules_by_index_set(tstate->interp, index, mod) < 0) {
-        PyMapping_DelItem(modules, info->name);
+        remove_module(tstate, info->name);
         Py_DECREF(mod);
         return NULL;
     }


### PR DESCRIPTION
When _modules_by_index_set() fails while re-importing a legacy single-phase extension module, it may leave a MemoryError pending. The cleanup path previously called PyMapping_DelItem() with that exception still set, causing debug builds to abort when the deletion succeeded.
Use the existing remove_module() helper to preserve the original exception while removing the partially initialized module from sys.modules. This keeps the cleanup consistent with other import failure paths and prevents the interpreter crash.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-153797 -->
* Issue: gh-153797
<!-- /gh-issue-number -->
