### PR TITLE
gh-141276: Avoid compiling zipimport source in get_filename

### DIFF
--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -827,7 +827,7 @@ class CmdLineTest(unittest.TestCase):
                 '-Werror:::test_pkg.__main__',
                 os.path.join(zip_name, 'test_pkg')
             )
-            self.assertEqual(err.count(b': SyntaxWarning: '), 12)
+            self.assertEqual(err.count(b': SyntaxWarning: '), 6)
 
 
 def tearDownModule():

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -9,6 +9,7 @@ import struct
 import time
 import unittest
 import unittest.mock
+import warnings
 
 from test import support
 from test.support import import_helper
@@ -228,6 +229,23 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
     def testPy(self):
         files = {TESTMOD + ".py": test_src}
         self.doTest(".py", files, TESTMOD)
+
+    def test_syntax_warning(self):
+        files = {TESTMOD + ".py": "x = 1 is 1\n"}
+        self.makeZip(files)
+        zi = zipimport.zipimporter(TEMP_ZIP)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", SyntaxWarning)
+            spec = zi.find_spec(TESTMOD)
+            self.assertIsNotNone(spec)
+            self.assertEqual(caught, [])
+
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+
+        self.assertEqual(len(caught), 1)
+        self.assertIsInstance(caught[0].message, SyntaxWarning)
 
     def testPyc(self):
         files = {TESTMOD + pyc_ext: test_pyc}

--- a/Lib/test/test_zipimport_support.py
+++ b/Lib/test/test_zipimport_support.py
@@ -253,7 +253,7 @@ class ZipSupportTests(unittest.TestCase):
                 warnings.filterwarnings('error', module='test_mod')
                 import test_pkg.test_mod
             self.assertEqual(sorted(wm.lineno for wm in wlog),
-                             sorted([4, 7, 10, 13, 14, 21]*2))
+                             [4, 7, 10, 13, 14, 21])
             filename = test_pkg.test_mod.__file__
             for wm in wlog:
                 self.assertEqual(wm.filename, filename)

--- a/Lib/zipimport.py
+++ b/Lib/zipimport.py
@@ -163,7 +163,8 @@ class zipimporter(_bootstrap_external._LoaderBasics):
         """
         # Deciding the filename requires working out where the code
         # would come from if the module was actually loaded
-        code, ispackage, modpath = _get_module_code(self, fullname)
+        _, _, modpath = _get_module_code(
+            self, fullname, compile_source=False)
         return modpath
 
 
@@ -793,9 +794,9 @@ def _get_pyc_source(self, path):
         return _get_data(self.archive, toc_entry)
 
 
-# Get the code object associated with the module specified by
-# 'fullname'.
-def _get_module_code(self, fullname):
+# Get the code object associated with the module specified by 'fullname'.
+# If compile_source is false, return None for source code without compiling it.
+def _get_module_code(self, fullname, *, compile_source=True):
     path = _get_module_path(self, fullname)
     import_error = None
     for suffix, isbytecode, ispackage in _zip_searchorder:
@@ -815,6 +816,8 @@ def _get_module_code(self, fullname):
                 except ImportError as exc:
                     import_error = exc
             else:
+                if not compile_source:
+                    return None, ispackage, modpath
                 code = _compile_source(modpath, data, fullname)
             if code is None:
                 # bad magic number or non-matching mtime

--- a/Misc/NEWS.d/next/Library/2026-07-15-21-45-33.gh-issue-141276.xH7qP2.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-15-21-45-33.gh-issue-141276.xH7qP2.rst
@@ -1,0 +1,2 @@
+Fix duplicate :exc:`SyntaxWarning` messages when importing source modules
+from ZIP archives.


### PR DESCRIPTION
## Summary

- avoid compiling zipimport source while resolving a module filename
- preserve bytecode validation and source fallback behavior
- add a regression test and a NEWS entry

## Root cause

`zipimporter.get_filename()` called `_get_module_code()`, which compiled source while import machinery was creating the module spec. Module execution then compiled the same source again.

## Tests

- `./python.exe -m test test_zipimport -m test_syntax_warning -m testBadMagic -m testBadMTime`
- `./python.exe -m test test_zipimport`

Refs #141276

## Duplicate-work check

No open or merged pull request referencing #141276 was found before submission.

## AI assistance

OpenAI Codex assisted with investigation, implementation, testing, and review.


<!-- gh-issue-number: gh-141276 -->
* Issue: gh-141276
<!-- /gh-issue-number -->

