### PR TITLE
gh-153803: Raise ResponseError for a malformed struct in xmlrpc.client

### DIFF
--- a/Lib/test/test_xmlrpc.py
+++ b/Lib/test/test_xmlrpc.py
@@ -252,6 +252,13 @@ class XMLRPCTestCase(unittest.TestCase):
                 '</struct></value></param></params>')
         self.assertRaises(ResponseError, xmlrpclib.loads, data)
 
+    def test_loads_malformed_struct(self):
+        ResponseError = xmlrpclib.ResponseError
+        data = ('<params><param><value><struct>'
+                '<member><name>k</name></member>'
+                '</struct></value></param></params>')
+        self.assertRaises(ResponseError, xmlrpclib.loads, data)
+
     def check_loads(self, s, value, **kwargs):
         dump = '<params><param><value>%s</value></param></params>' % s
         result, m = xmlrpclib.loads(dump, **kwargs)

--- a/Lib/xmlrpc/client.py
+++ b/Lib/xmlrpc/client.py
@@ -756,6 +756,8 @@ class Unmarshaller:
         # map structs to Python dictionaries
         dict = {}
         items = self._stack[mark:]
+        if len(items) % 2:
+            raise ResponseError()
         for i in range(0, len(items), 2):
             dict[items[i]] = items[i+1]
         self._stack[mark:] = [dict]

--- a/Misc/NEWS.d/next/Library/2026-07-16-12-00-00.gh-issue-153803.YbLNRy.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-16-12-00-00.gh-issue-153803.YbLNRy.rst
@@ -1,3 +1,2 @@
 Fix :func:`xmlrpc.client.loads` raising :exc:`IndexError` instead of
-:exc:`~xmlrpc.client.ResponseError` for a malformed ``<struct>``.  Patch by
-tonghuaroot.
+``ResponseError`` for a malformed ``<struct>``.  Patch by tonghuaroot.

--- a/Misc/NEWS.d/next/Library/2026-07-16-12-00-00.gh-issue-153803.YbLNRy.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-16-12-00-00.gh-issue-153803.YbLNRy.rst
@@ -1,0 +1,3 @@
+Fix :func:`xmlrpc.client.loads` raising :exc:`IndexError` instead of
+:exc:`~xmlrpc.client.ResponseError` for a malformed ``<struct>``.  Patch by
+tonghuaroot.


### PR DESCRIPTION
`Unmarshaller.end_struct` iterates stacked name/value items in pairs.  A `<member>` missing its `<value>` leaves an odd item count, so `items[i+1]` raises a raw `IndexError`.  Guard with `len(items) % 2` and raise `ResponseError`, matching the sibling checks at lines 640 and 663.

<!-- gh-issue-number: gh-153803 -->
* Issue: gh-153803
<!-- /gh-issue-number -->
