### PR TITLE
[3.14] gh-149162: Use _Py_LOCK_DONT_DETACH in intern_common (gh-149164)

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-04-29-15-10-59.gh-issue-149162.BPPyrq.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-04-29-15-10-59.gh-issue-149162.BPPyrq.rst
@@ -1,0 +1,3 @@
+Fix a potential deadlock in :c:func:`PyUnicode_InternFromString` and other
+interning functions in the :term:`free-threaded build` when called from C++
+static local initializers.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -113,7 +113,9 @@ NOTE: In the interpreter's initialization phase, some globals are currently
 #endif
 
 #ifdef Py_GIL_DISABLED
-#  define LOCK_INTERNED(interp) PyMutex_Lock(&_Py_INTERP_CACHED_OBJECT(interp, interned_mutex))
+#  define LOCK_INTERNED(interp) \
+    PyMutex_LockFlags(&_Py_INTERP_CACHED_OBJECT(interp, interned_mutex), \
+                      _Py_LOCK_DONT_DETACH)
 #  define UNLOCK_INTERNED(interp) PyMutex_Unlock(&_Py_INTERP_CACHED_OBJECT(interp, interned_mutex))
 #else
 #  define LOCK_INTERNED(interp)


### PR DESCRIPTION
Avoids potential deadlocks with C++ static local initialization in extensions that call PyUnicode_InternFromString during one-time initialization.

(cherry picked from commit f62050d65743f0c895f7e6d665936c4e86aa39d5)

<!-- gh-issue-number: gh-149162 -->
* Issue: gh-149162
<!-- /gh-issue-number -->
