### PR TITLE
gh-153691: Fix empty-list handling in PyInitConfig_*StrList

### DIFF
--- a/Misc/NEWS.d/next/C_API/2026-07-16-18-30-00.gh-issue-153691.kP4nWm.rst
+++ b/Misc/NEWS.d/next/C_API/2026-07-16-18-30-00.gh-issue-153691.kP4nWm.rst
@@ -1,0 +1,4 @@
+Fix :c:func:`PyInitConfig_GetStrList` and :c:func:`PyInitConfig_SetStrList`
+for empty string lists on platforms where ``malloc(0)`` returns ``NULL``.
+Previously these APIs could spuriously report out-of-memory for a valid
+empty list.

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1872,6 +1872,8 @@ static int test_initconfig_get_api(void)
     char **items;
     assert(PyInitConfig_GetStrList(config, "xoptions", &length, &items) == 0);
     assert(length == 0);
+    assert(items == NULL);
+    PyInitConfig_FreeStrList(length, items);
 
     char* xoptions[] = {"faulthandler"};
     assert(PyInitConfig_SetStrList(config, "xoptions",
@@ -1880,6 +1882,14 @@ static int test_initconfig_get_api(void)
     assert(PyInitConfig_GetStrList(config, "xoptions", &length, &items) == 0);
     assert(length == 1);
     assert(strcmp(items[0], "faulthandler") == 0);
+    PyInitConfig_FreeStrList(length, items);
+
+    // Setting an empty list must succeed even on platforms where malloc(0)
+    // returns NULL, and must round-trip through GetStrList().
+    assert(PyInitConfig_SetStrList(config, "xoptions", 0, NULL) == 0);
+    assert(PyInitConfig_GetStrList(config, "xoptions", &length, &items) == 0);
+    assert(length == 0);
+    assert(items == NULL);
     PyInitConfig_FreeStrList(length, items);
 
     // Setting hash_seed sets use_hash_seed

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -4213,6 +4213,12 @@ PyInitConfig_GetStrList(PyInitConfig *config, const char *name, size_t *length, 
     PyWideStringList *list = raw_member;
     *length = list->length;
 
+    // Don't call malloc(0): it may return NULL on some platforms.
+    if (list->length == 0) {
+        *items = NULL;
+        return 0;
+    }
+
     *items = malloc(list->length * sizeof(char*));
     if (*items == NULL) {
         config->status = _PyStatus_NO_MEMORY();
@@ -4408,6 +4414,14 @@ initconfig_set_str_list(PyInitConfig *config, PyWideStringList *list,
                         Py_ssize_t length, char * const *items)
 {
     PyWideStringList wlist = _PyWideStringList_INIT;
+
+    // Don't call malloc(0): it may return NULL on some platforms.
+    if (length == 0) {
+        initconfig_free_wstr_list(list);
+        *list = wlist;
+        return 0;
+    }
+
     size_t size = sizeof(wchar_t*) * length;
     wlist.items = (wchar_t **)malloc(size);
     if (wlist.items == NULL) {


### PR DESCRIPTION
## Summary

`PyInitConfig_GetStrList()` and `PyInitConfig_SetStrList()` used `malloc(n * sizeof(...))` even when `n == 0`. On platforms where `malloc(0)` returns `NULL`, that was treated as an out-of-memory failure, so a valid empty list (for example the default `xoptions`) incorrectly failed.

This change skips `malloc(0)` for empty lists:

- `GetStrList` returns `length == 0` and `items == NULL`
- `SetStrList` stores `{.length = 0, .items = NULL}` (same as `_PyWideStringList_INIT`)

This matches the existing empty-list handling in `_PyWideStringList_CopyEx()`.

Fixes #153691.

## Test plan

- [x] Reproduced the failure mode with `LD_PRELOAD` forcing `malloc(0)` → `NULL`
  - buggy path: `GetStrList`-style empty alloc returns `-1`
  - fixed path: returns `0` with `items == NULL`
- [x] `./python -m test test_embed -v -m test_initconfig_get_api`
- [x] `./Programs/_testembed test_initconfig_get_api` (with and without the preload)
- [x] `./python -m test test_embed -v -m 'test_initconfig*'`
- [ ] CI on GitHub Actions after the PR is opened

<!-- gh-issue-number: gh-153691 -->
* Issue: gh-153691
<!-- /gh-issue-number -->
