### PR TITLE
gh-153304: Remove incorrect assertion in pegen error handling

### DIFF
--- a/Parser/pegen_errors.c
+++ b/Parser/pegen_errors.c
@@ -311,7 +311,6 @@ _PyPegen_raise_error_known_location(Parser *p, PyObject *errtype,
            we're actually parsing from a file, which has an E_EOF SyntaxError and in that case
            `PyErr_ProgramTextObject` fails because lineno points to last_file_line + 1, which
            does not physically exist */
-        assert(p->tok->fp == NULL || p->tok->fp == stdin || p->tok->done == E_EOF);
 
         if (p->tok->lineno <= lineno && p->tok->inp > p->tok->buf) {
             Py_ssize_t size = p->tok->inp - p->tok->line_start;


### PR DESCRIPTION
## Summary

Remove an assertion in `_PyPegen_raise_error_known_location()` that can abort debug builds before the existing fallback logic handles the error.

When `_PyErr_ProgramDecodedTextObject()` cannot reopen the source file, it may return `NULL`. The code immediately following the assertion already handles this case, so the assertion prevents the intended fallback from executing.

## Testing

- Reproduced the assertion failure on a Linux `--with-pydebug` build using the reproducer from the issue.
- Verified that after removing the assertion, the reproducer reports a normal `SyntaxError` instead of aborting.
- Built CPython successfully on both Linux (`--with-pydebug`) and Windows Debug builds.

<!-- gh-issue-number: gh-153304 -->
* Issue: gh-153304
<!-- /gh-issue-number -->
