### PR TITLE
gh-153838: Skip non-regular and oversized files in heatmap exporter

### DIFF
--- a/Lib/profiling/sampling/heatmap_collector.py
+++ b/Lib/profiling/sampling/heatmap_collector.py
@@ -783,14 +783,16 @@ class HeatmapCollector(StackTraceCollector):
                           line_counts: Dict[int, int], self_counts: Dict[int, int],
                           file_stat: FileStats):
         """Generate HTML for a single source file with heatmap coloring."""
-        # Read source file
+        _MAX_SOURCE_SIZE = 10 * 1024 * 1024
+        source_lines = [f"# Source file not available: {filename}"]
         try:
-            source_lines = Path(filename).read_text(encoding='utf-8', errors='replace').splitlines()
-        except (IOError, OSError) as e:
-            if not (filename.startswith('<') or filename.startswith('[') or
-                    filename in ('~', '...', '.') or len(filename) < 2):
-                print(f"Warning: Could not read source file {filename}: {e}")
-            source_lines = [f"# Source file not available: {filename}"]
+            resolved = Path(filename).resolve()
+            if (resolved.is_file()
+                    and resolved.stat().st_size <= _MAX_SOURCE_SIZE):
+                source_lines = resolved.read_text(
+                    encoding='utf-8', errors='replace').splitlines()
+        except (IOError, OSError):
+            pass
 
         # Generate HTML for each line
         max_samples = max(line_counts.values()) if line_counts else 1

--- a/Lib/profiling/sampling/heatmap_collector.py
+++ b/Lib/profiling/sampling/heatmap_collector.py
@@ -783,12 +783,10 @@ class HeatmapCollector(StackTraceCollector):
                           line_counts: Dict[int, int], self_counts: Dict[int, int],
                           file_stat: FileStats):
         """Generate HTML for a single source file with heatmap coloring."""
-        _MAX_SOURCE_SIZE = 10 * 1024 * 1024
         source_lines = [f"# Source file not available: {filename}"]
         try:
             resolved = Path(filename).resolve()
-            if (resolved.is_file()
-                    and resolved.stat().st_size <= _MAX_SOURCE_SIZE):
+            if resolved.is_file():
                 source_lines = resolved.read_text(
                     encoding='utf-8', errors='replace').splitlines()
         except (IOError, OSError):

--- a/Lib/test/test_profiling/test_heatmap.py
+++ b/Lib/test/test_profiling/test_heatmap.py
@@ -622,6 +622,50 @@ class TestHeatmapCollectorExport(unittest.TestCase):
             # Should have line-related content
             self.assertIn('line-', content)
 
+    def test_export_skips_nonexistent_source(self):
+        """Source files that do not exist produce a placeholder."""
+        collector = HeatmapCollector(sample_interval_usec=100)
+
+        frames = [('/no/such/file.py', (1, 1, -1, -1), 'f', None)]
+        collector.process_frames(frames, thread_id=1)
+
+        output_path = os.path.join(self.test_dir, 'missing_src')
+
+        with captured_stdout(), captured_stderr():
+            collector.export(output_path)
+
+        html_files = [f for f in os.listdir(output_path)
+                      if f.startswith('file_') and f.endswith('.html')]
+        if html_files:
+            with open(os.path.join(output_path, html_files[0]),
+                      'r', encoding='utf-8') as f:
+                content = f.read()
+            self.assertIn('Source file not available', content)
+
+    def test_export_caps_oversized_source(self):
+        """Source files larger than the cap produce a placeholder."""
+        collector = HeatmapCollector(sample_interval_usec=100)
+
+        big_file = os.path.join(self.test_dir, 'big.py')
+        with open(big_file, 'w') as f:
+            f.write('x = 1\n' * 2_000_000)
+
+        frames = [(big_file, (1, 1, -1, -1), 'f', None)]
+        collector.process_frames(frames, thread_id=1)
+
+        output_path = os.path.join(self.test_dir, 'big_src')
+
+        with captured_stdout(), captured_stderr():
+            collector.export(output_path)
+
+        html_files = [f for f in os.listdir(output_path)
+                      if f.startswith('file_') and f.endswith('.html')]
+        if html_files:
+            with open(os.path.join(output_path, html_files[0]),
+                      'r', encoding='utf-8') as f:
+                content = f.read()
+            self.assertIn('Source file not available', content)
+
 
 class MockFrameInfo:
     """Mock FrameInfo for testing.

--- a/Lib/test/test_profiling/test_heatmap.py
+++ b/Lib/test/test_profiling/test_heatmap.py
@@ -642,29 +642,6 @@ class TestHeatmapCollectorExport(unittest.TestCase):
                 content = f.read()
             self.assertIn('Source file not available', content)
 
-    def test_export_caps_oversized_source(self):
-        """Source files larger than the cap produce a placeholder."""
-        collector = HeatmapCollector(sample_interval_usec=100)
-
-        big_file = os.path.join(self.test_dir, 'big.py')
-        with open(big_file, 'w') as f:
-            f.write('x = 1\n' * 2_000_000)
-
-        frames = [(big_file, (1, 1, -1, -1), 'f', None)]
-        collector.process_frames(frames, thread_id=1)
-
-        output_path = os.path.join(self.test_dir, 'big_src')
-
-        with captured_stdout(), captured_stderr():
-            collector.export(output_path)
-
-        html_files = [f for f in os.listdir(output_path)
-                      if f.startswith('file_') and f.endswith('.html')]
-        if html_files:
-            with open(os.path.join(output_path, html_files[0]),
-                      'r', encoding='utf-8') as f:
-                content = f.read()
-            self.assertIn('Source file not available', content)
 
 
 class MockFrameInfo:

--- a/Misc/NEWS.d/next/Library/2026-07-17-12-00-00.gh-issue-153838.HmCp5s.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-17-12-00-00.gh-issue-153838.HmCp5s.rst
@@ -1,0 +1,2 @@
+Skip non-regular and oversized files in the ``profiling.sampling`` heatmap
+exporter instead of reading them unconditionally.  Patch by tonghuaroot.

--- a/Misc/NEWS.d/next/Library/2026-07-17-12-00-00.gh-issue-153838.HmCp5s.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-17-12-00-00.gh-issue-153838.HmCp5s.rst
@@ -1,2 +1,2 @@
-Skip non-regular and oversized files in the ``profiling.sampling`` heatmap
-exporter instead of reading them unconditionally.  Patch by tonghuaroot.
+Skip non-regular files in the ``profiling.sampling`` heatmap exporter
+instead of reading them unconditionally.  Patch by tonghuaroot.


### PR DESCRIPTION
Guard the source-file read in `_generate_file_html` with `is_file()` and a 10 MB size cap. A device or oversized path now gets the existing placeholder instead of an unbounded read.

<!-- gh-issue-number: gh-153838 -->
* Issue: gh-153838
<!-- /gh-issue-number -->
