### PR TITLE
gh-153840: Escape special characters in flamegraph function names

### DIFF
--- a/Lib/profiling/sampling/_flamegraph_assets/flamegraph.js
+++ b/Lib/profiling/sampling/_flamegraph_assets/flamegraph.js
@@ -322,7 +322,7 @@ function createPythonTooltip(data) {
     const childCount = d.children ? d.children.length : 0;
     const source = d.data.source;
 
-    const funcname = resolveString(d.data.funcname) || resolveString(d.data.name);
+    const funcname = escapeHtml(resolveString(d.data.funcname) || resolveString(d.data.name) || "");
     const filename = resolveString(d.data.filename) || "";
     const moduleName = resolveString(d.data.module) || "";
     const displayName = escapeHtml(useModuleNames ? (moduleName || filename) : filename);

--- a/Lib/profiling/sampling/stack_collector.py
+++ b/Lib/profiling/sampling/stack_collector.py
@@ -401,7 +401,10 @@ class FlamegraphCollector(StackTraceCollector):
             return None
 
     def _create_flamegraph_html(self, data):
-        data_json = json.dumps(data)
+        data_json = (json.dumps(data)
+                     .replace("<", "\\u003c")
+                     .replace(">", "\\u003e")
+                     .replace("&", "\\u0026"))
 
         template_dir = importlib.resources.files(__package__)
         vendor_dir = template_dir / "_vendor"

--- a/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
@@ -584,7 +584,7 @@ class TestSampleProfilerComponents(unittest.TestCase):
                 [MockThreadInfo(
                     1,
                     [MockFrameInfo("test.py", 1, "root"),
-                     MockFrameInfo("test.py", 2, '</script><b>')]
+                     MockFrameInfo("test.py", 2, '</script><b>&')]
                 )],
             )
         ]
@@ -599,7 +599,7 @@ class TestSampleProfilerComponents(unittest.TestCase):
 
         # The funcname's </script> must be escaped in the embedded data so it
         # cannot close the inline <script> block; the raw form must be absent.
-        self.assertIn(r"\u003c/script\u003e\u003cb\u003e", content)
+        self.assertIn(r"\u003c/script\u003e\u003cb\u003e\u0026", content)
         self.assertNotIn("</script><b>", content)
 
     def test_flamegraph_collector_empty_export_fails(self):

--- a/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
@@ -583,14 +583,16 @@ class TestSampleProfilerComponents(unittest.TestCase):
                 0,
                 [MockThreadInfo(
                     1,
-                    [MockFrameInfo("test.py", 1, '</script><b>')]
+                    [MockFrameInfo("test.py", 1, "root"),
+                     MockFrameInfo("test.py", 2, '</script><b>')]
                 )],
             )
         ]
         collector.collect(frames)
 
         with captured_stdout(), captured_stderr():
-            collector.export(flamegraph_out.name)
+            export_ok = collector.export(flamegraph_out.name)
+        self.assertTrue(export_ok)
 
         with open(flamegraph_out.name, "r", encoding="utf-8") as f:
             content = f.read()

--- a/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
@@ -595,12 +595,10 @@ class TestSampleProfilerComponents(unittest.TestCase):
         with open(flamegraph_out.name, "r", encoding="utf-8") as f:
             content = f.read()
 
-        # The raw </script> must not appear unescaped in the output
-        # (it would break out of the inline <script> block)
-        idx = content.find("EMBEDDED_DATA")
-        if idx != -1:
-            after_embed = content[idx:]
-            self.assertNotIn("</script><b>", after_embed.split("</script>")[0])
+        # The funcname's </script> must be escaped in the embedded data so it
+        # cannot close the inline <script> block; the raw form must be absent.
+        self.assertIn(r"\u003c/script\u003e\u003cb\u003e", content)
+        self.assertNotIn("</script><b>", content)
 
     def test_flamegraph_collector_empty_export_fails(self):
         """Test empty flamegraph export reports no output."""

--- a/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
@@ -570,6 +570,38 @@ class TestSampleProfilerComponents(unittest.TestCase):
         self.assertIn('"value":', content)
         self.assertIn('"children":', content)
 
+    def test_flamegraph_escapes_special_chars_in_funcname(self):
+        """Function names with <, >, & must be escaped in the HTML."""
+        flamegraph_out = tempfile.NamedTemporaryFile(
+            suffix=".html", delete=False
+        )
+        self.addCleanup(close_and_unlink, flamegraph_out)
+
+        collector = FlamegraphCollector(1000)
+        frames = [
+            MockInterpreterInfo(
+                0,
+                [MockThreadInfo(
+                    1,
+                    [MockFrameInfo("test.py", 1, '</script><b>')]
+                )],
+            )
+        ]
+        collector.collect(frames)
+
+        with captured_stdout(), captured_stderr():
+            collector.export(flamegraph_out.name)
+
+        with open(flamegraph_out.name, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # The raw </script> must not appear unescaped in the output
+        # (it would break out of the inline <script> block)
+        idx = content.find("EMBEDDED_DATA")
+        if idx != -1:
+            after_embed = content[idx:]
+            self.assertNotIn("</script><b>", after_embed.split("</script>")[0])
+
     def test_flamegraph_collector_empty_export_fails(self):
         """Test empty flamegraph export reports no output."""
         flamegraph_out = tempfile.NamedTemporaryFile(

--- a/Misc/NEWS.d/next/Library/2026-07-17-14-00-00.gh-issue-153840.FgXs3e.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-17-14-00-00.gh-issue-153840.FgXs3e.rst
@@ -1,0 +1,3 @@
+Escape special characters in ``profiling.sampling`` flamegraph function
+names to prevent markup injection in the generated HTML report.  Patch by
+tonghuaroot.


### PR DESCRIPTION
Escape `<`, `>`, `&` as `<` etc. in the embedded JSON blob to prevent `</script>` breakout, and wrap the tooltip function name with the existing `escapeHtml()` helper. The sibling heatmap exporter and the flamegraph's own `displayName` already escape; the function name was missed.

<!-- gh-issue-number: gh-153840 -->
* Issue: gh-153840
<!-- /gh-issue-number -->
