### PR TITLE
gh-153853: Fix parameter name of calendar.setfirstweekday() in docs

### DIFF
--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -365,7 +365,7 @@ interpreted as prescribed by the ISO 8601 standard.  Year 0 is 1 BC, year -1 is
 
 For simple text calendars this module provides the following functions.
 
-.. function:: setfirstweekday(weekday)
+.. function:: setfirstweekday(firstweekday)
 
    Sets the weekday (``0`` is Monday, ``6`` is Sunday) to start each week. The
    values :const:`MONDAY`, :const:`TUESDAY`, :const:`WEDNESDAY`, :const:`THURSDAY`,


### PR DESCRIPTION
The module-level function is documented as `setfirstweekday(weekday)`, but the implementation in `Lib/calendar.py` is `def setfirstweekday(firstweekday)`. The parameter can be passed by keyword, so the documented signature fails:

```pycon
>>> import calendar
>>> calendar.setfirstweekday(weekday=calendar.SUNDAY)
Traceback (most recent call last):
  ...
TypeError: setfirstweekday() got an unexpected keyword argument 'weekday'
>>> calendar.setfirstweekday(firstweekday=calendar.SUNDAY)  # OK
```

This also makes the entry consistent with `Calendar.setfirstweekday(firstweekday)` documented earlier in the same file, and with the `Calendar(firstweekday=0)` constructor and the `calendar.firstweekday()` accessor.

Docs-only change; per the contributing guidelines, no issue for trivial fixes (skip issue).

<!-- gh-issue-number: gh-153853 -->
* Issue: gh-153853
<!-- /gh-issue-number -->
