### PR TITLE
gh-153855: Fix BasicInterpolation crash on None-valued interpolation reference.

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -471,10 +471,8 @@ class BasicInterpolation(Interpolation):
                 except KeyError:
                     raise InterpolationMissingOptionError(
                         option, section, rawval, var) from None
-
                 if v is None:
                     continue
-
                 if "%" in v:
                     self._interpolate_some(parser, option, accum, v,
                                            section, map, depth + 1)

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -471,6 +471,10 @@ class BasicInterpolation(Interpolation):
                 except KeyError:
                     raise InterpolationMissingOptionError(
                         option, section, rawval, var) from None
+
+                if v is None:
+                    continue
+
                 if "%" in v:
                     self._interpolate_some(parser, option, accum, v,
                                            section, map, depth + 1)

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -1379,6 +1379,17 @@ class RawConfigParserNoValueAndExtendedInterpolationTest(
 ):
     config_class = configparser.RawConfigParser
 
+class BasicInterpolationWithAllowNoValueTest(unittest.TestCase):
+    def test_interpolation_with_allow_no_value(self):
+        cf = configparser.ConfigParser(allow_no_value=True)
+        cf.read_string(textwrap.dedent("""
+            [s]
+            a
+            b = x%(a)sy
+        """))
+        self.assertIsNone(cf["s"]["a"])
+        self.assertEqual(cf.get("s", "b"), "xy")
+
 
 class ConfigParserTestCaseTrickyFile(CfgParserTestCaseClass, unittest.TestCase):
     config_class = configparser.ConfigParser

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -1385,10 +1385,10 @@ class BasicInterpolationWithAllowNoValueTest(unittest.TestCase):
         cf.read_string(textwrap.dedent("""
             [s]
             a
-            b = x%(a)sy
+            b = %(a)s
         """))
         self.assertIsNone(cf["s"]["a"])
-        self.assertEqual(cf.get("s", "b"), "xy")
+        self.assertEqual(cf.get("s", "b"), "")
 
 
 class ConfigParserTestCaseTrickyFile(CfgParserTestCaseClass, unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2026-07-17-18-53-45.gh-issue-153855.h6YZOX.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-17-18-53-45.gh-issue-153855.h6YZOX.rst
@@ -1,0 +1,1 @@
+Fix :class:`configparser.BasicInterpolation` raising ``TypeError`` when interpolating a reference to a value-less option with ``allow_no_value=True``; it now treats the missing value as empty, like :class:`configparser.ExtendedInterpolation`.

--- a/Misc/NEWS.d/next/Library/2026-07-17-18-53-45.gh-issue-153855.h6YZOX.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-17-18-53-45.gh-issue-153855.h6YZOX.rst
@@ -1,1 +1,4 @@
-Fix :class:`configparser.BasicInterpolation` raising ``TypeError`` when interpolating a reference to a value-less option with ``allow_no_value=True``; it now treats the missing value as empty, like :class:`configparser.ExtendedInterpolation`.
+Fix :class:`configparser.BasicInterpolation` raising ``TypeError`` when
+interpolating a reference to a value-less option with
+``allow_no_value=True``; it now treats the missing value as empty, like
+:class:`configparser.ExtendedInterpolation`.


### PR DESCRIPTION
`BasicInterpolation` interpolated a value-less option (`allow_no_value=True`) into a `TypeError`; it now resolves to empty, like `ExtendedInterpolation`.

<!-- gh-issue-number: gh-153855 -->
* Issue: gh-153855
<!-- /gh-issue-number -->
