### PR TITLE
gh-153856: Add `os.RWF_NOSIGNAL` constant

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1642,6 +1642,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    - :data:`RWF_APPEND`
    - :data:`RWF_DONTCACHE`
    - :data:`RWF_ATOMIC`
+   - :data:`RWF_NOSIGNAL`
 
    Return the total number of bytes actually written.
 
@@ -1689,6 +1690,16 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    .. availability:: Linux >= 4.16.
 
    .. versionadded:: 3.10
+
+
+.. data:: RWF_NOSIGNAL
+
+   Prevent pipe and socket writes from raising :const:`~signal.SIGPIPE`.
+   This flag is meaningful only for :func:`os.pwritev`.
+
+   .. availability:: Linux >= 6.18.
+
+   .. versionadded:: 3.16
 
 
 .. function:: read(fd, n, /)

--- a/Misc/NEWS.d/next/Library/2026-07-17-14-30-00.gh-issue-153856.JEHepm.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-17-14-30-00.gh-issue-153856.JEHepm.rst
@@ -1,0 +1,1 @@
+Add :data:`os.RWF_NOSIGNAL` constant for Linux 6.18+.

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -8801,6 +8801,7 @@ PyDoc_STRVAR(os_pwritev__doc__,
 "- RWF_APPEND\n"
 "- RWF_DONTCACHE\n"
 "- RWF_ATOMIC\n"
+"- RWF_NOSIGNAL\n"
 "\n"
 "Using non-zero flags requires Linux 4.7 or newer.");
 
@@ -13733,4 +13734,4 @@ exit:
 #ifndef OS__EMSCRIPTEN_LOG_METHODDEF
     #define OS__EMSCRIPTEN_LOG_METHODDEF
 #endif /* !defined(OS__EMSCRIPTEN_LOG_METHODDEF) */
-/*[clinic end generated code: output=d81494ceb6ce44ed input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d641f02a97057666 input=a9049054013a1b77]*/

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -12941,6 +12941,7 @@ following flags:
 - RWF_APPEND
 - RWF_DONTCACHE
 - RWF_ATOMIC
+- RWF_NOSIGNAL
 
 Using non-zero flags requires Linux 4.7 or newer.
 [clinic start generated code]*/
@@ -12948,7 +12949,7 @@ Using non-zero flags requires Linux 4.7 or newer.
 static Py_ssize_t
 os_pwritev_impl(PyObject *module, int fd, PyObject *buffers, Py_off_t offset,
                 int flags)
-/*[clinic end generated code: output=e3dd3e9d11a6a5c7 input=b2e352a22f030e9a]*/
+/*[clinic end generated code: output=e3dd3e9d11a6a5c7 input=c202f24f01fa66c9]*/
 {
     Py_ssize_t cnt;
     Py_ssize_t result;
@@ -18243,6 +18244,9 @@ all_ins(PyObject *m)
 #endif
 #ifdef RWF_APPEND
     if (PyModule_AddIntConstant(m, "RWF_APPEND", RWF_APPEND)) return -1;
+#endif
+#ifdef RWF_NOSIGNAL
+    if (PyModule_AddIntConstant(m, "RWF_NOSIGNAL", RWF_NOSIGNAL)) return -1;
 #endif
 
 /* constants for splice */


### PR DESCRIPTION
RWF_NOSIGNAL was added in Linux 6.18 to prevent pwritev2() from raising SIGPIPE when writing to disconnected pipes or sockets.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-153856 -->
* Issue: gh-153856
<!-- /gh-issue-number -->
