### PR TITLE
Skip curses tests when scr_dump()/is_keypad() are unavailable

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -1364,6 +1364,7 @@ class TestCurses(unittest.TestCase):
             self.assertEqual(win.getmaxyx(), (5, 12))
             self.assertEqual(win.instr(2, 0), b' Lorem ipsum')
 
+    @requires_curses_func('scr_dump')
     def test_scr_dump(self):
         # Test scr_dump(), scr_restore(), scr_init() and scr_set().
         # scr_dump() writes the virtual screen to a named file; the other three
@@ -1722,6 +1723,9 @@ class TestCurses(unittest.TestCase):
             ('notimeout', 'is_notimeout'),
             ('scrollok', 'is_scrollok'),
         ]:
+            # is_keypad()/is_leaveok() are not available in every curses build.
+            if not hasattr(stdscr, getter):
+                continue
             getattr(stdscr, setter)(True)
             self.assertIs(getattr(stdscr, getter)(), True)
             getattr(stdscr, setter)(False)


### PR DESCRIPTION
`test_scr_dump()` and `test_state_getters()` errored with `AttributeError` instead of skipping on curses builds that lack `scr_dump()`, `is_keypad()` or `is_leaveok()` — these are conditionally compiled, so they are absent on some builds (e.g. narrow ncurses, NetBSD curses, PDCurses). Standard wide-ncurses buildbots have them all, which is why this went unnoticed.

`test_scr_dump()` now uses `@requires_curses_func('scr_dump')`, and the getter loop in `test_state_getters()` skips a getter that the window does not provide.
