### PR TITLE
gh-152023: Update macOS installer builds to SQLite 3.53.3

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -359,13 +359,14 @@ def library_recipes():
                   ),
           ),
           dict(
-              name="SQLite 3.53.2",
-              url="https://www.sqlite.org/2026/sqlite-autoconf-3530200.tar.gz",
-              checksum="588ad51949419a56ebe81fe56193d510c559eb94c9a57748387860b5d3069316",
+              name="SQLite 3.53.3",
+              url="https://www.sqlite.org/2026/sqlite-autoconf-3530300.tar.gz",
+              checksum="c917d7db16648ec95f714974ace5e5dcf46b7dc70e26600a0a102a3141125db0",
               extra_cflags=('-Os '
                             '-DSQLITE_ENABLE_FTS5 '
                             '-DSQLITE_ENABLE_FTS4 '
                             '-DSQLITE_ENABLE_FTS3_PARENTHESIS '
+                            '-DSQLITE_ENABLE_PERCENTILE '
                             '-DSQLITE_ENABLE_RTREE '
                             '-DSQLITE_OMIT_AUTOINIT '
                             '-DSQLITE_TCL=0 '

--- a/Misc/NEWS.d/next/macOS/2026-07-17-23-20-27.gh-issue-152023.QAAgdj.rst
+++ b/Misc/NEWS.d/next/macOS/2026-07-17-23-20-27.gh-issue-152023.QAAgdj.rst
@@ -1,0 +1,2 @@
+Update macOS installer builds to SQLite 3.53.3. Enable median() and
+percentile() functions.


### PR DESCRIPTION
Enable median() and percentile() functions.

<!-- gh-issue-number: gh-152023 -->
* Issue: gh-152023
<!-- /gh-issue-number -->
