### PR TITLE
gh-124111: Update macOS installer to use Tcl/Tk 9.0.4.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -264,10 +264,10 @@ def library_recipes():
             tk_patches = ['backport_gh71383_fix.patch', 'tk868_on_10_8_10_9.patch', 'backport_gh110950_fix.patch']
 
         else:
-            tcl_tk_ver='9.0.3'
-            tcl_checksum='2537ba0c86112c8c953f7c09d33f134dd45c0fb3a71f2d7f7691fd301d2c33a6'
+            tcl_tk_ver='9.0.4'
+            tcl_checksum='d0aed49230bc02a65c1e0229e65f34590a4b037ec40d546f32573b467f7551ea'
 
-            tk_checksum='bf344efadb618babb7933f69275620f72454d1c8220130da93e3f7feb0efbf9b'
+            tk_checksum='d7a146d2917eb8b5cc95276dbf0e3d03c7464d2b19c1675357857c989301dbb4'
             tk_patches = []
 
 

--- a/Misc/NEWS.d/next/macOS/2026-07-17-23-35-36.gh-issue-124111.dmM4lk.rst
+++ b/Misc/NEWS.d/next/macOS/2026-07-17-23-35-36.gh-issue-124111.dmM4lk.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use Tcl/Tk 9.0.4.


### PR DESCRIPTION


<!-- gh-issue-number: gh-124111 -->
* Issue: gh-124111
<!-- /gh-issue-number -->
