### PR TITLE
gh-151950: Fix Sphinx reference warnings in termios docs

### DIFF
--- a/Doc/library/termios.rst
+++ b/Doc/library/termios.rst
@@ -39,6 +39,13 @@ The module defines the following functions:
    well as the indexing in the *cc* array must be done using the symbolic
    constants defined in the :mod:`!termios` module.
 
+   .. data:: VMIN
+             VTIME
+
+      Indices into the *cc* array controlling a non-canonical read: the minimum
+      number of characters to read and the timeout in tenths of a second,
+      respectively.
+
 
 .. function:: tcsetattr(fd, when, attributes)
 
@@ -77,12 +84,27 @@ The module defines the following functions:
    which queue: :const:`TCIFLUSH` for the input queue, :const:`TCOFLUSH` for the
    output queue, or :const:`TCIOFLUSH` for both queues.
 
+   .. data:: TCIFLUSH
+             TCOFLUSH
+             TCIOFLUSH
+
+      Values for the *queue* selector: the input queue, the output queue, or
+      both queues, respectively.
+
 
 .. function:: tcflow(fd, action)
 
    Suspend or resume input or output on file descriptor *fd*.  The *action*
    argument can be :const:`TCOOFF` to suspend output, :const:`TCOON` to restart
    output, :const:`TCIOFF` to suspend input, or :const:`TCION` to restart input.
+
+   .. data:: TCOOFF
+             TCOON
+             TCIOFF
+             TCION
+
+      Values for the *action* argument: suspend output, restart output,
+      suspend input, or restart input, respectively.
 
 
 .. function:: tcgetwinsize(fd)
@@ -92,6 +114,12 @@ The module defines the following functions:
    :const:`termios.TIOCGSIZE`.
 
    .. versionadded:: 3.11
+
+   .. data:: TIOCGWINSZ
+             TIOCGSIZE
+
+      ``ioctl()`` requests for querying the tty window size.  Not defined on
+      all platforms; :func:`tcgetwinsize` requires at least one of them.
 
 
 .. function:: tcsetwinsize(fd, winsize)
@@ -103,6 +131,12 @@ The module defines the following functions:
    (:const:`termios.TIOCGSIZE`, :const:`termios.TIOCSSIZE`) to be defined.
 
    .. versionadded:: 3.11
+
+   .. data:: TIOCSWINSZ
+             TIOCSSIZE
+
+      ``ioctl()`` requests for setting the tty window size.  Not defined on all
+      platforms; see :func:`tcsetwinsize` for the required pairs.
 
 
 .. seealso::

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -21,7 +21,6 @@ Doc/library/pyexpat.rst
 Doc/library/select.rst
 Doc/library/socket.rst
 Doc/library/ssl.rst
-Doc/library/termios.rst
 Doc/library/test.rst
 Doc/library/urllib.parse.rst
 Doc/library/urllib.request.rst


### PR DESCRIPTION
This covers the `termios.rst` file from gh-151950 (part of the
Sphinx-warnings meta issue gh-151940); other files there are handled by
separate per-file PRs.

Fixes the Sphinx nit-picky reference warnings for
`Doc/library/termios.rst` and removes the file from
`Doc/tools/.nitignore` so future regressions are caught by CI.

- Documents the constants the prose already references with `.. data::`
  directives, following the existing `TCSANOW`/`TCSADRAIN`/`TCSAFLUSH`
  pattern in the same file: the `VMIN`/`VTIME` `cc` indices, the
  `TCIFLUSH`/`TCOFLUSH`/`TCIOFLUSH` flush selectors, the
  `TCOOFF`/`TCOON`/`TCIOFF`/`TCION` flow actions, and the
  `TIOCGWINSZ`/`TIOCSWINSZ`/`TIOCGSIZE`/`TIOCSSIZE` window-size requests.
- The `TIOC*` entries note they are not defined on all platforms, since
  `tcgetwinsize`/`tcsetwinsize` only require one of each pair.

Verified with a full nit-picky build: the file emits no warnings and
`Doc/tools/check-warnings.py --fail-if-regression --fail-if-improved`
passes. Documentation-only reference fix, so no NEWS entry (skip news).

<!-- gh-issue-number: gh-151950 -->
* Issue: gh-151950
<!-- /gh-issue-number -->
