### PR TITLE
gh-81241: Fix importing `ctypes` from statically linked interpreters

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1704,6 +1704,9 @@ These prefabricated library loaders are available:
       :c:expr:`int`, which is of course not always the truth, so you have to assign
       the correct :attr:`!restype` attribute to use these functions.
 
+      Note that if the Python interpreter is statically linked, this will be
+      ``None``, as ``dlopen`` is not possible in this case.
+
 .. audit-event:: ctypes.dlopen name ctypes.LibraryLoader
 
    Loading a library through any of these objects raises an

--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -555,7 +555,10 @@ elif _sys.platform == "android":
 elif _sys.platform == "cygwin":
     pythonapi = PyDLL(_sysconfig.get_config_var("DLLLIBRARY"))
 else:
-    pythonapi = PyDLL(None)
+    try:
+        pythonapi = PyDLL(None)
+    except OSError:
+        pythonapi = None
 
 
 if _os.name == "nt":

--- a/Misc/NEWS.d/next/Library/2026-07-18-04-09-44.gh-issue-81241.gGRbBr.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-18-04-09-44.gh-issue-81241.gGRbBr.rst
@@ -1,0 +1,2 @@
+Fix :exc:`OSError` when importing :mod:`ctypes` from a statically linked
+interpreter.


### PR DESCRIPTION
Unfortunately, I don't think there's a great way to test for this.

<!-- gh-issue-number: gh-81241 -->
* Issue: gh-81241
<!-- /gh-issue-number -->
