### PR TITLE
Improve calendar constants deprecation coverage

### DIFF
--- a/Lib/test/test_calendar.py
+++ b/Lib/test/test_calendar.py
@@ -554,6 +554,11 @@ class CalendarTestCase(unittest.TestCase):
             "The 'January' attribute is deprecated, use 'JANUARY' instead"
         ):
             calendar.January
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            "The 'February' attribute is deprecated, use 'FEBRUARY' instead"
+        ):
+            calendar.February
 
     def test_isleap(self):
         # Make sure that the return is right for a few years, and


### PR DESCRIPTION
The `calendar.February` and `calendar.January` constants were both deprecated, while `Lib/test/test_calendar.py` only checked if a `DeprecationWarning` was issued for `calendar.January`. 

Extended the test to include `calendar.February` in the deprecation check as well.