### PR TITLE
doc fix: weekheader param name

### DIFF
--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -400,7 +400,7 @@ For simple text calendars this module provides the following functions.
    *month* (``1``--``12``), *day* (``1``--``31``).
 
 
-.. function:: weekheader(n)
+.. function:: weekheader(width)
 
    Return a header containing abbreviated weekday names. *n* specifies the width in
    characters for one weekday.


### PR DESCRIPTION
Update parameter name of calendar.weekheader from `n` to `width` in documentation.
