### PR TITLE
Add versionadded tag to wave module getformat functions

### DIFF
--- a/Doc/library/wave.rst
+++ b/Doc/library/wave.rst
@@ -125,6 +125,8 @@ Wave_read Objects
       This is one of :data:`WAVE_FORMAT_PCM`,
       :data:`WAVE_FORMAT_IEEE_FLOAT`, or :data:`WAVE_FORMAT_EXTENSIBLE`.
 
+      .. versionadded:: 3.15
+
 
    .. method:: getcomptype()
 
@@ -283,6 +285,8 @@ Wave_write Objects
    .. method:: getformat()
 
       Return the current frame format code.
+
+      .. versionadded:: 3.15
 
 
    .. method:: setparams(tuple)


### PR DESCRIPTION
Hello 👋 

Changes:

* add the `versionadded` tag to the documentation of `wave.Wave_read.getformat` which have been added in `3.15`.