### PR TITLE
gh-153899: Fix documented parameter names for `filecmp.cmpfiles`

### DIFF
--- a/Doc/library/filecmp.rst
+++ b/Doc/library/filecmp.rst
@@ -34,9 +34,9 @@ The :mod:`!filecmp` module defines the following functions:
    file changes.  The entire cache may be cleared using :func:`clear_cache`.
 
 
-.. function:: cmpfiles(dir1, dir2, common, shallow=True)
+.. function:: cmpfiles(a, b, common, shallow=True)
 
-   Compare the files in the two directories *dir1* and *dir2* whose names are
+   Compare the files in the two directories *a* and *b* whose names are
    given by *common*.
 
    Returns three lists of file names: *match*, *mismatch*,


### PR DESCRIPTION
`filecmp.cmpfiles()` documents its first two parameters as `dir1` and `dir2`, but the actual signature names them `a` and `b`. Calling `filecmp.cmpfiles(dir1=..., dir2=..., common=...)` therefore raises `TypeError`. This updates the documentation to match the real parameter names.

Fixes issue #153899.

<!-- gh-issue-number: gh-153899 -->
* Issue: gh-153899
<!-- /gh-issue-number -->
