### PR TITLE
gh-153902: strip trailing newlines when displaying source in pdb

### DIFF
--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -307,8 +307,13 @@ def iter_display_chars(
     buffer: str,
     colors: list[ColorSpan] | None = None,
     start_index: int = 0,
+    *,
+    escape: bool = True,
 ) -> Iterator[StyledChar]:
     """Yield visible display characters with widths and semantic color tags.
+
+    With ``escape=True`` (default) ASCII control chars are rewritten to caret
+    notation (``\\n`` -> ``^J``); pass ``escape=False`` to keep them verbatim.
 
     Note: ``colors`` is consumed in place as spans are processed -- callers
     that split a buffer across multiple calls rely on this mutation to track
@@ -331,7 +336,7 @@ def iter_display_chars(
         if colors and color_idx < len(colors) and colors[color_idx].span.start == i:
             active_tag = colors[color_idx].tag
 
-        if control := _ascii_control_repr(c):
+        if escape and (control := _ascii_control_repr(c)):
             text = control
             width = len(control)
         elif ord(c) < 128:
@@ -363,6 +368,8 @@ def disp_str(
     colors: list[ColorSpan] | None = None,
     start_index: int = 0,
     force_color: bool = False,
+    *,
+    escape: bool = True,
 ) -> tuple[CharBuffer, CharWidths]:
     r"""Decompose the input buffer into a printable variant with applied colors.
 
@@ -373,6 +380,9 @@ def disp_str(
       visible character*);
     - the second list is the visible width of each character in the input
       buffer.
+
+    With ``escape=True`` (default) ASCII control chars are rewritten to caret
+    notation (``\\n`` -> ``^J``); pass ``escape=False`` to keep them verbatim.
 
     Note on colors:
     - The `colors` list, if provided, is partially consumed within. We're using
@@ -393,7 +403,9 @@ def disp_str(
     (['\x1b[1;34mw', 'h', 'i', 'l', 'e\x1b[0m', ' ', '1', ':'], [1, 1, 1, 1, 1, 1, 1, 1])
 
     """
-    styled_chars = list(iter_display_chars(buffer, colors, start_index))
+    styled_chars = list(
+        iter_display_chars(buffer, colors, start_index, escape=escape)
+    )
     chars: CharBuffer = []
     char_widths: CharWidths = []
     theme = THEME(force_color=force_color)

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1268,7 +1268,12 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def _colorize_code(self, code):
         if self.colorize and _pyrepl:
             colors = list(_pyrepl.utils.gen_colors(code))
-            chars, _ = _pyrepl.utils.disp_str(code, colors=colors, force_color=True)
+            chars, _ = _pyrepl.utils.disp_str(
+                code,
+                colors=colors,
+                force_color=True,
+                escape=False
+            )
             code = "".join(chars)
         return code
 
@@ -2436,7 +2441,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             elif lineno == exc_lineno:
                 s += '>>'
             if self.colorize:
-                line = self._colorize_code(line.rstrip())
+                line = self._colorize_code(line)
             self.message(s + '\t' + line.rstrip())
 
     def do_whatis(self, arg):

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2436,7 +2436,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             elif lineno == exc_lineno:
                 s += '>>'
             if self.colorize:
-                line = self._colorize_code(line)
+                line = self._colorize_code(line.rstrip())
             self.message(s + '\t' + line.rstrip())
 
     def do_whatis(self, arg):

--- a/Lib/test/test_pyrepl/test_utils.py
+++ b/Lib/test/test_pyrepl/test_utils.py
@@ -1,6 +1,12 @@
 from unittest import TestCase
 
-from _pyrepl.utils import str_width, wlen, prev_next_window, gen_colors
+from _pyrepl.utils import (
+    disp_str,
+    gen_colors,
+    prev_next_window,
+    str_width,
+    wlen,
+)
 
 
 class TestUtils(TestCase):
@@ -159,3 +165,12 @@ class TestUtils(TestCase):
                     span_text = code[color.span.start:color.span.end + 1]
                     actual_highlights.append((span_text, color.tag))
                 self.assertEqual(actual_highlights, expected_highlights)
+
+    def test_disp_str_escape(self):
+        # default: control chars become caret notation
+        chars, _ = disp_str("a\nb\tc\x1bd")
+        self.assertEqual("".join(chars), "a^Jb^Ic^[d")
+
+        # escape=False: control chars pass through verbatim
+        chars, _ = disp_str("a\nb\tc\x1bd", escape=False)
+        self.assertEqual("".join(chars), "a\nb\tc\x1bd")


### PR DESCRIPTION
The source lines pdb fetches from `linecache.getlines` & `inspect.getsourcelines` have trailing `\n` characters

passing them to _pyrepl.utils.disp_str turns them into `^J` codes dirtying the output, pdb already prints line by line with `end="\n"` so rstripping each line shouldnt change the output

Maybe there is already a plan to whole switch pdb's output to the use the structured renderer from pyrepl, but in the meantime it looks broken


<!-- gh-issue-number: gh-153902 -->
* Issue: gh-153902
<!-- /gh-issue-number -->
