### PR TITLE
gh-153521: Preserve bytes message sets in imaplib

### DIFF
--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -168,6 +168,8 @@ def _seq_range(item):
 
 
 def _format_sequence_set(arg):
+    if isinstance(arg, (bytes, bytearray)):
+        return str(arg, 'ascii')
     if isinstance(arg, (int, str)):
         return str(arg)
     # A sequence of message numbers and ranges.

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -292,6 +292,8 @@ class TestImaplib(unittest.TestCase):
         # A scalar is passed through as a string.
         self.assertEqual(m._sequence_set(5), '5')
         self.assertEqual(m._sequence_set('1:3,7'), '1:3,7')
+        self.assertEqual(m._sequence_set(b'1:3,7'), '1:3,7')
+        self.assertEqual(m._sequence_set(bytearray(b'1:3,7')), '1:3,7')
         # A sequence of numbers and ranges is formatted as a sequence set.
         self.assertEqual(m._sequence_set([1, 2, 5]), '1,2,5')
         self.assertEqual(m._sequence_set([1, (3, 5), (8, '*')]), '1,3:5,8:*')
@@ -333,6 +335,7 @@ class TestImaplib(unittest.TestCase):
                          r'(\Seen \Answered)')
         # '?s' formats a message sequence set.
         self.assertEqual(sub('?s', [[1, (3, 5), (8, '*')]]), '1,3:5,8:*')
+        self.assertEqual(sub('?s', [b'1:3,7']), '1:3,7')
         # '??' is a literal '?'.
         self.assertEqual(sub('a?? b', []), 'a? b')
 
@@ -1566,6 +1569,16 @@ class NewIMAPTestsMixin:
         client.login('user', 'pass')
         client.select()
         typ, data = client.fetch('2:4', '(FLAGS)')
+        self.assertEqual(typ, 'OK')
+        self.assertEqual(data, [
+            br'2 (FLAGS (\Seen))',
+            br'3 (FLAGS (\Seen))',
+            br'4 (FLAGS (\Seen))',
+        ])
+        self.assertEqual(server.args, ['2:4', '(FLAGS)'])
+
+        # A preformatted message set may be passed as bytes.
+        typ, data = client.fetch(b'2:4', '(FLAGS)')
         self.assertEqual(typ, 'OK')
         self.assertEqual(data, [
             br'2 (FLAGS (\Seen))',


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


`_format_sequence_set()` treated every non-integer, non-string argument as a structured sequence. As a result, a preformatted bytes message set was iterated byte by byte. For example, `b"2:4"` was sent on the wire as`"50,58,52"`.

Before structured message-set support was added, bytes arguments were passed through unchanged. This therefore caused a backward compatibility regression.

This change decodes preformatted `bytes` and `bytearray` message sets as ASCII before processing structured sequence sets. It also covers bytes used through the new `?s` substitution mechanism.

The tests include an end-to-end FETCH case that verifies the server receives `2:4`, rather than the numeric values of the individual bytes.

Tests:

- `./python.exe -m test test_imaplib -j1`
- `make patchcheck`

No additional NEWS entry is included because this fixes behavior introduced by the unreleased feature tracked by gh-153521, which already has a NEWS entry.


