### PR TITLE
gh-153896: Deduplicate mutable args in `Literal` type

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2801,8 +2801,13 @@ class LiteralTests(BaseTestCase):
         self.assertEqual(Literal[1, 2, 3].__args__, (1, 2, 3))
         self.assertEqual(Literal[1, 2, 3, 3].__args__, (1, 2, 3))
         self.assertEqual(Literal[1, Literal[2], Literal[3, 4]].__args__, (1, 2, 3, 4))
-        # Mutable arguments will not be deduplicated
-        self.assertEqual(Literal[[], []].__args__, ([], []))
+        # Mutable arguments will also be deduplicated:
+        self.assertEqual(Literal[[], []].__args__, ([],))
+        self.assertEqual(
+            Literal[1, {'a': 'b'}, 2, {'a': 'b'}, 3].__args__,
+            (1, {'a': 'b'}, 2, 3),
+        )
+        self.assertEqual(Literal[{1}, {1}, {2}, {2}].__args__, ({1}, {2}))
 
     def test_flatten(self):
         l1 = Literal[Literal[1], Literal[2], Literal[3]]

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -776,10 +776,13 @@ def Literal(self, *parameters):
     # values, not types.
     parameters = _flatten_literal_params(parameters)
 
-    try:
-        parameters = tuple(p for p, _ in _deduplicate(list(_value_and_type_iter(parameters))))
-    except TypeError:  # unhashable parameters
-        pass
+    parameters = tuple(
+        p
+        for p, _ in _deduplicate(
+            list(_value_and_type_iter(parameters)),
+            unhashable_fallback=True,
+        )
+    )
 
     return _LiteralGenericAlias(self, parameters)
 

--- a/Misc/NEWS.d/next/Library/2026-07-18-13-32-04.gh-issue-153896.kj0wCj.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-18-13-32-04.gh-issue-153896.kj0wCj.rst
@@ -1,0 +1,1 @@
+Deduplicate mutable args in :data:`typing.Literal`.


### PR DESCRIPTION
It does not look to complex as a change, moreover this brings consistency among different arg types. Desipe the fact that `Literal[[], []]` does not really make much sense as a typing form as of right now.

But, it might be for some custom runtime type checks / etc.

Should we backport this?

<!-- gh-issue-number: gh-153896 -->
* Issue: gh-153896
<!-- /gh-issue-number -->
