### PR TITLE
gh-153908: Fix datarace in itertools.count().repr()

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-18-11-16-41.gh-issue-153908.82FiGk.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-18-11-16-41.gh-issue-153908.82FiGk.rst
@@ -1,1 +1,0 @@
-Fix data race in repr in itertools.counter() for freethreading builds

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-18-11-16-41.gh-issue-153908.82FiGk.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-18-11-16-41.gh-issue-153908.82FiGk.rst
@@ -1,0 +1,1 @@
+Fix data race in repr in itertools.counter() for freethreading builds

--- a/Misc/NEWS.d/next/Library/2026-07-18-11-16-41.gh-issue-153908.82FiGk.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-18-11-16-41.gh-issue-153908.82FiGk.rst
@@ -1,0 +1,1 @@
+Fix data race when calling :func:`repr` on :class:`itertools.count` under the :term:`free-threaded build`.

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3675,9 +3675,13 @@ static PyObject *
 count_repr(PyObject *op)
 {
     countobject *lz = countobject_CAST(op);
-    if (lz->long_cnt == NULL)
+    if (lz->long_cnt == NULL) {
+        /* Match the atomic access in count_next(); a concurrent next() may
+           be advancing lz->cnt via _Py_atomic_compare_exchange_ssize(). */
+        Py_ssize_t cnt = _Py_atomic_load_ssize_relaxed(&lz->cnt);
         return PyUnicode_FromFormat("%s(%zd)",
-                                    _PyType_Name(Py_TYPE(lz)), lz->cnt);
+                                    _PyType_Name(Py_TYPE(lz)), cnt);
+    }
 
     if (PyLong_Check(lz->long_step)) {
         long step = PyLong_AsLong(lz->long_step);

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3676,9 +3676,7 @@ count_repr(PyObject *op)
 {
     countobject *lz = countobject_CAST(op);
     if (lz->long_cnt == NULL) {
-        /* Match the atomic access in count_next(); a concurrent next() may
-           be advancing lz->cnt via _Py_atomic_compare_exchange_ssize(). */
-        Py_ssize_t cnt = _Py_atomic_load_ssize_relaxed(&lz->cnt);
+        Py_ssize_t cnt = FT_ATOMIC_LOAD_SSIZE_RELAXED(lz->cnt);
         return PyUnicode_FromFormat("%s(%zd)",
                                     _PyType_Name(Py_TYPE(lz)), cnt);
     }


### PR DESCRIPTION
Uses atomic load to ensure protected read to internal `cnt` variable that can be incremented on `next()`

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-153908 -->
* Issue: gh-153908
<!-- /gh-issue-number -->

When using `repro_tsan_0006_count.py` as a temporary script to expose the issue we not longer have TSAN flags

```
➜  cpython git:(tsan-0006-itertools-count-repr-ft) ✗ PYTHON_GIL=0 ./python.exe repro_tsan_0006_count.py
done (no race detected)
```