### PR TITLE
gh-153926: Fix documented parameter name for `calendar.calendar` and `calendar.prcal`

### DIFF
--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -430,12 +430,12 @@ For simple text calendars this module provides the following functions.
    of the :class:`TextCalendar` class.
 
 
-.. function:: prcal(year, w=0, l=0, c=6, m=3)
+.. function:: prcal(theyear, w=0, l=0, c=6, m=3)
 
    Prints the calendar for an entire year as returned by  :func:`calendar`.
 
 
-.. function:: calendar(year, w=2, l=1, c=6, m=3)
+.. function:: calendar(theyear, w=2, l=1, c=6, m=3)
 
    Returns a 3-column calendar for an entire year as a multi-line string using
    the :meth:`~TextCalendar.formatyear` of the :class:`TextCalendar` class.


### PR DESCRIPTION
`calendar.calendar()` and `calendar.prcal()` document their first parameter as `year`, but both are bound methods of the module's `TextCalendar` instance (`calendar = c.formatyear`, `prcal = c.pryear`) whose first parameter is named `theyear`. Calling `calendar.calendar(year=2025)` therefore raises `TypeError`, while `theyear=2025` works.

This updates the documentation to use the real parameter name `theyear`, which also matches the sibling `month()` and `prmonth()` functions documented just above.

Fixes #153926.

<!-- gh-issue-number: gh-153926 -->
* Issue: gh-153926
<!-- /gh-issue-number -->
