### PR TITLE
gh-153854: Fix imaplib.Time2Internaldate crash on an empty string

### DIFF
--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -2272,7 +2272,7 @@ def Time2Internaldate(date_time):
         if date_time.tzinfo is None:
             raise ValueError("date_time must be aware")
         dt = date_time
-    elif isinstance(date_time, str) and (date_time[0],date_time[-1]) == ('"','"'):
+    elif isinstance(date_time, str) and (date_time[:1], date_time[-1:]) == ('"', '"'):
         return date_time        # Assume in correct format
     else:
         raise ValueError("date_time not of a known type")

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -152,6 +152,14 @@ class TestImaplib(unittest.TestCase):
             '"18-May-2033 05:33:20 +0200"',
         )
 
+    def test_Time2Internaldate_invalid_str(self):
+        # gh-153854: an empty string raised IndexError instead of the
+        # documented ValueError.
+        for invalid in '', '18-May-2033 05:33:20 +0200':
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(ValueError):
+                    imaplib.Time2Internaldate(invalid)
+
     def test_that_Time2Internaldate_returns_a_result(self):
         # Without tzset, we can check only that it successfully
         # produces a result, not the correctness of the result itself,

--- a/Misc/NEWS.d/next/Library/2026-07-17-14-30-00.gh-issue-153854.Xw3Fyz.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-17-14-30-00.gh-issue-153854.Xw3Fyz.rst
@@ -1,0 +1,2 @@
+Fix :func:`imaplib.Time2Internaldate` raising :exc:`IndexError` instead of
+:exc:`ValueError` when passed an empty string.


### PR DESCRIPTION
`Time2Internaldate` subscripted its string argument before the type check, so an empty string raised `IndexError: string index out of range` instead of the function's own intended `ValueError("date_time not of a known type")`:

```pycon
>>> import imaplib
>>> imaplib.Time2Internaldate('')
Traceback (most recent call last):
  ...
IndexError: string index out of range
```

This PR switches the quoted-string check to slices, which are simply unequal to `('"', '"')` for an empty string, so control falls through to the intended `ValueError`. Behavior for every other input, including the single-character `'"'`, is unchanged. Includes a regression test and a NEWS entry.

Fixes gh-153854.