### PR TITLE
gh-71896: warn in doc about trailing newlines ignored by HtmlDiff

### DIFF
--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -85,6 +85,11 @@ diffs. For comparing directories and files, see also, the :mod:`filecmp` module.
    with inter-line and intra-line change highlights.  The table can be generated in
    either full or contextual difference mode.
 
+   .. warning::
+
+      The trailing newlines get stripped before the diff, so the result can be
+      incomplete. See :gh:`71896` for details.
+
    The constructor for this class is:
 
 

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -2016,6 +2016,8 @@ class HtmlDiff(object):
 
         # change tabs to spaces before it gets more difficult after we insert
         # markup
+        # it also removes trailing newlines, causing some diffs to be missed
+        # see: gh-71896
         fromlines,tolines = self._tab_newline_replace(fromlines,tolines)
 
         # create diffs iterator which generates side by side from/to data

--- a/Lib/test/test_difflib.py
+++ b/Lib/test/test_difflib.py
@@ -284,6 +284,29 @@ class TestSFpatches(unittest.TestCase):
         self.assertIn('charset="us-ascii"', output)
         self.assertIn('&#305;mpl&#305;c&#305;t', output)
 
+    def test_strip_trailing_newlines_before_diff(self):
+        # characterization test for the current buggy behavior
+        # see: gh-71896
+        html_diff = difflib.HtmlDiff()
+        from_lines = [
+            "Line 1: no newline after",
+            "Line 2: one newline after\n",
+            "Line 3: several newlines after\n\n\n\n\n",
+        ]
+        to_lines = [
+            "Line 1: no newline after",
+            "Line 2: one newline after",  # actually no \n
+            "Line 3: several newlines after",  # actually no \n
+        ]
+        output = html_diff.make_table(from_lines, to_lines)
+        # we (currently) expect no line change, so all equal
+        self.assertNotIn('class="diff_add"', output)
+        self.assertNotIn('class="diff_chg"', output)
+        self.assertNotIn('class="diff_sub"', output)
+        self.assertEqual(output.count('>Line&nbsp;1:&nbsp;no&nbsp;newline&nbsp;after<'), 2)
+        self.assertEqual(output.count('>Line&nbsp;2:&nbsp;one&nbsp;newline&nbsp;after<'), 2)
+        self.assertEqual(output.count('>Line&nbsp;3:&nbsp;several&nbsp;newlines&nbsp;after<'), 2)
+
 class TestDiffer(unittest.TestCase):
     def test_close_matches_aligned(self):
         # Of the 4 closely matching pairs, we want 1 to match with 3,

--- a/Misc/NEWS.d/next/Documentation/2026-07-18-14-02-10.gh-issue-71896.qK7pLm.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-07-18-14-02-10.gh-issue-71896.qK7pLm.rst
@@ -1,3 +1,0 @@
-Document a long-standing bug where :class:`~difflib.HtmlDiff` strips trailing
-newlines from input lines before diffing, causing some differences to be
-missed. A regression test now pins down this behavior.

--- a/Misc/NEWS.d/next/Documentation/2026-07-18-14-02-10.gh-issue-71896.qK7pLm.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-07-18-14-02-10.gh-issue-71896.qK7pLm.rst
@@ -1,0 +1,3 @@
+Document a long-standing bug where :class:`~difflib.HtmlDiff` strips trailing
+newlines from input lines before diffing, causing some differences to be
+missed. A regression test now pins down this behavior.


### PR DESCRIPTION


<!-- gh-issue-number: gh-71896 -->
* Issue: gh-71896
<!-- /gh-issue-number -->
