### PR TITLE
Improve getopt and unix_getopt test coverage

### DIFF
--- a/Lib/test/test_getopt.py
+++ b/Lib/test/test_getopt.py
@@ -149,6 +149,18 @@ class GetoptTests(unittest.TestCase):
                                 ('-a', ''), ('--alpha', '')])
         self.assertEqual(args, ['arg1', 'arg2'])
 
+        # Allow string for single long argument
+        opts, args = getopt.getopt(cmdline, 'a::', 'alpha=?')
+        self.assertEqual(opts, [('-a', '1'), ('--alpha', '2'), ('--alpha', ''),
+                                ('-a', ''), ('--alpha', '')])
+        self.assertEqual(args, ['arg1', 'arg2'])
+
+        # Pass everything after -- as args
+        cmdline = ['-a1', '--alpha=2', '--', '-b', '--beta=5']
+        opts, args = getopt.getopt(cmdline, 'a:b', ['alpha=', 'beta'])
+        self.assertEqual(opts, [('-a', '1'), ('--alpha', '2')])
+        self.assertEqual(args, ['-b', '--beta=5'])
+
         self.assertError(getopt.getopt, cmdline, 'a:b', ['alpha', 'beta'])
 
     def test_gnu_getopt(self):
@@ -190,6 +202,25 @@ class GetoptTests(unittest.TestCase):
         self.assertEqual(opts, [('-a', '')])
         self.assertEqual(args, ['arg1', '-b', '1', '--alpha', '--beta=2',
                                 '--beta', '3', 'arg2'])
+
+        # Allow string for single long argument
+        opts, args = getopt.gnu_getopt(cmdline, 'ab:', 'alpha')
+        self.assertEqual(opts, [('-a', '')])
+        self.assertEqual(args, ['arg1', '-b', '1', '--alpha', '--beta=2',
+                                '--beta', '3', 'arg2'])
+
+        # Pass everything after -- as args
+        cmdline = ['-a1', '--alpha=2', '--', '-b', '--beta=5']
+        opts, args = getopt.gnu_getopt(cmdline, 'a:b', ['alpha=', 'beta'])
+        self.assertEqual(opts, [('-a', '1'), ('--alpha', '2')])
+        self.assertEqual(args, ['-b', '--beta=5'])
+
+        # In order arguments
+        cmdline = ["gamma", "--alpha=3"]
+        opts, args = getopt.gnu_getopt(cmdline, '-', ["alpha="])
+        self.assertEqual(opts, [(None, ['gamma']), ('--alpha', '3')])
+        self.assertEqual(args, [])
+
 
     def test_issue4629(self):
         longopts, shortopts = getopt.getopt(['--help='], '', ['help='])


### PR DESCRIPTION
In both `getopt()` and `gnu_getopt()` tests were missing for `--` to pass the remainder of the `args` as unconsumed program arguments, as well as passing long-arguments as a plain string instead of a list of strings.

For `gnu_getopt()` this PR also adds a test for order-preservation with preceding non-option arguments before long-arguments.