### PR TITLE
gh-153934: Correct documented param from n to width

### DIFF
--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -400,9 +400,9 @@ For simple text calendars this module provides the following functions.
    *month* (``1``--``12``), *day* (``1``--``31``).
 
 
-.. function:: weekheader(n)
+.. function:: weekheader(width)
 
-   Return a header containing abbreviated weekday names. *n* specifies the width in
+   Return a header containing abbreviated weekday names. *width* specifies the width in
    characters for one weekday.
 
 


### PR DESCRIPTION
### Documentation

Documentation contains the [following signature](https://github.com/python/cpython/blob/7f8fc07e850d7b27a220c815db8c8abd545286c3/Doc/library/calendar.rst?plain=1#L403): 

```
.. function:: weekheader(n)

   Return a header containing abbreviated weekday names. *n* specifies the width in
   characters for one weekday.
```

In reality [the function](https://github.com/python/cpython/blob/d7b171b6b32c823f28ba974e7c80c4fdfe78c98e/Lib/calendar.py#L387) uses "width" as the parameter name: 

```
def formatweekheader(self, width):
        """
        Return a header for a week.
        """
        header = super().formatweekheader(width)
        theme = self._get_theme().calendar
        return f"{theme.weekday}{header}{theme.reset}"
```

Documentation in the calendar.rst file should be updated to reflect the actual implementation.

<!-- gh-issue-number: gh-153934 -->
* Issue: gh-153934
<!-- /gh-issue-number -->
