### PR TITLE
gh-70066: Switch MSVC build to use /W4 and suppress noisy warnings.

### DIFF
--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -69,7 +69,8 @@
       <ExceptionHandling></ExceptionHandling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
+      <DisableSpecificWarnings>4232;4706;4152;4204;4131;4115;4127;4054;4100;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
       <SuppressStartupBanner>true</SuppressStartupBanner>


### PR DESCRIPTION


<!-- gh-issue-number: gh-70066 -->
* Issue: gh-70066
<!-- /gh-issue-number -->
