### PR TITLE
Improve colorsys coverage

### DIFF
--- a/Lib/test/test_colorsys.py
+++ b/Lib/test/test_colorsys.py
@@ -42,6 +42,10 @@ class ColorsysTest(unittest.TestCase):
             self.assertTripleEqual(hsv, colorsys.rgb_to_hsv(*rgb))
             self.assertTripleEqual(rgb, colorsys.hsv_to_rgb(*hsv))
 
+            # test 360 phase shift in hue
+            h, s, v = hsv
+            self.assertTripleEqual(rgb, colorsys.hsv_to_rgb(h + 1.0, s, v))
+
     def test_hls_roundtrip(self):
         for r in frange(0.0, 1.0, 0.2):
             for g in frange(0.0, 1.0, 0.2):
@@ -88,6 +92,17 @@ class ColorsysTest(unittest.TestCase):
                         rgb,
                         colorsys.yiq_to_rgb(*colorsys.rgb_to_yiq(*rgb))
                     )
+
+    def test_yiq_to_rgb_clamping(self):
+        values = [
+            # rgb, yiq (invalid YIQ values clamped to RGB range)
+            ((1.0, 0.0, 1.0), (0.0, 0.5, 1.0)),
+            ((0.0, 1.0, 0.0), (0.25, -1.0, -1.0)),
+            ((0.0, 0.0, 1.0), (0.0, -1.0, 0.5))
+        ]
+
+        for (rgb, yiq) in values:
+            self.assertTripleEqual(rgb, colorsys.yiq_to_rgb(*yiq))
 
     def test_yiq_values(self):
         values = [

--- a/Lib/test/test_colorsys.py
+++ b/Lib/test/test_colorsys.py
@@ -102,7 +102,8 @@ class ColorsysTest(unittest.TestCase):
         ]
 
         for (rgb, yiq) in values:
-            self.assertTripleEqual(rgb, colorsys.yiq_to_rgb(*yiq))
+            with self.subTest(rgb=rgb, yiq=yiq):
+                self.assertTripleEqual(rgb, colorsys.yiq_to_rgb(*yiq))
 
     def test_yiq_values(self):
         values = [


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
The changes improve the test coverage and robustness of the `colorsys` module.
They add an extra test to ensure that HSV to RGB remains constant in the case of a 360° phase shift of the Hue.
Additionally, it tests the clamping fallback in the case of YIQ to RGB conversion.