### PR TITLE
Add vfspath TypeError test

### DIFF
--- a/Lib/test/test_pathlib/test_join_windows.py
+++ b/Lib/test/test_pathlib/test_join_windows.py
@@ -87,6 +87,11 @@ class JoinTestBase:
         p = self.cls(r'\\a\b\c\d')
         self.assertEqual(vfspath(p), '\\\\a\\b\\c\\d')
 
+    def test_invalid_vspath(self):
+        msg = "expected JoinablePath object, not NoneType"
+        with self.assertRaisesRegex(TypeError, msg):
+            vfspath(None)
+
     def test_parts(self):
         P = self.cls
         p = P(r'c:a\b')


### PR DESCRIPTION
Ensures that an object of an invalid type, such as `vfspath(None)`, trigger a TypeError with an appropriate message