### PR TITLE
[3.15] gh-152769: fixup enabling of perf trampoline on musl (Alpine Linux)

### DIFF
--- a/configure
+++ b/configure
@@ -14431,9 +14431,9 @@ case $PLATFORM_TRIPLET in #(
     perf_trampoline=yes ;; #(
   aarch64-linux-gnu) :
     perf_trampoline=yes ;; #(
-  x86_64-linux-gnu) :
-    perf_trampoline=yes ;; #(
   x86_64-linux-musl) :
+    perf_trampoline=yes ;; #(
+  aarch64-linux-musl) :
     perf_trampoline=yes ;; #(
   darwin) :
     case $MACOSX_DEPLOYMENT_TARGET in #(

--- a/configure.ac
+++ b/configure.ac
@@ -3873,8 +3873,8 @@ AC_MSG_CHECKING([perf trampoline])
 AS_CASE([$PLATFORM_TRIPLET],
   [x86_64-linux-gnu], [perf_trampoline=yes],
   [aarch64-linux-gnu], [perf_trampoline=yes],
-  [x86_64-linux-gnu], [perf_trampoline=yes],
   [x86_64-linux-musl], [perf_trampoline=yes],
+  [aarch64-linux-musl], [perf_trampoline=yes],
   [darwin], [AS_CASE([$MACOSX_DEPLOYMENT_TARGET],
                 [[10.[0-9]|10.1[0-1]]], [perf_trampoline=no],
                 [perf_trampoline=yes]


### PR DESCRIPTION
This fixes the addition of the `aarch64-linux-musl` platform from #153456


<!-- gh-issue-number: gh-152769 -->
* Issue: gh-152769
<!-- /gh-issue-number -->
