### PR TITLE
gh-154001: Avoid division by zero in `binomialvariate`

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -861,6 +861,8 @@ class Random(_random.Random):
             u = random()
             u -= 0.5
             us = 0.5 - _fabs(u)
+            if us == 0.0:
+                continue
             k = _floor((2.0 * a / us + b) * u + c)
             if k < 0 or k > n:
                 continue

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -861,9 +861,11 @@ class Random(_random.Random):
             u = random()
             u -= 0.5
             us = 0.5 - _fabs(u)
-            if us == 0.0:
+            try:
+                k = _floor((2.0 * a / us + b) * u + c)
+            except ZeroDivisionError:
+                # Reject case where random() returned 0.0
                 continue
-            k = _floor((2.0 * a / us + b) * u + c)
             if k < 0 or k > n:
                 continue
             v = random()

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -1082,6 +1082,14 @@ class TestDistributions(unittest.TestCase):
             self.assertIsInstance(result, int)
             self.assertIn(result, range(11))
 
+    def test_binomialvariate_btrs_random_zero(self):
+        for p, expected in ((0.25, 25), (0.75, 75)):
+            with self.subTest(p=p):
+                g = random.Random()
+                with unittest.mock.patch.object(
+                        g, 'random', side_effect=(0.0, 0.5, 0.5)):
+                    self.assertEqual(g.binomialvariate(100, p), expected)
+
     def test_constant(self):
         g = random.Random()
         N = 100

--- a/Misc/NEWS.d/next/Library/2026-07-18-17-09-49.gh-issue-154001.3brrUv.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-18-17-09-49.gh-issue-154001.3brrUv.rst
@@ -1,0 +1,2 @@
+Fix :meth:`random.Random.binomialvariate` raising :exc:`ZeroDivisionError`
+when a random draw is zero.

--- a/Misc/NEWS.d/next/Library/2026-07-18-17-09-49.gh-issue-154001.3brrUv.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-18-17-09-49.gh-issue-154001.3brrUv.rst
@@ -1,2 +1,2 @@
-Fix ``random.Random.binomialvariate()`` raising :exc:`ZeroDivisionError`
-when a random draw is zero.
+Fix :func:`random.binomialvariate` raising :exc:`ZeroDivisionError`
+when :func:`random.random` returns zero.

--- a/Misc/NEWS.d/next/Library/2026-07-18-17-09-49.gh-issue-154001.3brrUv.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-18-17-09-49.gh-issue-154001.3brrUv.rst
@@ -1,2 +1,2 @@
-Fix :meth:`random.Random.binomialvariate` raising :exc:`ZeroDivisionError`
+Fix :func:`random.binomialvariate` raising :exc:`ZeroDivisionError`
 when a random draw is zero.

--- a/Misc/NEWS.d/next/Library/2026-07-18-17-09-49.gh-issue-154001.3brrUv.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-18-17-09-49.gh-issue-154001.3brrUv.rst
@@ -1,2 +1,2 @@
-Fix :func:`random.binomialvariate` raising :exc:`ZeroDivisionError`
+Fix ``random.Random.binomialvariate()`` raising :exc:`ZeroDivisionError`
 when a random draw is zero.


### PR DESCRIPTION
`random.binomialvariate()` can raise `ZeroDivisionError` when `random()` returns `0.0` in one of the paths.

My initial simplest proposal of the fix is to reject zero, matching the retry behavior used in the other path.

Added regression tests.

Fixes #154001

<!-- gh-issue-number: gh-154001 -->
* Issue: gh-154001
<!-- /gh-issue-number -->
