### PR TITLE
gh-153395: Fix test_complexchar on narrow curses builds

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -2799,9 +2799,11 @@ class TestAscii(unittest.TestCase):
         # its single character.  A narrow build just forms fewer cells.
         cc = curses.complexchar
         def storable(s):
+            # ValueError if s has combining marks on a narrow build.
+            # OverflowError if s is a multibyte character on a narrow build.
             try:
                 cc(s)
-            except ValueError:
+            except (ValueError, OverflowError):
                 return False
             return True
 


### PR DESCRIPTION
`test_complexchar` errors on narrow curses builds under a multibyte (e.g. UTF-8) locale: `complexchar('\xe9')` raises `OverflowError` (the character has no single-byte cell) rather than `ValueError`, which the `storable()` helper did not catch, so the non-ASCII assertions raised instead of being skipped.

This surfaced as buildbot failures on Debian root and macOS after gh-153395; the `OverflowError` itself is long-standing behaviour of `PyCurses_ConvertToChtype`, not new.

<!-- gh-issue-number: gh-153395 -->
* Issue: gh-153395
<!-- /gh-issue-number -->
