### PR TITLE
Test that `ValueError` is raised when `vfsopen` is passed an invalid mode

### DIFF
--- a/Lib/test/test_pathlib/test_read.py
+++ b/Lib/test/test_pathlib/test_read.py
@@ -331,8 +331,8 @@ class ReadTestBase:
 
     def test_invalid_mode(self): 
         p = self.root / 'fileA'
-        with self.assertRaisesRegex(ValueError, "invalid mode"): 
-            vfsopen(p, "q")
+        with self.assertRaisesRegex(ValueError, 'invalid mode'): 
+            vfsopen(p, 'q')
 
 
 class ZipPathReadTest(ReadTestBase, unittest.TestCase):

--- a/Lib/test/test_pathlib/test_read.py
+++ b/Lib/test/test_pathlib/test_read.py
@@ -329,7 +329,14 @@ class ReadTestBase:
         self.assertFalse((p / 'fileA\udfff').info.is_symlink())
         self.assertFalse((p / 'fileA\x00').info.is_symlink())
 
+    def test_invalid_mode(self): 
+        p = self.root / 'fileA'
+        
+        with self.assertRaisesRegex(ValueError, "invalid mode"): 
+            vfsopen(p, "q")
 
+    
+    
 class ZipPathReadTest(ReadTestBase, unittest.TestCase):
     ground = ZipPathGround(ReadableZipPath)
 

--- a/Lib/test/test_pathlib/test_read.py
+++ b/Lib/test/test_pathlib/test_read.py
@@ -331,12 +331,10 @@ class ReadTestBase:
 
     def test_invalid_mode(self): 
         p = self.root / 'fileA'
-        
         with self.assertRaisesRegex(ValueError, "invalid mode"): 
             vfsopen(p, "q")
 
-    
-    
+
 class ZipPathReadTest(ReadTestBase, unittest.TestCase):
     ground = ZipPathGround(ReadableZipPath)
 

--- a/Lib/test/test_pathlib/test_read.py
+++ b/Lib/test/test_pathlib/test_read.py
@@ -329,9 +329,9 @@ class ReadTestBase:
         self.assertFalse((p / 'fileA\udfff').info.is_symlink())
         self.assertFalse((p / 'fileA\x00').info.is_symlink())
 
-    def test_invalid_mode(self): 
+    def test_invalid_mode(self):
         p = self.root / 'fileA'
-        with self.assertRaisesRegex(ValueError, 'invalid mode'): 
+        with self.assertRaisesRegex(ValueError, 'invalid mode'):
             vfsopen(p, 'q')
 
 


### PR DESCRIPTION
Ensures vfsopen called with invalid "mode" argument raises a ValueError with correct initial error message ("invalid mode...")

