### PR TITLE
Fix typo "extenstion" in howto/abi3t-migration.rst documentation

### DIFF
--- a/Doc/howto/abi3t-migration.rst
+++ b/Doc/howto/abi3t-migration.rst
@@ -127,7 +127,7 @@ Prerequisites
 This guide assumes that you have an extension written directly in C (or C++),
 which you want to port to ``abi3t``.
 
-If your extenstion uses a code generator (like Cython) or language binding
+If your extension uses a code generator (like Cython) or language binding
 (like PyO3), it's best to wait until that tool has support for ``abi3t``.
 If you maintain such a tool, you might be able to adapt the instructions
 here for your tool.


### PR DESCRIPTION
Fix typo `extenstion` to `extension` in howto/abi3t-migration.rst documentation.

## Methodology

```bash
$ brew install typos-cli
$ typos abi3t-migration.rst
error: `extenstion` should be `extension`
    ╭▸ abi3t-migration.rst:130:9
    │
130 │ If your extenstion uses a code generator (like Cython) or language binding
    ╰╴        ━━━━━━━━━━
```