### PR TITLE
Fix typo "extenstion" in Modules/xxlimited.c

### DIFF
--- a/Modules/xxlimited.c
+++ b/Modules/xxlimited.c
@@ -633,7 +633,7 @@ xx_free(void *module)
     }
 }
 
-// Information that CPython uses to prevent loading incompatible extenstions
+// Information that CPython uses to prevent loading incompatible extensions
 PyABIInfo_VAR(abi_info);
 
 static PySlot xx_slots[] = {


### PR DESCRIPTION
Fix typo `extenstion` to `extensions` in Modules/xxlimited.c

## Methodology

```bash
$ brew install typos-cli
$ typos xxlimited.c 
error: `extenstions` should be `extensions`
    ╭▸ xxlimited.c:636:66
    │
636 │ // Information that CPython uses to prevent loading incompatible extenstions
    ╰╴                                                                 ━━━━━━━━━━━
```