### PR TITLE
Fix typo "nubmer" in Descriptor Guide documentation

### DIFF
--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -1553,10 +1553,10 @@ assignments.  Only attribute names specified in ``__slots__`` are allowed:
 .. doctest::
 
         >>> auto = Vehicle()
-        >>> auto.id_nubmer = 'VYE483814LQEX'
+        >>> auto.id_number = 'VYE483814LQEX'
         Traceback (most recent call last):
             ...
-        AttributeError: 'Vehicle' object has no attribute 'id_nubmer'
+        AttributeError: 'Vehicle' object has no attribute 'id_number'
 
 2. Helps create immutable objects where descriptors manage access to private
 attributes stored in ``__slots__``:


### PR DESCRIPTION
Fix typo `nubmer` to `number` in Descriptor Guide documentation

## Methodology

```bash
$ brew install typos-cli

$ typos descriptor.rst
error: `nubmer` should be `number`
     ╭▸ descriptor.rst:1556:21
     │
1556 │         >>> auto.id_nubmer = 'VYE483814LQEX'
     ╰╴                    ━━━━━━
error: `nubmer` should be `number`
     ╭▸ descriptor.rst:1559:63
     │
1559 │         AttributeError: 'Vehicle' object has no attribute 'id_nubmer'
     ╰╴                                                              ━━━━━━
```