### PR TITLE
Fix typo "interruptability" in Logging Cookbook documentation

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -1955,7 +1955,7 @@ Subclass ``QueueListener``
     class NNGSocketListener(logging.handlers.QueueListener):
 
         def __init__(self, uri, /, *handlers, **kwargs):
-            # Have a timeout for interruptability, and open a
+            # Have a timeout for interruptibility, and open a
             # subscriber socket
             socket = pynng.Sub0(listen=uri, recv_timeout=500)
             # The b'' subscription matches all topics


### PR DESCRIPTION
Fix typo `interruptability` to `interruptibility` in Logging Cookbook documentation.

## Detection Method

```bash
$ brew install typos-cli

$ typos logging-cookbook.rst
error: `interruptability` should be `interruptibility`
     ╭▸ logging-cookbook.rst:1958:34
     │
1958 │             # Have a timeout for interruptability, and open a
     ╰╴                                 ━━━━━━━━━━━━━━━━
```

## Other Considerations Taken

- [x] Confirm this is not an intentional typo.
- [x] Confirm this is not a duplicate issue/PR.