### PR TITLE
gh-62534: Document that three-argument type() does not call __prepare__

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -2179,6 +2179,11 @@ are always available.  They are listed here in alphabetical order.
    in the same way that keywords in a class
    definition (besides *metaclass*) would.
 
+   Unlike a :keyword:`class` statement, the three argument form does not
+   call the metaclass ``__prepare__`` method (see :ref:`prepare`).  Use
+   :func:`types.new_class` to dynamically create a class using the
+   appropriate metaclass.
+
    See also :ref:`class-customization`.
 
    .. versionchanged:: 3.6


### PR DESCRIPTION
The three-argument form of `type()` skips the metaclass `__prepare__` method — `__prepare__` is called by the `class` statement machinery, not by the metaclass call itself — so a class created with `type('C', (Parent,), {})` silently misses anything a base's metaclass prepares. The entry currently calls the form "essentially a dynamic form of the class statement" and documents the keyword-argument metaclass machinery, but never mentions this difference.

Add the note the issue thread settled on: state that the three-argument form does not call `__prepare__`, and point to `types.new_class()` for dynamic class creation with the appropriate metaclass. Raising instead was considered and rejected in the thread, since a metaclass's own `__new__` legitimately calls `type(name, bases, ns)`.

Verified at tip: a subclass created via the `class` statement or `types.new_class()` gets the prepared namespace; the same bases through three-argument `type()` do not.


<!-- gh-issue-number: gh-62534 -->
* Issue: gh-62534
<!-- /gh-issue-number -->
