### PR TITLE
How to skip nuget.config

### DIFF
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -1183,6 +1183,10 @@ using curl or PowerShell. With the tool, the latest version of Python for
    nuget.exe install python -ExcludeVersion -OutputDirectory .
    nuget.exe install pythonx86 -ExcludeVersion -OutputDirectory .
 
+Resolve error `Unable to find package 'python'` from a misconfigured `nuget.config` using::
+
+   nuget.exe sources add -Name "nuget.org" -source "https://api.nuget.org/v3/index.json"
+
 To select a particular version, add a ``-Version 3.x.y``. The output directory
 may be changed from ``.``, and the package will be installed into a
 subdirectory. By default, the subdirectory is named the same as the package,

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -1183,10 +1183,6 @@ using curl or PowerShell. With the tool, the latest version of Python for
    nuget.exe install python -ExcludeVersion -OutputDirectory .
    nuget.exe install pythonx86 -ExcludeVersion -OutputDirectory .
 
-Resolve error ``Unable to find package 'python'`` from a misconfigured ``nuget.config`` using::
-
-   nuget.exe sources add -Name "nuget.org" -source "https://api.nuget.org/v3/index.json"
-
 To select a particular version, add a ``-Version 3.x.y``. The output directory
 may be changed from ``.``, and the package will be installed into a
 subdirectory. By default, the subdirectory is named the same as the package,
@@ -1220,6 +1216,10 @@ for the 64-bit version, `www.nuget.org/packages/pythonx86
 <https://www.nuget.org/packages/pythonx86>`_ for the 32-bit version, and
 `www.nuget.org/packages/pythonarm64
 <https://www.nuget.org/packages/pythonarm64>`_ for the ARM64 version
+
+Resolve error ``Unable to find package 'python'`` from a misconfigured ``nuget.config`` using::
+
+   nuget.exe sources add -Name "nuget.org" -source "https://api.nuget.org/v3/index.json"
 
 Free-threaded packages
 ----------------------

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -1183,7 +1183,7 @@ using curl or PowerShell. With the tool, the latest version of Python for
    nuget.exe install python -ExcludeVersion -OutputDirectory .
    nuget.exe install pythonx86 -ExcludeVersion -OutputDirectory .
 
-Resolve error `Unable to find package 'python'` from a misconfigured `nuget.config` using::
+Resolve error ``Unable to find package 'python'`` from a misconfigured ``nuget.config`` using::
 
    nuget.exe sources add -Name "nuget.org" -source "https://api.nuget.org/v3/index.json"
 


### PR DESCRIPTION
Developers who do not already have nuget and do not need to write a nuget.config file can use this one extra command to let nuget find the python package in the official repository.

<!-- gh-issue-number: gh-114073 -->
* Issue: gh-114073
<!-- /gh-issue-number -->
