### PR TITLE
gh-104533: Fix `@ctypes.util.struct` with string annotations

### DIFF
--- a/Lib/ctypes/util.py
+++ b/Lib/ctypes/util.py
@@ -512,7 +512,8 @@ def _process_struct(decorated_class, /, *, align, layout, endian, pack):
         fields.extend(decorated_class._fields_)
         anonymous.extend(decorated_class._anonymous_)
 
-    for name, hint in annotationlib.get_annotations(decorated_class).items():
+    annotations = annotationlib.get_annotations(decorated_class, eval_str=True)
+    for name, hint in annotations.items():
         if get_origin(hint) is ClassVar:
             continue
 

--- a/Lib/test/test_ctypes/struct_str_ann.py
+++ b/Lib/test/test_ctypes/struct_str_ann.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from ctypes.util import struct
+from ctypes import c_int
+
+class TestAnn:
+    x: c_int
+
+# Check that "from __future__ import annotations" works as expected
+if not isinstance(TestAnn.__annotations__['x'], str):
+    raise Exception("annotations must be strings")
+
+@struct
+class Point:
+    x: c_int
+    y: c_int

--- a/Lib/test/test_ctypes/test_structures.py
+++ b/Lib/test/test_ctypes/test_structures.py
@@ -88,13 +88,14 @@ class StructureTestCase(unittest.TestCase, StructCheckMixin):
         self.assertEqual(sizeof(X), min(8, longlong_align) + longlong_size)
         self.assertEqual(X.b.offset, min(8, longlong_align))
 
-        with self.assertRaises(ValueError):
-            if use_struct_util:
+        if use_struct_util:
+            with self.assertRaises(NameError):
                 @struct_util(pack=-1, layout='ms')
                 class X:
                     a: "b"
                     b: "q"
-            else:
+        else:
+            with self.assertRaises(ValueError):
                 class X(Structure):
                     _fields_ = [("a", "b"), ("b", "q")]
                     _pack_ = -1
@@ -953,6 +954,12 @@ class StructureTestCase(unittest.TestCase, StructCheckMixin):
             pass
 
         self.assertEqual(Foo.__name__, "Foo")
+
+    def test_string_annotations(self):
+        from test.test_ctypes import struct_str_ann
+        Point = struct_str_ann.Point
+        fields = [['x', c_int], ['y', c_int]]
+        self.assertEqual(Point._fields_, fields)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix `@ctypes.util.struct` on structures declared in a module which uses `from __future__ import annotations`. The decorator now calls get_annotations() with eval_str=True.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-104533 -->
* Issue: gh-104533
<!-- /gh-issue-number -->
