### PR TITLE
gh-154046: docs: fix dead link to codahale timing attacks article in secrets.rst

### DIFF
--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -137,7 +137,7 @@ Other functions
    :term:`bytes-like objects <bytes-like object>`
    *a* and *b* are equal, otherwise ``False``,
    using a "constant-time compare" to reduce the risk of
-   `timing attacks <https://codahale.com/a-lesson-in-timing-attacks/>`_.
+   `timing attacks <https://web.archive.org/web/20211122171120/https://codahale.com/a-lesson-in-timing-attacks/>`_.
    See :func:`hmac.compare_digest` for additional details.
 
 

--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -137,7 +137,7 @@ Other functions
    :term:`bytes-like objects <bytes-like object>`
    *a* and *b* are equal, otherwise ``False``,
    using a "constant-time compare" to reduce the risk of
-   `timing attacks <https://web.archive.org/web/20211122171120/https://codahale.com/a-lesson-in-timing-attacks/>`_.
+   `timing attacks <https://web.archive.org/web/20250815071532/https://codahale.com/a-lesson-in-timing-attacks/>`__.
    See :func:`hmac.compare_digest` for additional details.
 
 


### PR DESCRIPTION
Fixes #154046

Replaces the dead link to `codahale.com` with a Wayback Machine archive link, as the original domain fails to resolve.

<!-- gh-issue-number: gh-154046 -->
* Issue: gh-154046
<!-- /gh-issue-number -->
