### PR TITLE
gh-154048: Fix building the iconv codec on illumos/Solaris

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -8279,7 +8279,10 @@ _PyUnicode_DecodeIconv(const char *encoding,
         char *outptr = (char *)chunk;
         size_t outleft = sizeof(chunk);
 
-        size_t ret = iconv(cd, &inptr, &inleft, &outptr, &outleft);
+        /* Cast the input buffer through void*: iconv() declares its second
+           argument as "char **" on most systems but "const char **" on some
+           (e.g. illumos), and void* converts to either without a warning. */
+        size_t ret = iconv(cd, (void *)&inptr, &inleft, &outptr, &outleft);
         int err = errno;
         in = inptr;
 
@@ -8452,7 +8455,8 @@ _PyUnicode_EncodeIconv(const char *encoding, PyObject *unicode,
         size_t outleft = (size_t)(outend - out);
         /* When the whole string is converted, a final iconv() call with a
            NULL input flushes any pending shift sequence (e.g. ISO-2022). */
-        size_t ret = iconv(cd, flushing ? NULL : &inptr, &inleft, &out, &outleft);
+        /* See the note above on the void* cast of the iconv() input buffer. */
+        size_t ret = iconv(cd, flushing ? NULL : (void *)&inptr, &inleft, &out, &outleft);
         if (!flushing) {
             up = inptr;
         }


### PR DESCRIPTION
`iconv()`'s input-buffer argument is declared `const char **` on some systems (illumos/Solaris, old GNU libiconv) rather than the POSIX `char **`, so passing a `char **` failed to compile — breaking the whole build on illumos, since it is a core object file.

Cast the argument through `void *`, which converts to either `char **` or `const char **` without a warning and needs no configure probe.

Verified: compiles on illumos (OpenIndiana, previously failing) and on Linux/glibc (no regression).

<!-- gh-issue-number: gh-154048 -->
* Issue: gh-154048
<!-- /gh-issue-number -->
