### PR TITLE
gh-154053: Fix compilation of the ssl module against LibreSSL

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -49,12 +49,15 @@ Py_DEBUG_WIN32 = support.Py_DEBUG and sys.platform == 'win32'
 PROTOCOLS = sorted(ssl._PROTOCOL_NAMES)
 HOST = socket_helper.HOST
 IS_AWS_LC = "AWS-LC" in ssl.OPENSSL_VERSION
+IS_LIBRESSL = "LibreSSL" in ssl.OPENSSL_VERSION
 IS_OPENSSL_3_0_0 = ssl.OPENSSL_VERSION_INFO >= (3, 0, 0)
 CAN_GET_SELECTED_OPENSSL_GROUP = ssl.OPENSSL_VERSION_INFO >= (3, 2)
 CAN_IGNORE_UNKNOWN_OPENSSL_GROUPS = ssl.OPENSSL_VERSION_INFO >= (3, 3)
 CAN_GET_AVAILABLE_OPENSSL_GROUPS = ssl.OPENSSL_VERSION_INFO >= (3, 5)
 CAN_GET_AVAILABLE_OPENSSL_SIGALGS = ssl.OPENSSL_VERSION_INFO >= (3, 4)
-CAN_SET_CLIENT_SIGALGS = not IS_AWS_LC
+# LibreSSL does not provide SSL_CTX_set1_(client_)sigalgs_list().
+CAN_SET_CLIENT_SIGALGS = not IS_AWS_LC and not IS_LIBRESSL
+CAN_SET_SERVER_SIGALGS = not IS_LIBRESSL
 CAN_IGNORE_UNKNOWN_OPENSSL_SIGALGS = ssl.OPENSSL_VERSION_INFO >= (3, 3)
 CAN_GET_SELECTED_OPENSSL_SIGALG = ssl.OPENSSL_VERSION_INFO >= (3, 5)
 PY_SSL_DEFAULT_CIPHERS = sysconfig.get_config_var('PY_SSL_DEFAULT_CIPHERS')
@@ -1080,6 +1083,8 @@ class ContextTests(unittest.TestCase):
         if CAN_IGNORE_UNKNOWN_OPENSSL_SIGALGS:
             self.assertIsNone(ctx.set_client_sigalgs('rsa_pss_rsae_sha256:?foo'))
 
+    @unittest.skipUnless(CAN_SET_SERVER_SIGALGS,
+                         "SSL library doesn't support setting server sigalgs")
     def test_set_server_sigalgs(self):
         ctx = ssl.create_default_context()
 
@@ -4593,6 +4598,8 @@ class ThreadedTests(unittest.TestCase):
                                chatty=True, connectionchatty=True,
                                sni_name=hostname)
 
+    @unittest.skipUnless(CAN_SET_SERVER_SIGALGS,
+                         "SSL library doesn't support setting server sigalgs")
     def test_server_sigalgs(self):
         # server rsa_pss_rsae_sha384, client auto
         sigalg = "rsa_pss_rsae_sha384"
@@ -4613,6 +4620,8 @@ class ThreadedTests(unittest.TestCase):
         if CAN_GET_SELECTED_OPENSSL_SIGALG:
             self.assertEqual(stats['server_sigalg'], sigalg)
 
+    @unittest.skipUnless(CAN_SET_SERVER_SIGALGS,
+                         "SSL library doesn't support setting server sigalgs")
     def test_server_sigalgs_mismatch(self):
         client_context, server_context, hostname = testing_context()
         client_context.set_server_sigalgs("rsa_pss_rsae_sha256")

--- a/Misc/NEWS.d/next/Library/2026-07-19-00-00-00.gh-issue-154053.LibreSSLsigalgs.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-19-00-00-00.gh-issue-154053.LibreSSLsigalgs.rst
@@ -1,0 +1,4 @@
+Fix compilation of the :mod:`ssl` module against LibreSSL, which does not
+provide ``SSL_CTX_set1_sigalgs_list()`` and ``SSL_CTX_set1_client_sigalgs_list()``.
+The :meth:`!set_server_sigalgs` and :meth:`!set_client_sigalgs` methods of
+:class:`ssl.SSLContext` now raise :exc:`NotImplementedError` on LibreSSL.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3863,6 +3863,10 @@ _ssl__SSLContext_set_client_sigalgs_impl(PySSLContext *self,
 #ifdef OPENSSL_IS_AWSLC
     _setSSLError(get_state_ctx(self), "can't set client sigalgs on AWS-LC", 0, __FILE__, __LINE__);
     return NULL;
+#elif defined(LIBRESSL_VERSION_NUMBER)
+    PyErr_SetString(PyExc_NotImplementedError,
+                    "setting client sigalgs is not supported by LibreSSL");
+    return NULL;
 #else
     if (!SSL_CTX_set1_client_sigalgs_list(self->ctx, sigalgslist)) {
         _setSSLError(get_state_ctx(self), "unrecognized signature algorithm", 0, __FILE__, __LINE__);
@@ -3884,11 +3888,17 @@ _ssl__SSLContext_set_server_sigalgs_impl(PySSLContext *self,
                                          const char *sigalgslist)
 /*[clinic end generated code: output=31ecb1d310285644 input=653b752e4f8d801b]*/
 {
+#ifdef LIBRESSL_VERSION_NUMBER
+    PyErr_SetString(PyExc_NotImplementedError,
+                    "setting server sigalgs is not supported by LibreSSL");
+    return NULL;
+#else
     if (!SSL_CTX_set1_sigalgs_list(self->ctx, sigalgslist)) {
         _setSSLError(get_state_ctx(self), "unrecognized signature algorithm", 0, __FILE__, __LINE__);
         return NULL;
     }
     Py_RETURN_NONE;
+#endif
 }
 
 static int


### PR DESCRIPTION
Since gh-138252 (TLS signature-algorithm support, 3.15+), `_ssl` fails to compile against LibreSSL, which does not provide `SSL_CTX_set1_sigalgs_list()` / `SSL_CTX_set1_client_sigalgs_list()`:

```
Modules/_ssl.c:3867: call to undeclared function 'SSL_CTX_set1_client_sigalgs_list'
Modules/_ssl.c:3887: call to undeclared function 'SSL_CTX_set1_sigalgs_list'
```

With `-Werror=implicit-function-declaration` this is fatal, so `_ssl` is not built at all on LibreSSL (regression from 3.14).

This PR guards the `set_client_sigalgs`/`set_server_sigalgs` methods so they raise `NotImplementedError` on LibreSSL (matching how other library-unavailable features are handled in `_ssl.c`), and skips the corresponding `test_ssl` tests.

Verified:
- OpenSSL 3.5.5: builds clean, sigalgs tests pass (unaffected).
- LibreSSL 4.3.0 (OpenBSD 7.9): `_ssl` now compiles; the 7 sigalgs tests skip; the remaining `test_ssl` failures are identical to those already present on 3.14 (pre-existing LibreSSL divergences), i.e. no new failures.


<!-- gh-issue-number: gh-154053 -->
* Issue: gh-154053
<!-- /gh-issue-number -->
