### PR TITLE
Docs: add frozendict to data types theme

### DIFF
--- a/Doc/library/datatypes.rst
+++ b/Doc/library/datatypes.rst
@@ -8,9 +8,10 @@ The modules described in this chapter provide a variety of specialized data
 types such as dates and times, fixed-type arrays, heap queues, double-ended
 queues, and enumerations.
 
-Python also provides some built-in data types, in particular,
-:class:`dict`, :class:`list`, :class:`set` and :class:`frozenset`, and
-:class:`tuple`.  The :class:`str` class is used to hold
+Python also provides :ref:`some built-in data types <bltin-types>`, in particular,
+:class:`list`, :class:`tuple`, :class:`dict`, :class:`frozendict`,
+:class:`set`,  and :class:`frozenset`.
+The :class:`str` class is used to hold
 Unicode strings, and the :class:`bytes` and :class:`bytearray` classes are used
 to hold binary data.
 


### PR DESCRIPTION
Adds `frozendict` to the list of built-in types listed in the “Data types” theme page from the library.

Additionally, felt like a good idea to link to the actual page on built-in types.