### PR TITLE
gh-154083: Add itertools.sliding_window()

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -44,6 +44,7 @@ Iterator                        Arguments                       Results         
 :func:`groupby`                 iterable[, key]                 sub-iterators grouped by value of key(v)            ``groupby(['A','B','DEF'], len) → (1, A B) (3, DEF)``
 :func:`islice`                  seq, [start,] stop [, step]     elements from seq[start:stop:step]                  ``islice('ABCDEFG', 2, None) → C D E F G``
 :func:`pairwise`                iterable                        (p[0], p[1]), (p[1], p[2])                          ``pairwise('ABCDEFG') → AB BC CD DE EF FG``
+:func:`sliding_window`          iterable, n                     (p[0], ..., p[n-1]), (p[1], ..., p[n]), ...         ``sliding_window('ABCDEFG', 4) → ABCD BCDE CDEF DEFG``
 :func:`repeat`                  elem [,n]                       elem, elem, elem, ... endlessly or up to n times    ``repeat(10, 3) → 10 10 10``
 :func:`starmap`                 func, seq                       func(\*seq[0]), func(\*seq[1]), ...                 ``starmap(pow, [(2,5), (3,2), (10,3)]) → 32 9 1000``
 :func:`takewhile`               predicate, seq                  seq[0], seq[1], until predicate fails               ``takewhile(lambda x: x<5, [1,4,6,3,8]) → 1 4``
@@ -646,6 +647,34 @@ loops that truncate the stream.
       [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
 
 
+.. function:: sliding_window(iterable, n)
+
+   Return successive overlapping windows of width *n* taken from the input
+   *iterable*.
+
+       sliding_window('ABCDEFG', 4) → ABCD BCDE CDEF DEFG
+
+   The number of windows in the output iterator is
+   ``max(0, len(iterable) - n + 1)``.  It will be empty if the input iterable
+   has fewer than *n* values.  When *n* is ``2``, this is equivalent to
+   :func:`pairwise`.
+
+   Roughly equivalent to::
+
+       def sliding_window(iterable, n):
+           # sliding_window('ABCDEFG', 4) → ABCD BCDE CDEF DEFG
+
+           iterator = iter(iterable)
+           window = deque(islice(iterator, n - 1), maxlen=n)
+           for x in iterator:
+               window.append(x)
+               yield tuple(window)
+
+   If *n* is less than ``1``, :exc:`ValueError` is raised.
+
+   .. versionadded:: 3.16
+
+
 .. function:: starmap(function, iterable)
 
    Make an iterator that computes the *function* using arguments obtained
@@ -815,9 +844,9 @@ well as with the built-in itertools such as ``map()``, ``filter()``,
 ``reversed()``, and ``enumerate()``.
 
 A secondary purpose of the recipes is to serve as an incubator.  The
-``accumulate()``, ``compress()``, and ``pairwise()`` itertools started out as
-recipes.  Currently, the ``sliding_window()``, ``derangements()``, and ``sieve()``
-recipes are being tested to see whether they prove their worth.
+``accumulate()``, ``compress()``, ``pairwise()``, and ``sliding_window()``
+itertools started out as recipes.  Currently, the ``derangements()`` and
+``sieve()`` recipes are being tested to see whether they prove their worth.
 
 Substantially all of these recipes and many, many others can be installed from
 the :pypi:`more-itertools` project found
@@ -837,7 +866,7 @@ and :term:`generators <generator>` which incur interpreter overhead.
 
    from itertools import (accumulate, batched, chain, combinations, compress,
         count, cycle, filterfalse, groupby, islice, permutations, product,
-        repeat, starmap, tee, zip_longest)
+        repeat, sliding_window, starmap, tee, zip_longest)
    from collections import Counter, deque
    from contextlib import suppress
    from functools import reduce
@@ -940,15 +969,6 @@ and :term:`generators <generator>` which incur interpreter overhead.
        # unique([[1, 2], [3, 4], [1, 2]]) → [1, 2] [3, 4]
        sequenced = sorted(iterable, key=key, reverse=reverse)
        return unique_justseen(sequenced, key=key)
-
-   def sliding_window(iterable, n):
-       "Collect data into overlapping fixed-length chunks or blocks."
-       # sliding_window('ABCDEFG', 3) → ABC BCD CDE DEF EFG
-       iterator = iter(iterable)
-       window = deque(islice(iterator, n - 1), maxlen=n)
-       for x in iterator:
-           window.append(x)
-           yield tuple(window)
 
    def grouper(iterable, n, *, incomplete='fill', fillvalue=None):
        "Collect data into non-overlapping fixed-length chunks or blocks."

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -310,6 +310,16 @@ Add :meth:`~ipaddress.IPv4Network.next_network` and
 network with a specific prefix size.
 
 
+itertools
+---------
+
+* Add :func:`itertools.sliding_window`, an iterator returning overlapping
+  windows of a given width taken from the input iterable.  It generalizes
+  :func:`itertools.pairwise` to windows of any length and was previously
+  a documented recipe.
+  (Contributed by Vyron Vasileiadis in :gh:`154083`.)
+
+
 logging
 -------
 

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1039,6 +1039,87 @@ class TestBasicOps(unittest.TestCase):
         check(3, [])
         check(4, [(([2], [3]), [4])])
 
+    def test_sliding_window(self):
+        self.assertEqual(list(sliding_window('', 1)), [])
+        self.assertEqual(list(sliding_window('', 3)), [])
+        self.assertEqual(list(sliding_window('ABCDEFG', 1)),
+                         [('A',), ('B',), ('C',), ('D',), ('E',), ('F',), ('G',)])
+        # A window of width 2 is exactly pairwise().
+        self.assertEqual(list(sliding_window('ABCDEFG', 2)),
+                         list(pairwise('ABCDEFG')))
+        self.assertEqual(list(sliding_window('ABCDEFG', 3)),
+                         [('A', 'B', 'C'), ('B', 'C', 'D'), ('C', 'D', 'E'),
+                          ('D', 'E', 'F'), ('E', 'F', 'G')])
+        self.assertEqual(list(sliding_window('ABCDEFG', 7)),
+                         [tuple('ABCDEFG')])
+        # No windows when the input has fewer than n items.
+        self.assertEqual(list(sliding_window('ABCDEFG', 8)), [])
+        self.assertEqual(list(sliding_window('ABCDEFG', 100)), [])
+        # The n argument may be passed by keyword.
+        self.assertEqual(list(sliding_window('ABCD', n=3)),
+                         [('A', 'B', 'C'), ('B', 'C', 'D')])
+
+        # Each window is a distinct, freshly built tuple.
+        windows = list(sliding_window('ABCDE', 3))
+        self.assertEqual(len(set(map(id, windows))), len(windows))
+
+        # Exhaustive check of the output against slicing, including the
+        # empty-output cases where len(iterable) < n.
+        for length in range(10):
+            for n in range(1, 6):
+                data = list(range(length))
+                expected = [tuple(data[i:i + n])
+                            for i in range(length - n + 1)]
+                self.assertEqual(list(sliding_window(data, n)), expected)
+                self.assertEqual(len(list(sliding_window(data, n))),
+                                 max(0, length - n + 1))
+
+        # Large inputs, exercising both the recycle path (windows discarded
+        # each step) and the fresh-tuple path (windows retained in a list).
+        for n in (1, 2, 3, 4, 50):
+            data = list(range(1000))
+            expected = [tuple(data[i:i + n]) for i in range(len(data) - n + 1)]
+            self.assertEqual(list(sliding_window(data, n)), expected)
+            self.assertEqual([sum(w) for w in sliding_window(data, n)],
+                             [sum(w) for w in expected])
+
+        with self.assertRaises(TypeError):
+            sliding_window('ABC')                   # too few arguments
+        with self.assertRaises(TypeError):
+            sliding_window('ABC', 2, 3)             # too many arguments
+        with self.assertRaises(TypeError):
+            sliding_window('ABC', 'x')              # n is not an integer
+        with self.assertRaises(TypeError):
+            sliding_window(None, 2)                 # non-iterable argument
+        with self.assertRaises(ValueError):
+            sliding_window('ABC', 0)                # n is zero
+        with self.assertRaises(ValueError):
+            sliding_window('ABC', -1)               # n is negative
+
+    def test_sliding_window_reenter(self):
+        # A pathological iterator that reenters the sliding_window while it is
+        # advancing (e.g. from a destructor) must not crash, leak, or emit
+        # malformed windows.  Cover reentry during both the initial priming
+        # (count <= n) and the sliding phase (count > n).
+        for reenter_at in (1, 2, 3, 4, 6):
+            with self.subTest(reenter_at=reenter_at):
+                target = None
+                class I:
+                    def __init__(self):
+                        self.count = 0
+                    def __iter__(self):
+                        return self
+                    def __next__(self):
+                        self.count += 1
+                        if self.count == reenter_at and target is not None:
+                            next(target, None)
+                        if self.count > 20:
+                            raise StopIteration
+                        return [self.count]     # new object each time
+                target = sliding_window(I(), 3)
+                for window in target:
+                    self.assertEqual(len(window), 3)
+
     def test_product(self):
         for args, result in [
             ([], [()]),                     # zero iterables
@@ -1513,6 +1594,15 @@ class TestBasicOps(unittest.TestCase):
         self.assertTrue(gc.is_tracked(next(it)))
 
     @support.cpython_only
+    def test_sliding_window_result_gc(self):
+        # Ditto for sliding_window, for both the primed and recycled tuple.
+        it = sliding_window([None, None, None], 2)
+        gc.collect()
+        self.assertTrue(gc.is_tracked(next(it)))
+        gc.collect()
+        self.assertTrue(gc.is_tracked(next(it)))
+
+    @support.cpython_only
     def test_immutable_types(self):
         from itertools import _grouper, _tee, _tee_dataobject
         dataset = (
@@ -1533,6 +1623,7 @@ class TestBasicOps(unittest.TestCase):
             permutations,
             product,
             repeat,
+            sliding_window,
             starmap,
             takewhile,
             _tee,
@@ -2094,6 +2185,10 @@ class TestGC(unittest.TestCase):
         a = []
         self.makecycle(pairwise([a]*5), a)
 
+    def test_sliding_window(self):
+        a = []
+        self.makecycle(sliding_window([a]*5, 3), a)
+
     def test_permutations(self):
         a = []
         self.makecycle(permutations([1,2,a,3], 3), a)
@@ -2339,6 +2434,19 @@ class TestVariousIteratorArgs(unittest.TestCase):
             self.assertRaises(TypeError, pairwise, X(s))
             self.assertRaises(TypeError, pairwise, N(s))
             self.assertRaises(ZeroDivisionError, list, pairwise(E(s)))
+
+    def test_sliding_window(self):
+        for s in ("123", "", range(1000), ('do', 1.2), range(2000,2200,5)):
+            for n in (1, 3):
+                for g in (G, I, Ig, S, L, R):
+                    seq = list(g(s))
+                    expected = [tuple(seq[i:i+n])
+                                for i in range(len(seq) - n + 1)]
+                    actual = list(sliding_window(g(s), n))
+                    self.assertEqual(actual, expected)
+                self.assertRaises(TypeError, sliding_window, X(s), n)
+                self.assertRaises(TypeError, sliding_window, N(s), n)
+                self.assertRaises(ZeroDivisionError, list, sliding_window(E(s), n))
 
     def test_starmap(self):
         for s in (range(10), range(0), range(100), (7,11), range(20,50,5)):

--- a/Misc/NEWS.d/next/Library/2026-07-19-12-30-00.gh-issue-154083.Sl1dWn.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-19-12-30-00.gh-issue-154083.Sl1dWn.rst
@@ -1,0 +1,3 @@
+Add :func:`itertools.sliding_window`, an iterator over overlapping windows of
+a given width taken from the input iterable.  Previously a documented recipe,
+it generalizes :func:`itertools.pairwise` to windows of any length.

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -137,6 +137,83 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(sliding_window_new__doc__,
+"sliding_window(iterable, n)\n"
+"--\n"
+"\n"
+"Return an iterator of overlapping length-n windows from the iterable.\n"
+"\n"
+"    sliding_window(\'ABCDEFG\', 4) --> ABCD BCDE CDEF DEFG\n"
+"\n"
+"Each window is a tuple of the n most recent items.  The number of\n"
+"windows is max(0, len(iterable) - n + 1), so no windows are produced\n"
+"when the input has fewer than n items.  When n equals 2, this is the\n"
+"same as pairwise().");
+
+static PyObject *
+sliding_window_new_impl(PyTypeObject *type, PyObject *iterable, Py_ssize_t n);
+
+static PyObject *
+sliding_window_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+
+    #define NUM_KEYWORDS 2
+    static struct {
+        PyGC_Head _this_is_not_used;
+        PyObject_VAR_HEAD
+        Py_hash_t ob_hash;
+        PyObject *ob_item[NUM_KEYWORDS];
+    } _kwtuple = {
+        .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
+        .ob_hash = -1,
+        .ob_item = { &_Py_ID(iterable), _Py_LATIN1_CHR('n'), },
+    };
+    #undef NUM_KEYWORDS
+    #define KWTUPLE (&_kwtuple.ob_base.ob_base)
+
+    #else  // !Py_BUILD_CORE
+    #  define KWTUPLE NULL
+    #endif  // !Py_BUILD_CORE
+
+    static const char * const _keywords[] = {"iterable", "n", NULL};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "sliding_window",
+        .kwtuple = KWTUPLE,
+    };
+    #undef KWTUPLE
+    PyObject *argsbuf[2];
+    PyObject * const *fastargs;
+    Py_ssize_t nargs = PyTuple_GET_SIZE(args);
+    PyObject *iterable;
+    Py_ssize_t n;
+
+    fastargs = _PyArg_UnpackKeywords(_PyTuple_CAST(args)->ob_item, nargs, kwargs, NULL, &_parser,
+            /*minpos*/ 2, /*maxpos*/ 2, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
+    if (!fastargs) {
+        goto exit;
+    }
+    iterable = fastargs[0];
+    {
+        Py_ssize_t ival = -1;
+        PyObject *iobj = _PyNumber_Index(fastargs[1]);
+        if (iobj != NULL) {
+            ival = PyLong_AsSsize_t(iobj);
+            Py_DECREF(iobj);
+        }
+        if (ival == -1 && PyErr_Occurred()) {
+            goto exit;
+        }
+        n = ival;
+    }
+    return_value = sliding_window_new_impl(type, iterable, n);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(itertools_groupby__doc__,
 "groupby(iterable, key=None)\n"
 "--\n"
@@ -980,4 +1057,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=a34a31f60100e0ff input=a9049054013a1b77]*/
+/*[clinic end generated code: output=10d2c885d6995f25 input=a9049054013a1b77]*/

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -32,6 +32,7 @@ typedef struct {
     PyTypeObject *permutations_type;
     PyTypeObject *product_type;
     PyTypeObject *repeat_type;
+    PyTypeObject *sliding_window_type;
     PyTypeObject *starmap_type;
     PyTypeObject *takewhile_type;
     PyTypeObject *tee_type;
@@ -85,8 +86,9 @@ class itertools.compress "compressobject *" "clinic_state()->compress_type"
 class itertools.filterfalse "filterfalseobject *" "clinic_state()->filterfalse_type"
 class itertools.count "countobject *" "clinic_state()->count_type"
 class itertools.pairwise "pairwiseobject *" "clinic_state()->pairwise_type"
+class itertools.sliding_window "slidingwindowobject *" "clinic_state()->sliding_window_type"
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=aa48fe4de9d4080f]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=8b311ccb31b06648]*/
 
 #define clinic_state() (find_state_by_type(type))
 #define clinic_state_by_cls() (get_module_state_by_cls(base_tp))
@@ -417,6 +419,194 @@ static PyType_Spec pairwise_spec = {
     .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE |
               Py_TPFLAGS_IMMUTABLETYPE),
     .slots = pairwise_slots,
+};
+
+
+/* sliding_window object *****************************************************/
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *it;
+    Py_ssize_t n;
+    PyObject *result;
+} slidingwindowobject;
+
+#define slidingwindowobject_CAST(op)  ((slidingwindowobject *)(op))
+
+/*[clinic input]
+@classmethod
+itertools.sliding_window.__new__ as sliding_window_new
+    iterable: object
+    n: Py_ssize_t
+
+Return an iterator of overlapping length-n windows from the iterable.
+
+    sliding_window('ABCDEFG', 4) --> ABCD BCDE CDEF DEFG
+
+Each window is a tuple of the n most recent items.  The number of
+windows is max(0, len(iterable) - n + 1), so no windows are produced
+when the input has fewer than n items.  When n equals 2, this is the
+same as pairwise().
+[clinic start generated code]*/
+
+static PyObject *
+sliding_window_new_impl(PyTypeObject *type, PyObject *iterable, Py_ssize_t n)
+/*[clinic end generated code: output=a8c0fe21a87ec1dc input=150e215d37d04c52]*/
+{
+    PyObject *it;
+    slidingwindowobject *sw;
+
+    if (n < 1) {
+        PyErr_SetString(PyExc_ValueError, "n must be at least one");
+        return NULL;
+    }
+    it = PyObject_GetIter(iterable);
+    if (it == NULL) {
+        return NULL;
+    }
+    sw = (slidingwindowobject *)type->tp_alloc(type, 0);
+    if (sw == NULL) {
+        Py_DECREF(it);
+        return NULL;
+    }
+    sw->it = it;
+    sw->n = n;
+    sw->result = NULL;
+    return (PyObject *)sw;
+}
+
+static void
+sliding_window_dealloc(PyObject *op)
+{
+    slidingwindowobject *sw = slidingwindowobject_CAST(op);
+    PyTypeObject *tp = Py_TYPE(sw);
+    PyObject_GC_UnTrack(sw);
+    Py_XDECREF(sw->it);
+    Py_XDECREF(sw->result);
+    tp->tp_free(sw);
+    Py_DECREF(tp);
+}
+
+static int
+sliding_window_traverse(PyObject *op, visitproc visit, void *arg)
+{
+    slidingwindowobject *sw = slidingwindowobject_CAST(op);
+    Py_VISIT(Py_TYPE(sw));
+    Py_VISIT(sw->it);
+    Py_VISIT(sw->result);
+    return 0;
+}
+
+static PyObject *
+sliding_window_next(PyObject *op)
+{
+    slidingwindowobject *sw = slidingwindowobject_CAST(op);
+    PyObject *it = sw->it;
+    Py_ssize_t n = sw->n;
+    PyObject *result = sw->result;
+    PyObject *item;
+
+    if (it == NULL) {
+        return NULL;
+    }
+    iternextfunc iternext = *Py_TYPE(it)->tp_iternext;
+
+    if (result == NULL) {
+        /* First call: fill the initial window with n items.  Each iternext()
+           call can run arbitrary Python that reenters this iterator, so
+           (like pairwise) re-read sw->it after every step and publish the
+           finished window with Py_XSETREF, in case a reentrant call already
+           installed one. */
+        result = PyTuple_New(n);
+        if (result == NULL) {
+            return NULL;
+        }
+        PyObject **items = _PyTuple_ITEMS(result);
+        for (Py_ssize_t i = 0; i < n; i++) {
+            item = iternext(it);
+            if (item == NULL) {
+                /* Fewer than n items: no window is produced. */
+                Py_DECREF(result);
+                Py_CLEAR(sw->it);
+                return NULL;
+            }
+            items[i] = item;
+            it = sw->it;
+            if (it == NULL) {
+                /* A reentrant call exhausted the underlying iterator. */
+                Py_DECREF(result);
+                return NULL;
+            }
+        }
+        Py_XSETREF(sw->result, result);
+        return Py_NewRef(result);
+    }
+
+    /* Slide the window forward by one item. */
+    item = iternext(it);
+    if (item == NULL) {
+        Py_CLEAR(sw->it);
+        return NULL;
+    }
+
+    if (_PyObject_IsUniquelyReferenced(result)) {
+        /* Recycle the result tuple: drop the oldest item, shift the rest
+           down by one, and append the new item at the end. */
+        Py_INCREF(result);
+        PyObject **items = _PyTuple_ITEMS(result);
+        PyObject *oldest = items[0];
+        for (Py_ssize_t i = 1; i < n; i++) {
+            items[i - 1] = items[i];
+        }
+        items[n - 1] = item;
+        // bpo-42536: The GC may have untracked this result tuple.  Since we're
+        // recycling it, make sure it's tracked again:
+        _PyTuple_Recycle(result);
+        // Drop the evicted item last: it may run arbitrary code (__del__),
+        // and by now the window is fully consistent.
+        Py_DECREF(oldest);
+        return result;
+    }
+
+    /* The previous window is still referenced elsewhere; build a fresh one. */
+    PyObject *newresult = PyTuple_New(n);
+    if (newresult == NULL) {
+        /* The just-pulled item cannot be preserved (there is no spare slot);
+           stop cleanly so that retrying after the error reports exhaustion
+           rather than silently dropping an element from a later window. */
+        Py_DECREF(item);
+        Py_CLEAR(sw->it);
+        return NULL;
+    }
+    PyObject **src = _PyTuple_ITEMS(result);
+    PyObject **dst = _PyTuple_ITEMS(newresult);
+    for (Py_ssize_t i = 1; i < n; i++) {
+        dst[i - 1] = Py_NewRef(src[i]);
+    }
+    dst[n - 1] = item;
+    Py_SETREF(sw->result, newresult);
+    return Py_NewRef(newresult);
+}
+
+static PyType_Slot sliding_window_slots[] = {
+    {Py_tp_dealloc, sliding_window_dealloc},
+    {Py_tp_getattro, PyObject_GenericGetAttr},
+    {Py_tp_doc, (void *)sliding_window_new__doc__},
+    {Py_tp_traverse, sliding_window_traverse},
+    {Py_tp_iter, PyObject_SelfIter},
+    {Py_tp_iternext, sliding_window_next},
+    {Py_tp_alloc, PyType_GenericAlloc},
+    {Py_tp_new, sliding_window_new},
+    {Py_tp_free, PyObject_GC_Del},
+    {0, NULL},
+};
+
+static PyType_Spec sliding_window_spec = {
+    .name = "itertools.sliding_window",
+    .basicsize = sizeof(slidingwindowobject),
+    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE |
+              Py_TPFLAGS_IMMUTABLETYPE),
+    .slots = sliding_window_slots,
 };
 
 
@@ -4090,6 +4280,7 @@ filterfalse(predicate, seq) --> elements of seq where predicate(elem) is False\n
 islice(seq, [start,] stop [, step]) --> elements from\n\
        seq[start:stop:step]\n\
 pairwise(s) --> (s[0],s[1]), (s[1],s[2]), (s[2], s[3]), ...\n\
+sliding_window(s, n) --> (s[0],...,s[n-1]), (s[1],...,s[n]), ...\n\
 starmap(fun, seq) --> fun(*seq[0]), fun(*seq[1]), ...\n\
 tee(it, n=2) --> (it1, it2 , ... itn) splits one iterator into n\n\
 takewhile(predicate, seq) --> seq[0], seq[1], until predicate fails\n\
@@ -4123,6 +4314,7 @@ itertoolsmodule_traverse(PyObject *mod, visitproc visit, void *arg)
     Py_VISIT(state->permutations_type);
     Py_VISIT(state->product_type);
     Py_VISIT(state->repeat_type);
+    Py_VISIT(state->sliding_window_type);
     Py_VISIT(state->starmap_type);
     Py_VISIT(state->takewhile_type);
     Py_VISIT(state->tee_type);
@@ -4152,6 +4344,7 @@ itertoolsmodule_clear(PyObject *mod)
     Py_CLEAR(state->permutations_type);
     Py_CLEAR(state->product_type);
     Py_CLEAR(state->repeat_type);
+    Py_CLEAR(state->sliding_window_type);
     Py_CLEAR(state->starmap_type);
     Py_CLEAR(state->takewhile_type);
     Py_CLEAR(state->tee_type);
@@ -4198,6 +4391,7 @@ itertoolsmodule_exec(PyObject *mod)
     ADD_TYPE(mod, state->permutations_type, &permutations_spec);
     ADD_TYPE(mod, state->product_type, &product_spec);
     ADD_TYPE(mod, state->repeat_type, &repeat_spec);
+    ADD_TYPE(mod, state->sliding_window_type, &sliding_window_spec);
     ADD_TYPE(mod, state->starmap_type, &starmap_spec);
     ADD_TYPE(mod, state->takewhile_type, &takewhile_spec);
     ADD_TYPE(mod, state->tee_type, &tee_spec);


### PR DESCRIPTION
This promotes the `sliding_window` recipe to a real itertools function, following the same path as `pairwise` (3.10) and `batched` (3.12).

`sliding_window(iterable, n)` returns overlapping windows of the n most recent items, advancing one item at a time:

```pycon
>>> [''.join(w) for w in sliding_window('ABCDEFG', 4)]
['ABCD', 'BCDE', 'CDEF', 'DEFG']
```

It is the general form of `pairwise`, so `pairwise(iterable)` and `sliding_window(iterable, 2)` produce the same result. It raises `ValueError` when n is less than 1, and yields nothing when the input has fewer than n items.

The implementation is in C, modeled on the existing pairwise object, and reuses the same result-tuple recycling so consumers that do not retain the windows avoid a per-step allocation. The change removes `sliding_window` from the recipes and the incubator list, adds it to the general iterators table and the function reference, and updates the `convolve` recipe to use the new function.

Tests cover the basic behavior, the pairwise equivalence, the empty and short-input cases, argument errors, reentrancy during both the priming and sliding phases, garbage collection of the recycled tuple, and immutability of the type.


<!-- gh-issue-number: gh-154083 -->
* Issue: gh-154083
<!-- /gh-issue-number -->
