### PR TITLE
urllib: Add tests for HTTP errors to complete coverage

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -472,19 +472,19 @@ Connection: close
             "Authorization": "Bearer foobar",
             "Accept": "application/json"
         }
-        exc = urllib.error.HTTPError("http://something", 404, "foo", hdrs, None)
-        self.assertEqual(exc.filename, "http://something")
-        self.assertEqual(exc.code, 404)
-        self.assertEqual(exc.msg, "foo")
-        self.assertEqual(exc.reason, "foo")
-        self.assertEqual(exc.hdrs, hdrs)
-        self.assertEqual(exc.headers, hdrs)
-        exc.close()
+        err = urllib.error.HTTPError("http://something", 404, "foo", hdrs, None)
+        self.assertEqual(err.filename, "http://something")
+        self.assertEqual(err.code, 404)
+        self.assertEqual(err.msg, "foo")
+        self.assertEqual(err.reason, "foo")
+        self.assertEqual(err.hdrs, hdrs)
+        self.assertEqual(err.headers, hdrs)
+        err.close()
 
     def test_http_error_default_fp(self):
-        exc = urllib.error.HTTPError("http://something", 404, "foo", {}, None)
-        self.assertIsInstance(exc.fp, io.BytesIO)
-        exc.close()
+        err = urllib.error.HTTPError("http://something", 404, "foo", {}, None)
+        self.assertIsInstance(err.fp, io.BytesIO)
+        err.close()
 
     def test_empty_socket(self):
         # urlopen() raises OSError if the underlying socket does not send any

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -479,10 +479,12 @@ Connection: close
         self.assertEqual(exc.reason, "foo")
         self.assertEqual(exc.hdrs, hdrs)
         self.assertEqual(exc.headers, hdrs)
+        exc.close()
 
     def test_http_error_default_fp(self):
         exc = urllib.error.HTTPError("http://something", 404, "foo", {}, None)
         self.assertIsInstance(exc.fp, io.BytesIO)
+        exc.close()
 
     def test_empty_socket(self):
         # urlopen() raises OSError if the underlying socket does not send any

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -479,6 +479,9 @@ Connection: close
         self.assertEqual(exc.reason, "foo")
         self.assertEqual(exc.hdrs, hdrs)
         self.assertEqual(exc.headers, hdrs)
+
+    def test_http_error_default_fp(self):
+        exc = urllib.error.HTTPError("http://something", 404, "foo", {}, None)
         self.assertIsInstance(exc.fp, io.BytesIO)
 
     def test_empty_socket(self):

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -473,10 +473,12 @@ Connection: close
             "Accept": "application/json"
         }
         exc = urllib.error.HTTPError("http://something", 404, "foo", hdrs, None)
-        self.assertEqual(exc.url, "http://something")
+        self.assertEqual(exc.filename, "http://something")
         self.assertEqual(exc.code, 404)
         self.assertEqual(exc.msg, "foo")
+        self.assertEqual(exc.reason, "foo")
         self.assertEqual(exc.hdrs, hdrs)
+        self.assertEqual(exc.headers, hdrs)
         self.assertIsInstance(exc.fp, io.BytesIO)
 
     def test_empty_socket(self):
@@ -528,8 +530,7 @@ Connection: close
     def test_url_error_stringified(self):
         reason = 'sixseven'
         err = urllib.error.URLError(reason)
-        self.assertEqual(reason, err.reason)
-        self.assertEqual(str(err), '<urlopen error %s>' % reason)
+        self.assertEqual(str(err), f'<urlopen error {reason}>')
 
 
 class urlopen_DataTests(unittest.TestCase):

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -467,6 +467,18 @@ Connection: close
             finally:
                 self.unfakehttp()
 
+    def test_http_error_attribute_values(self):
+        hdrs = {
+            "Authorization": "Bearer foobar",
+            "Accept": "application/json"
+        }
+        exc = urllib.error.HTTPError("http://something", 404, "foo", hdrs, None)
+        self.assertEqual(exc.url, "http://something")
+        self.assertEqual(exc.code, 404)
+        self.assertEqual(exc.msg, "foo")
+        self.assertEqual(exc.hdrs, hdrs)
+        self.assertIsInstance(exc.fp, io.BytesIO)
+
     def test_empty_socket(self):
         # urlopen() raises OSError if the underlying socket does not send any
         # data. (#1680230)
@@ -512,6 +524,12 @@ Connection: close
             urllib.request.urlopen('ftp://localhost/a/file/which/doesnot/exists.py')
         self.assertFalse(e.exception.filename)
         self.assertTrue(e.exception.reason)
+
+    def test_url_error_stringified(self):
+        reason = 'sixseven'
+        err = urllib.error.URLError(reason)
+        self.assertEqual(reason, err.reason)
+        self.assertEqual(str(err), '<urlopen error %s>' % reason)
 
 
 class urlopen_DataTests(unittest.TestCase):


### PR DESCRIPTION
Adds tests for the properties of `HTTPError` and `URLError`