### PR TITLE
gh-154109: fix sqlite load_extension memory leak

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-07-19-15-53-06.gh-issue-154109.uPm_M0.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-19-15-53-06.gh-issue-154109.uPm_M0.rst
@@ -1,0 +1,2 @@
+Fix memory leak in :meth:`sqlite3.Connection.load_extension` when
+:exc:`sqlite3.OperationalError` is raised.

--- a/Misc/NEWS.d/next/Security/2026-07-19-14-00-59.gh-issue-154109.Dt-0Pc.rst
+++ b/Misc/NEWS.d/next/Security/2026-07-19-14-00-59.gh-issue-154109.Dt-0Pc.rst
@@ -1,0 +1,2 @@
+Fix memory leak in sqlite3.Connection.load_extension() when error is
+returned

--- a/Misc/NEWS.d/next/Security/2026-07-19-14-00-59.gh-issue-154109.Dt-0Pc.rst
+++ b/Misc/NEWS.d/next/Security/2026-07-19-14-00-59.gh-issue-154109.Dt-0Pc.rst
@@ -1,2 +1,0 @@
-Fix memory leak in sqlite3.Connection.load_extension() when error is
-returned

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1758,6 +1758,7 @@ pysqlite_connection_load_extension_impl(pysqlite_Connection *self,
     rc = sqlite3_load_extension(self->db, extension_name, entrypoint, &errmsg);
     if (rc != 0) {
         PyErr_SetString(self->OperationalError, errmsg);
+        sqlite3_free((void *)errmsg);
         return NULL;
     } else {
         Py_RETURN_NONE;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Fix the memory leak created when `sqlite3.Connection.load_extension()` by freeing the buffer used to get the error message from the sqlite library.


<!-- gh-issue-number: gh-154109 -->
* Issue: gh-154109
<!-- /gh-issue-number -->
