### PR TITLE
gh-145559: Make PyUnstable_DumpTraceback return void again 

### DIFF
--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -1167,11 +1167,10 @@ dump_traceback(int fd, PyThreadState *tstate, int write_header)
 
    The caller is responsible to call PyErr_CheckSignals() to call Python signal
    handlers if signals were received. */
-const char*
+void
 PyUnstable_DumpTraceback(int fd, PyThreadState *tstate)
 {
     dump_traceback(fd, tstate, 1);
-    return NULL;
 }
 
 #if defined(HAVE_PTHREAD_GETNAME_NP) || defined(HAVE_PTHREAD_GET_NAME_NP)


### PR DESCRIPTION
In gh-148145, we changed this to return a const char* but it is always NULL. I don't think this makes sense, so this puts it back.


<!-- gh-issue-number: gh-145559 -->
* Issue: gh-145559
<!-- /gh-issue-number -->
