### PR TITLE
gh-154136: Define _ISOC23_SOURCE to fix building the math module on FreeBSD

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-07-19-16-45-00.gh-issue-154136.mathpi.rst
+++ b/Misc/NEWS.d/next/Build/2026-07-19-16-45-00.gh-issue-154136.mathpi.rst
@@ -1,0 +1,3 @@
+Fix building the :mod:`math` module on FreeBSD.
+Define ``_ISOC23_SOURCE`` to make the C23 library declarations
+(such as ``sinpi()`` in ``math.h``) visible.

--- a/configure
+++ b/configure
@@ -4809,6 +4809,13 @@ printf "%s\n" "#define _XOPEN_SOURCE_EXTENDED 1" >>confdefs.h
 
 printf "%s\n" "#define _POSIX_C_SOURCE 202405L" >>confdefs.h
 
+
+  # Defining _POSIX_C_SOURCE and _XOPEN_SOURCE hides C23 library
+  # declarations on FreeBSD (e.g. sinpi() in math.h) when compiling
+  # with -std=c11.  Defining _ISOC23_SOURCE makes them visible again.
+
+printf "%s\n" "#define _ISOC23_SOURCE 1" >>confdefs.h
+
 fi
 
 # On HP-UX mbstate_t requires _INCLUDE__STDC_A1_SOURCE

--- a/configure.ac
+++ b/configure.ac
@@ -935,6 +935,12 @@ then
 
   AC_DEFINE([_POSIX_C_SOURCE], [202405L],
             [Define to activate features from IEEE Std 1003.1-2024])
+
+  # Defining _POSIX_C_SOURCE and _XOPEN_SOURCE hides C23 library
+  # declarations on FreeBSD (e.g. sinpi() in math.h) when compiling
+  # with -std=c11.  Defining _ISOC23_SOURCE makes them visible again.
+  AC_DEFINE([_ISOC23_SOURCE], [1],
+            [Define to activate ISO C23 library declarations])
 fi
 
 # On HP-UX mbstate_t requires _INCLUDE__STDC_A1_SOURCE

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -2143,6 +2143,9 @@
 /* Define to include mbstate_t for mbrtowc */
 #undef _INCLUDE__STDC_A1_SOURCE
 
+/* Define to activate ISO C23 library declarations */
+#undef _ISOC23_SOURCE
+
 /* This must be defined on some systems to enable large file support. */
 #undef _LARGEFILE_SOURCE
 


### PR DESCRIPTION
On FreeBSD, libm provides `cospi`, `sinpi` and `tanpi`, but `math.h` declares them only for C23, and defining `_POSIX_C_SOURCE` and `_XOPEN_SOURCE` reduces header visibility to C11. The link-only `AC_CHECK_FUNCS` test still finds the symbols, so compiling `Modules/mathmodule.c` failed.

Defining `_ISOC23_SOURCE` makes the declarations visible, so the native libm implementations are detected and used. On other platforms it is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-154136 -->
* Issue: gh-154136
<!-- /gh-issue-number -->
