### PR TITLE
gh-154013: Add free-threading test for shared struct.iter_unpack

### DIFF
--- a/Lib/test/test_free_threading/test_struct.py
+++ b/Lib/test/test_free_threading/test_struct.py
@@ -1,0 +1,37 @@
+import struct
+import threading
+import unittest
+from test.support import threading_helper
+
+
+threading_helper.requires_working_threading(module=True)
+
+
+class TestStructIterUnpack(unittest.TestCase):
+    def test_shared_iteration_is_exactly_once(self):
+        # Every record must be handed to exactly one thread: no crash, no
+        # duplicated record, and no skipped record.
+        nthreads = 8
+        nrecords = 100_000
+        s = struct.Struct("i")
+        data = b"".join(s.pack(i) for i in range(nrecords))
+
+        for _ in range(5):
+            it = s.iter_unpack(data)
+            collected = []
+            lock = threading.Lock()
+
+            def worker():
+                local = [value for (value,) in it]
+                with lock:
+                    collected.extend(local)
+
+            threading_helper.run_concurrently(
+                worker, nthreads=nthreads
+            )
+
+            self.assertEqual(len(collected), nrecords)
+            self.assertEqual(sorted(collected), list(range(nrecords)))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -12,6 +12,7 @@
 #include "pycore_lock.h"          // _PyOnceFlag_CallOnce()
 #include "pycore_long.h"          // _PyLong_AsByteArray()
 #include "pycore_moduleobject.h"  // _PyModule_GetState()
+#include "pycore_pyatomic_ft_wrappers.h"  // FT_ATOMIC_LOAD_SSIZE_RELAXED()
 #include "pycore_weakref.h"       // FT_CLEAR_WEAKREFS()
 
 #include <stddef.h>               // offsetof()
@@ -2246,7 +2247,12 @@ unpackiter_len(PyObject *op, PyObject *Py_UNUSED(dummy))
         len = 0;
     }
     else {
-        len = (self->buf.len - self->index) / self->so->s_size;
+        Py_ssize_t index = FT_ATOMIC_LOAD_SSIZE_RELAXED(self->index);
+        len = (self->buf.len - index) / self->so->s_size;
+        if (len < 0) {
+            /* index may briefly overshoot buf.len on a concurrent iteration */
+            len = 0;
+        }
     }
     return PyLong_FromSsize_t(len);
 }
@@ -2261,22 +2267,31 @@ unpackiter_iternext(PyObject *op)
 {
     unpackiterobject *self = unpackiterobject_CAST(op);
     _structmodulestate *state = get_struct_state_iterinst(self);
-    PyObject *result;
     if (self->so == NULL) {
         return NULL;
     }
-    if (self->index >= self->buf.len) {
-        /* Iterator exhausted */
-        Py_CLEAR(self->so);
-        PyBuffer_Release(&self->buf);
-        return NULL;
-    }
-    assert(self->index + self->so->s_size <= self->buf.len);
-    result = s_unpack_internal(self->so,
-                               (char*)self->buf.buf + self->index,
-                               state);
-    self->index += self->so->s_size;
-    return result;
+    Py_ssize_t size = self->so->s_size;
+
+    #ifdef Py_GIL_DISABLED
+        /* Claim a unique, in-bounds slot; buffer/Struct released only in dealloc,
+           so a concurrent reader can never observe a freed buffer. */
+        Py_ssize_t off = _Py_atomic_load_ssize_relaxed(&self->index);
+        do {
+            if (off + size > self->buf.len) {
+                return NULL;   /* exhausted */
+            }
+        } while (!_Py_atomic_compare_exchange_ssize(&self->index, &off, off + size));
+    #else
+        Py_ssize_t off = self->index;      /* GIL build: keep eager release */
+        if (off >= self->buf.len) {
+            Py_CLEAR(self->so);
+            PyBuffer_Release(&self->buf);
+            return NULL;
+        }
+        assert(off + size <= self->buf.len);
+        self->index = off + size;
+    #endif
+    return s_unpack_internal(self->so, (char*)self->buf.buf + off, state);
 }
 
 static PyType_Slot unpackiter_type_slots[] = {


### PR DESCRIPTION
Leverage `_Py_atomic_compare_exchange_ssize` to "claim" a single index position for each thread

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-154013 -->
* Issue: gh-154013
<!-- /gh-issue-number -->
