### PR TITLE
gh-154014: Initialize cold executor vm_data fields

### DIFF
--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -5127,6 +5127,16 @@ class TestUopsOptimization(unittest.TestCase):
                               f" {executor} at offset {idx} rather"
                               f" than expected _EXIT_TRACE")
 
+    def test_jit_shutdown_after_cold_executor_creation(self):
+        script_helper.assert_python_ok("-c", textwrap.dedent(f"""
+            def f():
+                for x in range({TIER2_THRESHOLD + 3}):
+                    for y in range({TIER2_THRESHOLD + 3}):
+                        z = x + y
+
+            f()
+        """), PYTHON_JIT="1")
+
     def test_enter_executor_valid_op_arg(self):
         script_helper.assert_python_ok("-c", textwrap.dedent("""
             import sys

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-19-16-18-25.gh-issue-154014.CJsjVL.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-19-16-18-25.gh-issue-154014.CJsjVL.rst
@@ -1,0 +1,2 @@
+Fix a JIT assertion during interpreter shutdown by initializing ``vm_data``
+fields for cold executors that bypass ``_Py_ExecutorInit()``.

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1809,7 +1809,7 @@ make_cold_executor(uint16_t opcode)
     cold->jit_code = NULL;
     cold->jit_size = 0;
     if (_PyJIT_Compile(cold, cold->trace, 1)) {
-        Py_DECREF(cold);
+        PyExecutor_Free(cold);
         Py_FatalError("Cannot allocate core JIT code");
     }
 #endif

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1809,7 +1809,7 @@ make_cold_executor(uint16_t opcode)
     cold->jit_code = NULL;
     cold->jit_size = 0;
     if (_PyJIT_Compile(cold, cold->trace, 1)) {
-        PyExecutor_Free(cold);
+        _PyExecutor_Free(cold);
         Py_FatalError("Cannot allocate core JIT code");
     }
 #endif

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1788,7 +1788,6 @@ _Py_ExecutorInit(_PyExecutorObject *executor, const _PyBloomFilter *dependency_s
     }
     return 0;
 }
-
 static _PyExecutorObject *
 make_cold_executor(uint16_t opcode)
 {
@@ -1796,10 +1795,17 @@ make_cold_executor(uint16_t opcode)
     if (cold == NULL) {
         Py_FatalError("Cannot allocate core JIT code");
     }
+
     ((_PyUOpInstruction *)cold->trace)->opcode = opcode;
+
+    // Cold executors bypass _Py_ExecutorInit().
+    cold->vm_data.valid = true;
+    cold->vm_data.pending_deletion = 0;
+
     // This is initialized to false so we can prevent the executor
     // from being immediately detected as cold and invalidated.
     cold->vm_data.cold = false;
+
 #ifdef _Py_JIT
     cold->jit_code = NULL;
     cold->jit_size = 0;
@@ -1808,6 +1814,7 @@ make_cold_executor(uint16_t opcode)
         Py_FatalError("Cannot allocate core JIT code");
     }
 #endif
+
     _Py_SetImmortal((PyObject *)cold);
     return cold;
 }

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1800,6 +1800,7 @@ make_cold_executor(uint16_t opcode)
     // Cold executors bypass _Py_ExecutorInit().
     cold->vm_data.valid = true;
     cold->vm_data.pending_deletion = 0;
+    cold->vm_data.code = NULL;
 
     // This is initialized to false so we can prevent the executor
     // from being immediately detected as cold and invalidated.

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1788,6 +1788,7 @@ _Py_ExecutorInit(_PyExecutorObject *executor, const _PyBloomFilter *dependency_s
     }
     return 0;
 }
+
 static _PyExecutorObject *
 make_cold_executor(uint16_t opcode)
 {
@@ -1795,9 +1796,7 @@ make_cold_executor(uint16_t opcode)
     if (cold == NULL) {
         Py_FatalError("Cannot allocate core JIT code");
     }
-
     ((_PyUOpInstruction *)cold->trace)->opcode = opcode;
-
     // Cold executors bypass _Py_ExecutorInit().
     cold->vm_data.valid = true;
     cold->vm_data.pending_deletion = 0;
@@ -1805,7 +1804,6 @@ make_cold_executor(uint16_t opcode)
     // This is initialized to false so we can prevent the executor
     // from being immediately detected as cold and invalidated.
     cold->vm_data.cold = false;
-
 #ifdef _Py_JIT
     cold->jit_code = NULL;
     cold->jit_size = 0;
@@ -1814,7 +1812,6 @@ make_cold_executor(uint16_t opcode)
         Py_FatalError("Cannot allocate core JIT code");
     }
 #endif
-
     _Py_SetImmortal((PyObject *)cold);
     return cold;
 }


### PR DESCRIPTION
## Issue

Fixes gh-154014.

## Summary

`make_cold_executor()` allocates cold executors directly via
`allocate_executor()` and bypasses `_Py_ExecutorInit()`. As a result,
`vm_data.valid` and `vm_data.pending_deletion` remain uninitialized.

During interpreter shutdown, `interpreter_clear()` asserts that
`cold->vm_data.valid` is true, causing assertion failures when CPython is
built with `--enable-experimental-jit --with-assertions`.

This change initializes the required `vm_data` fields for cold executors,
restoring the expected invariant during shutdown.

## Testing

Reproduced the original crash reported in the issue using:

```sh
./configure --enable-experimental-jit --with-assertions
make -j$(nproc)
```

Before this change, `_bootstrap_python` aborted with:

```text
Assertion `cold->vm_data.valid' failed.
```

After this change:

- `make -j$(nproc)` completes successfully.
- The full CPython regression test suite passes.