### PR TITLE
gh-154144: Fix false positive from the stdbool.h guard in _testcapimodule.c

### DIFF
--- a/Misc/NEWS.d/next/Tests/2026-07-19-18-20-00.gh-issue-154144.tcbool.rst
+++ b/Misc/NEWS.d/next/Tests/2026-07-19-18-20-00.gh-issue-154144.tcbool.rst
@@ -1,0 +1,1 @@
+Fix building the :mod:`!_testcapi` module on NetBSD.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -15,6 +15,10 @@
 #include "frameobject.h"          // PyFrame_New()
 #include "marshal.h"              // PyMarshal_WriteLongToFile()
 
+#ifdef bool
+#  error "The public headers should not include <stdbool.h>, see gh-90904"
+#endif
+
 #include <float.h>                // FLT_MAX
 #include <signal.h>
 #include <stddef.h>               // offsetof()
@@ -24,10 +28,6 @@
 #endif
 #ifdef HAVE_SYS_SYSCTL_H
 #  include <sys/sysctl.h>         // sysctlbyname()
-#endif
-
-#ifdef bool
-#  error "The public headers should not include <stdbool.h>, see gh-48924"
 #endif
 
 #include "_testcapi/util.h"


### PR DESCRIPTION
Move the guard above the system includes: NetBSD's `<sys/sysctl.h>` includes `<stdbool.h>`. Also correct the issue reference (gh-90904, not gh-48924).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-154144 -->
* Issue: gh-154144
<!-- /gh-issue-number -->
