### PR TITLE
gh-153769: Clarify the TypeError from ipaddress subnet_of()/supernet_of()

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1026,14 +1026,16 @@ class _BaseNetwork(_IPAddressBase):
 
     @staticmethod
     def _is_subnet_of(a, b):
-        if not (isinstance(a, _BaseNetwork) and isinstance(b, _BaseNetwork)):
-            raise TypeError(f"Unable to test subnet containment between "
-                            f"{a} and {b}: both must be network objects")
-        # Always false if one is v4 and the other is v6.
-        if a.version != b.version:
-            raise TypeError(f"{a} and {b} are not of the same version")
-        return (b.network_address <= a.network_address and
-                b.broadcast_address >= a.broadcast_address)
+        try:
+            # Always false if one is v4 and the other is v6.
+            if a.version != b.version:
+                raise TypeError(f"{a} and {b} are not of the same version")
+            return (b.network_address <= a.network_address and
+                    b.broadcast_address >= a.broadcast_address)
+        except AttributeError:
+            raise TypeError(
+                f"Unable to test subnet containment between {a} and {b}: "
+                f"both must be network objects") from None
 
     def subnet_of(self, other):
         """Return True if this network is a subnet of other."""

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1026,15 +1026,14 @@ class _BaseNetwork(_IPAddressBase):
 
     @staticmethod
     def _is_subnet_of(a, b):
-        try:
-            # Always false if one is v4 and the other is v6.
-            if a.version != b.version:
-                raise TypeError(f"{a} and {b} are not of the same version")
-            return (b.network_address <= a.network_address and
-                    b.broadcast_address >= a.broadcast_address)
-        except AttributeError:
-            raise TypeError(f"Unable to test subnet containment "
-                            f"between {a} and {b}")
+        if not (isinstance(a, _BaseNetwork) and isinstance(b, _BaseNetwork)):
+            raise TypeError(f"Unable to test subnet containment between "
+                            f"{a} and {b}: both must be network objects")
+        # Always false if one is v4 and the other is v6.
+        if a.version != b.version:
+            raise TypeError(f"{a} and {b} are not of the same version")
+        return (b.network_address <= a.network_address and
+                b.broadcast_address >= a.broadcast_address)
 
     def subnet_of(self, other):
         """Return True if this network is a subnet of other."""

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -733,9 +733,8 @@ class NetworkTestCase_v4(BaseTestCase, NetmaskTestMixin_v4):
                 with self.assertRaises(TypeError) as cm:
                     method(other)
                 self.assertIn('network', str(cm.exception))
-                # The error should not be a swallowed AttributeError.
-                self.assertNotIsInstance(cm.exception.__context__,
-                                         AttributeError)
+                # The internal AttributeError is not shown to the caller.
+                self.assertTrue(cm.exception.__suppress_context__)
 
 
 class NetmaskTestMixin_v6(CommonTestMixin_v6):

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -723,6 +723,20 @@ class NetworkTestCase_v4(BaseTestCase, NetmaskTestMixin_v4):
             ipaddress.IPv6Network('::1/128').subnet_of(
                 ipaddress.IPv4Network('10.0.0.0/30'))
 
+    def test_subnet_of_non_network(self):
+        # Passing something that is not a network object (e.g. an address)
+        # must raise a clear TypeError rather than masking an internal
+        # AttributeError (gh-153769).
+        net = ipaddress.IPv4Network('10.0.0.0/30')
+        for other in (ipaddress.IPv4Address('10.0.0.1'), '10.0.0.0/30', 42):
+            for method in (net.subnet_of, net.supernet_of):
+                with self.assertRaises(TypeError) as cm:
+                    method(other)
+                self.assertIn('network', str(cm.exception))
+                # The error should not be a swallowed AttributeError.
+                self.assertNotIsInstance(cm.exception.__context__,
+                                         AttributeError)
+
 
 class NetmaskTestMixin_v6(CommonTestMixin_v6):
     """Input validation on interfaces and networks is very similar"""

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -2008,6 +2008,7 @@ Wm. Keith van der Meulen
 Eric N. Vander Weele
 Andrew Vant
 Atul Varma
+Vyron Vasileiadis
 Dmitry Vasiliev
 Sebastian Ortiz Vasquez
 Alexandre Vassalotti

--- a/Misc/NEWS.d/next/Library/2026-07-19-16-30-00.gh-issue-153769.STygbq.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-19-16-30-00.gh-issue-153769.STygbq.rst
@@ -1,0 +1,5 @@
+:meth:`~ipaddress.IPv4Network.subnet_of` and
+:meth:`~ipaddress.IPv4Network.supernet_of` now raise a clear
+:exc:`TypeError` when passed an argument that is not a network object,
+such as an address, instead of a confusing error that masked an internal
+:exc:`AttributeError`.

--- a/Misc/NEWS.d/next/Library/2026-07-19-16-30-00.gh-issue-153769.STygbq.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-19-16-30-00.gh-issue-153769.STygbq.rst
@@ -1,5 +1,4 @@
 :meth:`~ipaddress.IPv4Network.subnet_of` and
-:meth:`~ipaddress.IPv4Network.supernet_of` now raise a clear
-:exc:`TypeError` when passed an argument that is not a network object,
-such as an address, instead of a confusing error that masked an internal
-:exc:`AttributeError`.
+:meth:`~ipaddress.IPv4Network.supernet_of` now say that both arguments must be
+network objects when passed something else, such as an address, and no longer
+show the internal :exc:`AttributeError` behind it.


### PR DESCRIPTION
`subnet_of()` and `supernet_of()` reported a non-network argument as "Unable to test subnet
containment between ::/0 and ::1", with an `AttributeError` about `network_address` shown
above it. The message now says what is actually wrong, and the internal error is no longer
displayed:

```
TypeError: Unable to test subnet containment between ::/0 and ::1: both must be network objects
```

The exception type does not change, and the handler stays. An `isinstance(_BaseNetwork)`
check would also reject a network-like object that is not a subclass of it, which works
today:

```python
class DuckNetwork:
    version = 4
    network_address = ipaddress.IPv4Address('10.0.0.0')
    broadcast_address = ipaddress.IPv4Address('10.255.255.255')

ipaddress.IPv4Network('10.1.0.0/16').subnet_of(DuckNetwork())   # True on 3.14 and on main
```

Nothing documents *other* as having to be a network instance, so that stays working here.

`test_ipaddress` passes, 216 tests.
