### PR TITLE
gh-154146: Fix accuracy of the math.acospi() fallback near 1

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-07-19-19-05-00.gh-issue-154146.acospi.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-19-19-05-00.gh-issue-154146.acospi.rst
@@ -1,0 +1,2 @@
+Fix accuracy of :func:`math.acospi` for arguments close to 1
+on platforms that do not provide ``acospi()`` in libm.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -220,6 +220,12 @@ static const double logpi = 1.144729885849400174143427351353058711647;
 static double
 m_acospi(double x)
 {
+    if (x >= 0.5) {
+        /* acos(x) = 2*asin(sqrt((1 - x)/2)).  1 - x is exact here.
+           Some libms (old fdlibm derivatives) lose precision in acos(x)
+           near x = 1, while asin() is accurate for small arguments. */
+        return 2.0*asin(sqrt((1.0 - x)/2.0))/pi;
+    }
     double r = acos(x)/pi;
     if (isgreater(r, 1.0)) {
         return 1.0;


### PR DESCRIPTION
The fallback computed `acos(x)/pi`, and some libms (old fdlibm derivatives on NetBSD, OpenBSD and DragonFly) lose precision in `acos(x)` near x = 1. Compute it as `2*asin(sqrt((1 - x)/2))/pi` for x >= 0.5, where `1 - x` is exact and `asin()` is accurate.

Tested on NetBSD 10.1, OpenBSD 7.9 and DragonFly 6.4 (the failing mtest cases pass now) and FreeBSD 15.1 (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-154146 -->
* Issue: gh-154146
<!-- /gh-issue-number -->
