### PR TITLE
gh-153772: Make abc isinstance() tolerate instances without __class__

### DIFF
--- a/Lib/_py_abc.py
+++ b/Lib/_py_abc.py
@@ -92,7 +92,12 @@ class ABCMeta(type):
     def __instancecheck__(cls, instance):
         """Override for isinstance(instance, cls)."""
         # Inline the cache checking
-        subclass = instance.__class__
+        try:
+            subclass = instance.__class__
+        except AttributeError:
+            # Fall back to the type when the instance has no __class__,
+            # matching the behaviour of the built-in isinstance() (gh-153772).
+            subclass = type(instance)
         if subclass in cls._abc_cache:
             return True
         subtype = type(instance)

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -380,6 +380,25 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
             self.assertIsSubclass(C, A)
             self.assertIsSubclass(C, (A,))
 
+        def test_instancecheck_no_class(self):
+            # gh-153772: __instancecheck__ must fall back to type(instance)
+            # when the instance has no __class__, matching isinstance().
+            class NoClass:
+                def __getattribute__(self, name):
+                    if name == "__class__":
+                        raise AttributeError(name)
+                    return super().__getattribute__(name)
+
+            class A(metaclass=abc_ABCMeta):
+                pass
+
+            obj = NoClass()
+            # Must return False rather than propagating the AttributeError.
+            self.assertNotIsInstance(obj, A)
+            # Registering the actual type makes the fallback report a match.
+            A.register(NoClass)
+            self.assertIsInstance(obj, A)
+
         def test_registration_edge_cases(self):
             class A(metaclass=abc_ABCMeta):
                 pass

--- a/Misc/NEWS.d/next/Library/2026-07-19-17-05-00.gh-issue-153772.cobjTK.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-19-17-05-00.gh-issue-153772.cobjTK.rst
@@ -1,0 +1,5 @@
+:func:`isinstance` checks against :mod:`collections.abc` classes such as
+:class:`~collections.abc.Mapping` no longer raise :exc:`AttributeError`
+when the instance has no ``__class__``.  The abstract base class machinery
+now falls back to the object's type in that case, matching the behaviour of
+the built-in :func:`isinstance`.

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -629,10 +629,14 @@ _abc__abc_instancecheck_impl(PyObject *module, PyObject *self,
         return NULL;
     }
 
-    subclass = PyObject_GetAttr(instance, &_Py_ID(__class__));
-    if (subclass == NULL) {
+    if (PyObject_GetOptionalAttr(instance, &_Py_ID(__class__), &subclass) < 0) {
         Py_DECREF(impl);
         return NULL;
+    }
+    if (subclass == NULL) {
+        /* Fall back to the type when the instance has no __class__, matching
+           the behaviour of the built-in isinstance() (gh-153772). */
+        subclass = Py_NewRef((PyObject *)Py_TYPE(instance));
     }
     /* Inline the cache checking. */
     int incache = _in_weak_set(impl, &impl->_abc_cache, subclass);


### PR DESCRIPTION
The built-in `isinstance()` reads an instance's `__class__` with a lookup that suppresses `AttributeError` and falls back to the object's type, so a value whose `__class__` access raises still checks cleanly:

```pycon
>>> class NoClass:
...     def __getattribute__(self, name):
...         if name == "__class__":
...             raise AttributeError(name)
...         return super().__getattribute__(name)
...
>>> isinstance(NoClass(), int)
False
```

`ABCMeta.__instancecheck__` read `__class__` directly instead, so the same object leaked the `AttributeError` when checked against a `collections.abc` class:

```pycon
>>> from collections.abc import Mapping
>>> isinstance(NoClass(), Mapping)
AttributeError: __class__
```

This makes the abstract base class machinery fall back to `type(instance)` when `__class__` is unavailable, in both the C (`Modules/_abc.c`) and the pure-Python (`Lib/_py_abc.py`) implementations, so it matches the built-in `isinstance()`:

```pycon
>>> isinstance(NoClass(), Mapping)
False
```

Objects without a `__class__` are unusual, but they do turn up in the wild (for example some Qt widgets, as noted in the issue).

<!-- gh-issue-number: gh-153772 -->
* Issue: gh-153772
<!-- /gh-issue-number -->