### PR TITLE
Fix typos in C API Type Objects documentation

### DIFF
--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -699,7 +699,7 @@ but need extra remarks for use as slots:
 
    .. soft-deprecated:: 3.15
 
-      When not targetting older Python versions, pefer :c:macro:`!Py_tp_bases`.
+      When not targeting older Python versions, prefer :c:macro:`!Py_tp_bases`.
 
 The following slots do not correspond to public fields in the
 underlying structures:


### PR DESCRIPTION
Fix 2 typos in C API Type Objects documentation.

## Method

```console
% brew install typos-cli

% typos type.rst
error: `targetting` should be `targeting`
    ╭▸ type.rst:702:16
    │
702 │       When not targetting older Python versions, pefer :c:macro:`!Py_tp_bases`.
    ╰╴               ━━━━━━━━━━
error: `pefer` should be `prefer`
    ╭▸ type.rst:702:50
    │
702 │       When not targetting older Python versions, pefer :c:macro:`!Py_tp_bases`.
    ╰╴                                                 ━━━━━

% typos --write-changes type.rst
```

## Other Considerations Taken

- [x] Confirm this is not an intentional typo.
- [x] Confirm this is not a duplicate issue/PR.
 