### PR TITLE
[3.13] gh-153862: Fix curses window.inch() for non-ASCII characters on a wide build (GH-153863)

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -1063,6 +1063,8 @@ Window objects
    The bottom 8 bits are the character proper and the upper bits are the attributes;
    extract them with the :data:`A_CHARTEXT` and :data:`A_ATTRIBUTES` bit-masks,
    and the color pair with :func:`pair_number`.
+   The character byte is the locale-encoded byte of the cell's character,
+   consistent with :meth:`instr`.
 
 
 .. method:: window.insch(ch[, attr])

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -512,10 +512,9 @@ class TestCurses(unittest.TestCase):
         self.assertRaises(ValueError, stdscr.instr, -2)
         self.assertRaises(ValueError, stdscr.instr, 0, 2, -2)
         # A non-ASCII character of an 8-bit locale reads back as its encoded
-        # byte (see _encodable for the set).  instr() returns the locale bytes
-        # for any single-byte character; inch() packs the text into a chtype, so
-        # on a wide build it only round-trips a Latin-1 codepoint (byte ==
-        # codepoint).
+        # byte (see _encodable for the set).  Both instr() and inch() return the
+        # locale byte for any character that fits the locale's single-byte
+        # encoding.
         encoding = stdscr.encoding
         for ch in ('A', 'é', '¤', '€', 'є'):
             try:
@@ -527,8 +526,7 @@ class TestCurses(unittest.TestCase):
             with self.subTest(ch=ch):
                 stdscr.addstr(2, 0, ch)
                 self.assertEqual(stdscr.instr(2, 0, 1), b)
-                if ord(ch) < 0x100:
-                    self.assertEqual(stdscr.inch(2, 0) & curses.A_CHARTEXT, b[0])
+                self.assertEqual(stdscr.inch(2, 0) & curses.A_CHARTEXT, b[0])
 
     def test_coordinate_errors(self):
         # Addressing a cell outside the window raises curses.error.

--- a/Misc/NEWS.d/next/Library/2026-07-17-20-31-00.gh-issue-153862.X3kjoY.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-17-20-31-00.gh-issue-153862.X3kjoY.rst
@@ -1,0 +1,3 @@
+On a wide :mod:`curses` build, :meth:`curses.window.inch` now returns the
+locale-encoded byte of a non-ASCII character, matching
+:meth:`~curses.window.instr`, instead of the low byte of its code point.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -1714,6 +1714,34 @@ _curses_window_insch_impl(PyCursesWindowObject *self, int group_left_1,
     return PyCursesCheckERR(rtn, "insch");
 }
 
+#ifdef HAVE_NCURSESW
+/* winch() returns the low 8 bits of the character's code point with no locale
+   conversion, unlike instr(), so recover the locale byte from the wide cell
+   when the character maps to exactly one byte, keeping the attribute and color
+   bits in RTN.  A character with no single-byte form is left to winch(). */
+static chtype
+curses_cell_locale_byte(chtype rtn, const cchar_t *cell)
+{
+    wchar_t wstr[CCHARW_MAX + 1];
+    attr_t attrs;
+    short pair;
+    /* getcchar() is not guaranteed to write the text of an empty cell. */
+    wstr[0] = L'\0';
+    if (getcchar(cell, wstr, &attrs, &pair, NULL) == ERR
+        || wstr[0] == L'\0' || wstr[1] != L'\0')
+    {
+        return rtn;
+    }
+    /* wctob() mirrors ncurses' own _nc_to_char(): the single-byte form, or EOF
+       when the character has none in this locale. */
+    int byte = wctob(wstr[0]);
+    if (byte != EOF) {
+        rtn = (rtn & ~(chtype)A_CHARTEXT) | (unsigned char)byte;
+    }
+    return rtn;
+}
+#endif
+
 /*[clinic input]
 _curses.window.inch -> unsigned_long
 
@@ -1744,7 +1772,14 @@ _curses_window_inch_impl(PyCursesWindowObject *self, int group_right_1,
     else {
         rtn = mvwinch(self->win, y, x);
     }
-
+#ifdef HAVE_NCURSESW
+    cchar_t cell = {0};
+    if ((group_right_1 ? mvwin_wch(self->win, y, x, &cell)
+                       : win_wch(self->win, &cell)) != ERR)
+    {
+        rtn = curses_cell_locale_byte(rtn, &cell);
+    }
+#endif
     return rtn;
 }
 


### PR DESCRIPTION
Manual backport of #153863; the automatic backport hit a conflict.

3.13 predates both the 3.16 `complexchar` refactor and the 3.15 error-handling refactor, so `inch()` keeps its `unsigned long` return and just gains the wide-cell locale-byte recovery (the `getcchar()` + `wctob()` helper).

Verified on a wide (`HAVE_NCURSESW`) build: `test_read_from_window` passes under `ISO-8859-15` where `€` (0xA4) exercises the fix, and the full `test_curses` is green there once the paired `insch` fix (gh-153864) is also applied.


<!-- gh-issue-number: gh-153862 -->
* Issue: gh-153862
<!-- /gh-issue-number -->
