### PR TITLE
gh-154160: Make sys.executable absolute when resolved from a relative PATH entry

### DIFF
--- a/Lib/test/test_getpath.py
+++ b/Lib/test/test_getpath.py
@@ -290,6 +290,32 @@ class MockGetPathTests(unittest.TestCase):
         actual = getpath(ns, expected)
         self.assertEqual(expected, actual)
 
+    def test_relative_path_env_posix(self):
+        "Resolving the executable from a relative PATH entry yields an absolute path (gh-154160)"
+        ns = MockPosixNamespace(
+            PREFIX="/usr",
+            argv0="python",
+            ENV_PATH="usr/bin",
+        )
+        ns.add_known_xfile("usr/bin/python")
+        ns.add_known_xfile("/Absolute/usr/bin/python")
+        ns.add_known_file("/usr/lib/python9.8/os.py")
+        ns.add_known_dir("/usr/lib/python9.8/lib-dynload")
+        expected = dict(
+            executable="/Absolute/usr/bin/python",
+            base_executable="/Absolute/usr/bin/python",
+            prefix="/usr",
+            exec_prefix="/usr",
+            module_search_paths_set=1,
+            module_search_paths=[
+                "/usr/lib/python98.zip",
+                "/usr/lib/python9.8",
+                "/usr/lib/python9.8/lib-dynload",
+            ],
+        )
+        actual = getpath(ns, expected)
+        self.assertEqual(expected, actual)
+
     def test_buildpath_posix(self):
         """Test an in-build-tree layout on POSIX.
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-19-18-30-00.gh-issue-154160.XnXeqS.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-19-18-30-00.gh-issue-154160.XnXeqS.rst
@@ -1,0 +1,3 @@
+Fixed :data:`sys.executable` being a relative path when the interpreter was
+found through a relative entry in :envvar:`PATH`.  It is now made absolute, as
+documented.

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -285,7 +285,9 @@ if not executable and program_name and ENV_PATH:
     for p in ENV_PATH.split(DELIM):
         p = joinpath(p, program_name)
         if isxfile(p):
-            executable = p
+            # A relative PATH entry would otherwise leave executable
+            # relative, contrary to the documented behaviour (gh-154160).
+            executable = abspath(p)
             break
 
 if not executable:


### PR DESCRIPTION
`sys.executable` is documented as *"a string giving the absolute path of the executable binary for the Python interpreter"*. When the interpreter is started by a bare program name (no separator) and found through a **relative** directory in `PATH`, it was left as that relative path instead:

```console
$ python3 -m venv venv
$ cd /tmp && PATH="venv/bin" python3 -c 'import sys; print(sys.executable)'
venv/bin/python3          # expected an absolute path
```

`getpath` absolutizes the executable in the sibling branch that handles a program name containing a separator (`executable = abspath(program_name)`), but the PATH-resolution loop assigned the joined path directly. This makes it call `abspath()` there too:

```console
$ cd /tmp && PATH="venv/bin" python3 -c 'import sys; print(sys.executable)'
/tmp/venv/bin/python3
```

This is a regression from the getpath.c rewrite in 3.11 (bpo-45582 / #29041); 3.10 returned an absolute path.

The issue also notes a separate, cosmetic double-slash case (`//usr/local/bin/python3` when invoked as `usr/local/bin/python3` from `/`); that comes from a different branch and is not addressed here.

<!-- gh-issue-number: gh-154160 -->
* Issue: gh-154160
<!-- /gh-issue-number -->