### PR TITLE
gh-154167: Fix test suite hang when SIGINT is ignored

### DIFF
--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -50,6 +50,14 @@ def setup_process() -> None:
         for signum in signals:
             faulthandler.register(signum, chain=True, file=stderr_fd)
 
+    # Restore the default SIGINT handler if there is no Python-level
+    # handler.  Python inherits the SIG_IGN disposition when the test
+    # suite runs as a shell background job; then asyncio.Runner does not
+    # install its own handler and _thread.interrupt_main() is a no-op,
+    # which makes some tests in test_asyncio and test_threading hang.
+    if signal.getsignal(signal.SIGINT) in (signal.SIG_IGN, signal.SIG_DFL):
+        signal.signal(signal.SIGINT, signal.default_int_handler)
+
     adjust_rlimit_nofile()
 
     support.record_original_stdout(sys.stdout)

--- a/Misc/NEWS.d/next/Tests/2026-07-19-20-15-00.gh-issue-154167.sigint.rst
+++ b/Misc/NEWS.d/next/Tests/2026-07-19-20-15-00.gh-issue-154167.sigint.rst
@@ -1,0 +1,3 @@
+regrtest now restores the default SIGINT handler if it was inherited as
+ignored, so the test suite no longer hangs when run as a shell background
+job.

--- a/Misc/NEWS.d/next/Tests/2026-07-19-20-15-00.gh-issue-154167.sigint.rst
+++ b/Misc/NEWS.d/next/Tests/2026-07-19-20-15-00.gh-issue-154167.sigint.rst
@@ -1,3 +1,3 @@
-regrtest now restores the default SIGINT handler if it was inherited as
-ignored, so the test suite no longer hangs when run as a shell background
-job.
+The test runner (regrtest) now restores the default SIGINT handler if it
+was inherited as ignored, so the test suite no longer hangs when run as
+a shell background job.


### PR DESCRIPTION
Restore the default SIGINT handler in regrtest `setup_process()` when there is no Python-level handler. Python inherits the SIG_IGN disposition when the test suite runs as a shell background job; then `asyncio.Runner` does not install its own handler and `_thread.interrupt_main()` is a no-op, which makes some tests in test_asyncio and test_threading hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-154167 -->
* Issue: gh-154167
<!-- /gh-issue-number -->
