### PR TITLE
gh-104533: Fix ctypes test_pointer_proto_missing_argtypes_error()

### DIFF
--- a/Lib/test/test_ctypes/test_pointers.py
+++ b/Lib/test/test_ctypes/test_pointers.py
@@ -11,6 +11,7 @@ from ctypes import (CDLL, CFUNCTYPE, Structure,
                     c_long, c_ulong, c_longlong, c_ulonglong,
                     c_float, c_double)
 from ctypes import _pointer_type_cache, _pointer_type_cache_fallback
+from test import support
 from test.support import import_helper
 from weakref import WeakSet
 _ctypes_test = import_helper.import_module("_ctypes_test")
@@ -409,10 +410,9 @@ class PointersTestCase(unittest.TestCase):
             pass
 
         func = ctypes.pythonapi.Py_GetVersion
-        func.argtypes = (BadType,)
-
-        with self.assertRaises(ctypes.ArgumentError):
-            func(object())
+        with support.swap_attr(func, 'argtypes', (BadType,)):
+            with self.assertRaises(ctypes.ArgumentError):
+                func(object())
 
 class PointerTypeCacheTestCase(unittest.TestCase):
     # dummy tests to check warnings and base behavior


### PR DESCRIPTION
Save/restore Py_GetVersion.argtypes, since Py_GetVersion is used in another test.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-104533 -->
* Issue: gh-104533
<!-- /gh-issue-number -->
