### PR TITLE
gh-154139: Document that curses is not thread-safe

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -31,6 +31,19 @@ Linux and the BSD variants of Unix.
    Whenever the documentation mentions a *character string* it can be specified
    as a Unicode string or a byte string.
 
+.. note::
+
+   Whether curses may be used from several threads
+   depends on the underlying library and how it was built.
+   In many implementations, including the default build of ncurses,
+   the screen state is shared and not thread-safe;
+   since the blocking and refresh methods
+   (such as :meth:`~window.getch` and :meth:`~window.refresh`)
+   release the :term:`GIL`,
+   unsynchronized use from several threads can then crash the interpreter.
+   Serialize the calls,
+   or wrap them in :meth:`window.use` and :meth:`screen.use`.
+
 .. seealso::
 
    Module :mod:`curses.ascii`


### PR DESCRIPTION
Documents the thread-safety limitation reported in #154139.

`_curses` releases the GIL around the blocking and refresh calls (`getch`, `refresh`, …), so with a non-reentrant curses — the default ncurses build on many systems — two threads can race on the shared global screen state and crash the interpreter. Whether curses is usable from multiple threads depends on the library and how it was built, so this is a documentation gap rather than a missing lock in CPython.

The note points to serializing the calls or wrapping them in `window.use()` / `screen.use()`, which lock only when the library is built with reentrant support.


<!-- gh-issue-number: gh-154139 -->
* Issue: gh-154139
<!-- /gh-issue-number -->
