### PR TITLE
Fix typos in Py_tp_base C API documentation

### DIFF
--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -699,7 +699,7 @@ but need extra remarks for use as slots:
 
    .. soft-deprecated:: 3.15
 
-      When not targetting older Python versions, pefer :c:macro:`!Py_tp_bases`.
+      When not targeting older Python versions, prefer :c:macro:`!Py_tp_bases`.
 
 The following slots do not correspond to public fields in the
 underlying structures:


### PR DESCRIPTION
Fixes two typos in the `Py_tp_base` soft-deprecation note in
`Doc/c-api/type.rst`:

- `targetting` → `targeting`
- `pefer` → `prefer`

Documentation-only change; no behavior impact.