### PR TITLE
Fix grammatical typos in documentation

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1366,7 +1366,7 @@ Control flow
 
    ``try`` blocks which are followed by ``except*`` clauses. The attributes are the
    same as for :class:`Try` but the :class:`ExceptHandler` nodes in ``handlers``
-   are interpreted as ``except*`` blocks rather then ``except``.
+   are interpreted as ``except*`` blocks rather than ``except``.
 
    .. doctest::
 

--- a/Doc/library/compression.zstd.rst
+++ b/Doc/library/compression.zstd.rst
@@ -503,7 +503,7 @@ Advanced parameter control
    The :meth:`~.bounds` method can be used on any attribute to get the valid
    values for that parameter.
 
-   Parameters are optional; any omitted parameter will have it's value selected
+   Parameters are optional; any omitted parameter will have its value selected
    automatically.
 
    Example getting the lower and upper bound of :attr:`~.compression_level`::
@@ -732,7 +732,7 @@ Advanced parameter control
 
    An :class:`~enum.IntEnum` containing the advanced decompression parameter
    keys that can be used when decompressing data. Parameters are optional; any
-   omitted parameter will have it's value selected automatically.
+   omitted parameter will have its value selected automatically.
 
    The :meth:`~.bounds` method can be used on any attribute to get the valid
    values for that parameter.

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -2135,7 +2135,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    returned by the :func:`open` function.  Their parameters are chosen as
    follows:
 
-   * The encoding and error handling are is initialized from
+   * The encoding and error handling are initialized from
      :c:member:`PyConfig.stdio_encoding` and :c:member:`PyConfig.stdio_errors`.
 
      On Windows, UTF-8 is used for the console device.  Non-character


### PR DESCRIPTION
Fix grammatical typos in the documentation (grammar only, no behavior change):

- `Doc/library/sys.rst`: "are is initialized" → "are initialized"
- `Doc/library/ast.rst`: "rather then" → "rather than"
- `Doc/library/compression.zstd.rst`: "it's value" → "its value" (two occurrences)