### PR TITLE
Add test that IMAP4.enable() after SELECT raises an error

### DIFF
--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -2523,7 +2523,16 @@ class ThreadedNetworkedTests(unittest.TestCase):
             self.assertRaises(imaplib.IMAP4.error, client.enable, 'foo')
             self.assertFalse(client.utf8_enabled)
 
-    # XXX Also need a test that enable after SELECT raises an error.
+    @threading_helper.reap_threads
+    def test_enable_raises_error_after_select(self):
+        with self.reaped_pair(self.UTF8Server) as (server, client):
+            typ, _ = client.authenticate('MYAUTH', lambda x: b'fake')
+            self.assertEqual(typ, 'OK')
+            typ, _ = client.select()
+            self.assertEqual(typ, 'OK')
+            self.assertFalse(client.utf8_enabled)
+            self.assertRaises(imaplib.IMAP4.error, client.enable, 'UTF8=ACCEPT')
+            self.assertFalse(client.utf8_enabled)
 
     @threading_helper.reap_threads
     def test_enable_raises_error_if_no_capability(self):


### PR DESCRIPTION
Resolve a long-standing `XXX` TODO in `test_imaplib.py` by covering the
case where `enable()` is called from the `SELECTED` state.

`ENABLE` is only valid in the `AUTH` state (`Commands['ENABLE'] == ('AUTH',)`),
so calling `enable()` after `select()` must raise `imaplib.IMAP4.error`. The
new `test_enable_raises_error_after_select` authenticates, selects a mailbox,
then asserts that `enable('UTF8=ACCEPT')` raises and does not set
`utf8_enabled`.

Test-only change; no behavior change.