### PR TITLE
gh-44672: Stop pre-resolving the FTP host in urllib.request

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -787,7 +787,7 @@ class HandlerTests(unittest.TestCase):
             # ftp authentication not yet implemented by FTPHandler
             self.assertEqual(h.user, user)
             self.assertEqual(h.passwd, passwd)
-            self.assertEqual(h.host, socket.gethostbyname(host))
+            self.assertEqual(h.host, host)
             self.assertEqual(h.port, port)
             self.assertEqual(h.dirs, dirs)
             self.assertEqual(h.ftpwrapper.filename, filename)
@@ -796,6 +796,45 @@ class HandlerTests(unittest.TestCase):
             self.assertEqual(headers.get("Content-type"), mimetype)
             self.assertEqual(int(headers["Content-length"]), len(data))
             r.close()
+
+    def test_ftp_no_hostname_resolution(self):
+        # gh-44672: the host must reach connect_ftp unresolved so that
+        # ftplib resolves it via getaddrinfo(), which supports IPv6.
+        class MockFTPWrapper:
+            def retrfile(self, filename, filetype):
+                return io.StringIO(""), 0
+
+            def close(self):
+                pass
+
+        class NullFTPHandler(urllib.request.FTPHandler):
+            def connect_ftp(self, user, passwd, host, port, dirs, timeout):
+                self.host = host
+                return MockFTPWrapper()
+
+        h = NullFTPHandler()
+        req = Request("ftp://localhost/foo/bar.html")
+        req.timeout = None
+        with mock.patch.object(socket, "gethostbyname",
+                               side_effect=AssertionError(
+                                   "ftp_open must not pre-resolve the host")):
+            r = h.ftp_open(req)
+        r.close()
+        self.assertEqual(h.host, "localhost")
+
+    def test_ftp_gaierror(self):
+        # gh-44672: without pre-resolution the lookup failure now surfaces
+        # from ftplib as socket.gaierror; it must still become a URLError.
+        class GaiErrorFTPHandler(urllib.request.FTPHandler):
+            def connect_ftp(self, user, passwd, host, port, dirs, timeout):
+                raise socket.gaierror(-2, "Name or service not known")
+
+        h = GaiErrorFTPHandler()
+        req = Request("ftp://nonexistent.invalid/")
+        req.timeout = None
+        with self.assertRaises(urllib.error.URLError) as cm:
+            h.ftp_open(req)
+        self.assertIsInstance(cm.exception.__cause__, socket.gaierror)
 
     @support.requires_resource("network")
     def test_ftp_error(self):

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1526,10 +1526,6 @@ class FTPHandler(BaseHandler):
         user = user or ''
         passwd = passwd or ''
 
-        try:
-            host = socket.gethostbyname(host)
-        except OSError as msg:
-            raise URLError(msg)
         path, attrs = _splitattr(req.selector)
         dirs = path.split('/')
         dirs = list(map(unquote, dirs))

--- a/Misc/NEWS.d/next/Library/2026-07-19-20-57-04.gh-issue-44672.nFrMYT.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-19-20-57-04.gh-issue-44672.nFrMYT.rst
@@ -1,0 +1,4 @@
+:func:`urllib.request.urlopen` can now fetch ``ftp://`` URLs whose host is
+IPv6-only.  :class:`~urllib.request.FTPHandler` no longer pre-resolves the host
+with the IPv4-only :func:`socket.gethostbyname`; the unresolved host is passed to
+:mod:`ftplib`, which resolves it with :func:`socket.getaddrinfo`.


### PR DESCRIPTION
`urllib.request.FTPHandler.ftp_open()` pre-resolves the host with `socket.gethostbyname()` before connecting. That function is IPv4-only, so an `ftp://` URL pointing at an IPv6-only host fails at the resolve step with a name-resolution error even though the server is reachable over IPv6.

As diagnosed on the tracker (bpo-1675455) back in 2009, `ftp_open()` has no need to resolve the host itself: it hands the host to `connect_ftp()`, then to `ftpwrapper`, and finally to `ftplib.FTP.connect()`, which connects through `socket.create_connection()` and resolves via `getaddrinfo()`. That path is already IPv6-aware. This change removes the pre-resolution so the host flows through unresolved and IPv6-only hosts work.

The one behavior to preserve is the exception type for a bad host. Previously an unresolvable host raised `socket.gaierror` from `gethostbyname()` and was turned into `URLError`. With the pre-resolution gone, the same `gaierror` is raised deeper, inside `ftplib`. Because `socket.gaierror` is a subclass of `OSError` and therefore a member of `ftplib.all_errors`, `ftp_open()`'s existing handler still catches it and re-raises it as `URLError`, so callers see exactly the same exception type as before.

Tests: `test_ftp` now asserts the original hostname reaches `connect_ftp()` rather than a pre-resolved IP; `test_ftp_no_hostname_resolution` tripwires `socket.gethostbyname` to prove `ftp_open()` never calls it; and `test_ftp_gaierror` asserts the `gaierror` -> `URLError` conversion still holds. All three fail on `main` and pass with this change.

<!-- gh-issue-number: gh-44672 -->
* Issue: gh-44672
<!-- /gh-issue-number -->
