### PR TITLE
[3.13] Fix grammatical typos in documentation (GH-154181)

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1301,7 +1301,7 @@ Control flow
 
    ``try`` blocks which are followed by ``except*`` clauses. The attributes are the
    same as for :class:`Try` but the :class:`ExceptHandler` nodes in ``handlers``
-   are interpreted as ``except*`` blocks rather then ``except``.
+   are interpreted as ``except*`` blocks rather than ``except``.
 
    .. doctest::
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1835,7 +1835,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    returned by the :func:`open` function.  Their parameters are chosen as
    follows:
 
-   * The encoding and error handling are is initialized from
+   * The encoding and error handling are initialized from
      :c:member:`PyConfig.stdio_encoding` and :c:member:`PyConfig.stdio_errors`.
 
      On Windows, UTF-8 is used for the console device.  Non-character


### PR DESCRIPTION
Manual backport of GH-154181 to 3.13.

Only the sys.rst and ast.rst fixes apply here; the compression.zstd.rst
change from the original PR is omitted because the compression.zstd module
does not exist in 3.13 (added in 3.14) — this is what prevented the
automated backport.

(cherry picked from commit 40f7fbf4a53d2f2cb0414a22f891d6e7e288280c)