### PR TITLE
gh-154174: Support fresh ZipInfo objects in ZipFile.mkdir

### DIFF
--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -5463,9 +5463,6 @@ class TestWithDirectory(unittest.TestCase):
 
             old_zinfo = zipfile.ZipInfo("directory4/")
             old_zinfo.external_attr = (0o40777 << 16) | 0x10
-            old_zinfo.CRC = 0
-            old_zinfo.file_size = 0
-            old_zinfo.compress_size = 0
             zf.mkdir(old_zinfo)
             new_zinfo = zf.filelist[3]
             self.assertEqual(old_zinfo.filename, "directory4/")
@@ -5475,6 +5472,34 @@ class TestWithDirectory(unittest.TestCase):
             os.mkdir(target)
             zf.extractall(target)
             self.assertEqual(set(os.listdir(target)), {"directory", "directory2", "directory3", "directory4"})
+
+    def test_mkdir_zipinfo_preserves_metadata(self):
+        zinfo = zipfile.ZipInfo("directory/", (2001, 2, 3, 4, 5, 6))
+        zinfo.compress_type = zipfile.ZIP_STORED
+        zinfo.compress_level = 1
+        zinfo.comment = b"comment"
+        zinfo.extra = b"\x99\x99\x00\x00"
+        zinfo.external_attr = (0o40700 << 16) | 0x10
+        zinfo.file_size = 1
+        zinfo.compress_size = 2
+
+        archive = io.BytesIO()
+        with zipfile.ZipFile(
+            archive, "w", zipfile.ZIP_DEFLATED, compresslevel=9
+        ) as zf:
+            zf.mkdir(zinfo)
+            self.assertEqual(zinfo.compress_level, 1)
+
+        self.assertEqual(zinfo.CRC, 0)
+        self.assertEqual(zinfo.file_size, 0)
+        self.assertEqual(zinfo.compress_size, 0)
+        with zipfile.ZipFile(archive) as zf:
+            written = zf.getinfo("directory/")
+        self.assertEqual(written.date_time, (2001, 2, 3, 4, 5, 6))
+        self.assertEqual(written.compress_type, zipfile.ZIP_STORED)
+        self.assertEqual(written.comment, b"comment")
+        self.assertEqual(written.extra, b"\x99\x99\x00\x00")
+        self.assertEqual(written.external_attr, (0o40700 << 16) | 0x10)
 
     def test_create_directory_with_write(self):
         with zipfile.ZipFile(TESTFN, "w") as zf:

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -5484,9 +5484,7 @@ class TestWithDirectory(unittest.TestCase):
         zinfo.compress_size = 2
 
         archive = io.BytesIO()
-        with zipfile.ZipFile(
-            archive, "w", zipfile.ZIP_DEFLATED, compresslevel=9
-        ) as zf:
+        with zipfile.ZipFile(archive, "w") as zf:
             zf.mkdir(zinfo)
             self.assertEqual(zinfo.compress_level, 1)
 

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -2529,8 +2529,6 @@ class ZipFile:
                                   strict_timestamps=self._strict_timestamps)
 
         if zinfo.is_dir():
-            zinfo.compress_size = 0
-            zinfo.CRC = 0
             self.mkdir(zinfo)
         else:
             if compress_type is not None:

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -2593,9 +2593,7 @@ class ZipFile:
         else:
             raise TypeError("Expected type str or ZipInfo")
 
-        zinfo.compress_size = 0
-        zinfo.CRC = 0
-        zinfo.file_size = 0
+        zinfo.CRC = zinfo.compress_size = zinfo.file_size = 0
 
         with self._lock:
             if self._seekable:

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -2590,13 +2590,14 @@ class ZipFile:
             if not directory_name.endswith("/"):
                 directory_name += "/"
             zinfo = ZipInfo(directory_name)
-            zinfo.compress_size = 0
-            zinfo.CRC = 0
             zinfo.external_attr = ((0o40000 | mode) & 0xFFFF) << 16
-            zinfo.file_size = 0
             zinfo.external_attr |= 0x10
         else:
             raise TypeError("Expected type str or ZipInfo")
+
+        zinfo.compress_size = 0
+        zinfo.CRC = 0
+        zinfo.file_size = 0
 
         with self._lock:
             if self._seekable:

--- a/Misc/NEWS.d/next/Library/2026-07-20-04-33-58.gh-issue-154174.A7mQ2x.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-20-04-33-58.gh-issue-154174.A7mQ2x.rst
@@ -1,0 +1,2 @@
+Fix :meth:`zipfile.ZipFile.mkdir` failing with an :class:`zipfile.ZipInfo`
+that does not already have a ``CRC`` attribute.


### PR DESCRIPTION
Fixes #154174.

`ZipFile.mkdir()` expected caller-supplied `ZipInfo` objects to already have a `CRC` attribute, even though a fresh `ZipInfo` does not initialize that attribute.

Initialize `CRC`, `file_size`, and `compress_size` to zero for directory entries regardless of whether `mkdir()` receives a name or a `ZipInfo`. Do not apply `ZipInfo._for_archive()`, since caller-supplied timestamps, compression settings, comments, extra data, and permissions must be preserved consistently with `writestr()`.

Tests verify that a fresh `ZipInfo` works and that caller metadata is preserved.

Tests:

- `PCbuild\amd64\python_d.exe -m unittest -v test.test_zipfile.test_core.TestWithDirectory.test_mkdir test.test_zipfile.test_core.TestWithDirectory.test_mkdir_zipinfo_preserves_metadata`
- `PCbuild\amd64\python_d.exe -m test test_zipfile -v` (`590` tests passed, `5` skipped)
- Ruff 0.15.17
- sphinx-lint 1.0.2
- `git diff --check`

AI tooling assisted with repository analysis, implementation, and test preparation. The resulting changes and tests were reviewed and verified against a CPython debug build.


<!-- gh-issue-number: gh-154174 -->
* Issue: gh-154174
<!-- /gh-issue-number -->
