### PR TITLE
gh-154317: Add test for parse_qsl/parse_qs strict_parsing on malformed fields

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -1527,6 +1527,34 @@ class UrlParseTestCase(unittest.TestCase):
             self.assertEqual(cm.filename, __file__)
             self.assertRaises(ValueError, urllib.parse.parse_qsl, x, separator=1)
 
+    def test_parse_qsl_strict_parsing(self):
+        self.assertRaises(ValueError, urllib.parse.parse_qsl,
+                          'a=1&b&c=3', strict_parsing=True)
+        self.assertRaises(ValueError, urllib.parse.parse_qsl,
+                          b'a=1&b', strict_parsing=True)
+        self.assertRaises(ValueError, urllib.parse.parse_qs,
+                          'a=1&b&c=3', strict_parsing=True)
+        self.assertRaises(ValueError, urllib.parse.parse_qs,
+                          b'a=1&b', strict_parsing=True)
+        self.assertRaises(ValueError, urllib.parse.parse_qsl,
+                          'a=1&&c=3', strict_parsing=True)
+        self.assertRaises(ValueError, urllib.parse.parse_qsl,
+                          b'a=1&', strict_parsing=True)
+        self.assertRaises(ValueError, urllib.parse.parse_qs,
+                          'a=1&&c=3', strict_parsing=True)
+        self.assertRaises(ValueError, urllib.parse.parse_qs,
+                          b'a=1&', strict_parsing=True)
+        self.assertEqual(urllib.parse.parse_qsl('a=1&c=3', strict_parsing=True),
+                         [('a', '1'), ('c', '3')])
+        self.assertEqual(urllib.parse.parse_qs('a=1&c=3', strict_parsing=True),
+                         {'a': ['1'], 'c': ['3']})
+        self.assertEqual(urllib.parse.parse_qsl('=abc', strict_parsing=True),
+                         [('', 'abc')])
+        self.assertEqual(
+            urllib.parse.parse_qsl(
+                'abc=', strict_parsing=True, keep_blank_values=True),
+            [('abc', '')])
+
     def test_parse_qsl_errors(self):
         self.assertRaises(TypeError, urllib.parse.parse_qsl, list(b'a=b'))
         self.assertRaises(TypeError, urllib.parse.parse_qsl, iter(b'a=b'))


### PR DESCRIPTION
Add test coverage for the `strict_parsing=True` branch of `urllib.parse.parse_qsl` and `parse_qs`.

The existing `strict_parsing` tests only pass empty inputs (`""`, `b""`), which return early before the parsing loop, so the `ValueError` branch for a malformed field — one without `=` — was never exercised. This adds a test that:

- a field without `=` raises `ValueError` under `strict_parsing` for both `str` (`'a=1&b&c=3'`) and `bytes` (`b'a=1&b'`) inputs, and
- well-formed input still parses correctly under `strict_parsing`.

Test-only change; no behavior change. The asserted behavior is identical across CPython 3.9–3.14.


<!-- gh-issue-number: gh-154317 -->
* Issue: gh-154317
<!-- /gh-issue-number -->
