### PR TITLE
gh-154199: Fix find_msvcrt() on builds with a truncated sys.version

### DIFF
--- a/Lib/ctypes/util.py
+++ b/Lib/ctypes/util.py
@@ -17,16 +17,21 @@ if os.name == "nt":
     def _get_build_version():
         """Return the version of MSVC that was used to build Python.
 
-        For Python 2.3 and up, the version number is included in
-        sys.version.  For earlier versions, assume the compiler is MSVC 6.
+        The version number is included in sys.version.  Return None if it
+        cannot be found there, for example because Python was not built
+        with MSVC or because sys.version has been truncated.
         """
         # This function was copied from Lib/distutils/msvccompiler.py
         prefix = "MSC v."
         i = sys.version.find(prefix)
         if i == -1:
-            return 6
+            # We don't know what version of the compiler this is.
+            return None
         i = i + len(prefix)
-        s, rest = sys.version[i:].split(" ", 1)
+        s, sep, _ = sys.version[i:].partition(" ")
+        if not sep:
+            # sys.version was truncated inside the version number.
+            return None
         majorVersion = int(s[:-2]) - 6
         if majorVersion >= 13:
             majorVersion += 1

--- a/Lib/test/test_ctypes/test_find.py
+++ b/Lib/test/test_ctypes/test_find.py
@@ -1,3 +1,4 @@
+import ctypes.util
 import os.path
 import sys
 import test.support
@@ -219,6 +220,57 @@ class FindLibraryEmscripten(unittest.TestCase):
                 self.assertIsNone(result)
                 result = find_library('other')
                 self.assertIsNone(result)
+
+
+@unittest.skipUnless(os.name == 'nt', 'Test only valid for Windows')
+class FindLibraryWindows(unittest.TestCase):
+    # gh-154199: Python/getversion.c formats the compiler identification with
+    # "%.80s", so a long banner (as emitted by clang-cl builds) can be cut off
+    # before the "MSC v." marker.  The build version must then be reported as
+    # unknown instead of defaulting to MSVC 6, which would make find_msvcrt()
+    # hand out msvcrt.dll -- a CRT that does not share its errno with the one
+    # the _ctypes extension module was linked against.
+    TRUNCATED_CLANG_VERSION = (
+        '3.16.0a0 free-threading build (heads/main:0123456789ab, '
+        'Jan  1 2026, 00:00:00) [Clang 22.1.8 '
+        '(https://github.com/llvm/llvm-project ca7933e47d3a3451d81e72ac174d'
+    )
+    # Truncated just after the marker, so the version digits are missing.
+    TRUNCATED_IN_MARKER_VERSION = (
+        '3.16.0a0 (main:0123456789ab, Jan  1 2026, 00:00:00) '
+        '[Clang 22.1.8 (https://example.invalid) 64 bit (AMD64) with MSC v.1944'
+    )
+    MSVC_VERSION = (
+        '3.16.0a0 (main:0123456789ab, Jan  1 2026, 00:00:00) '
+        '[MSC v.1944 64 bit (AMD64)]'
+    )
+
+    @thread_unsafe('patches sys.version')
+    def test_get_build_version_truncated(self):
+        with unittest.mock.patch.object(sys, 'version',
+                                        self.TRUNCATED_CLANG_VERSION):
+            self.assertIsNone(ctypes.util._get_build_version())
+
+    @thread_unsafe('patches sys.version')
+    def test_get_build_version_truncated_in_marker(self):
+        with unittest.mock.patch.object(sys, 'version',
+                                        self.TRUNCATED_IN_MARKER_VERSION):
+            self.assertIsNone(ctypes.util._get_build_version())
+
+    @thread_unsafe('patches sys.version')
+    def test_find_msvcrt_truncated(self):
+        with unittest.mock.patch.object(sys, 'version',
+                                        self.TRUNCATED_CLANG_VERSION):
+            self.assertIsNone(ctypes.util.find_msvcrt())
+            self.assertIsNone(find_library('c'))
+            self.assertIsNone(find_library('m'))
+
+    @thread_unsafe('patches sys.version')
+    def test_get_build_version_msvc(self):
+        with unittest.mock.patch.object(sys, 'version', self.MSVC_VERSION):
+            self.assertEqual(ctypes.util._get_build_version(), 14.4)
+            # Recent versions of the CRT are not directly loadable.
+            self.assertIsNone(ctypes.util.find_msvcrt())
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Library/2026-07-19-21-40-00.gh-issue-154199.Kq3mVt.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-19-21-40-00.gh-issue-154199.Kq3mVt.rst
@@ -1,0 +1,8 @@
+Fix :func:`ctypes.util.find_msvcrt` on Windows builds whose :data:`sys.version`
+does not contain the ``MSC v.`` marker, which happens on ``clang-cl`` builds
+because the compiler banner is truncated to 80 characters. Instead of assuming
+MSVC 6 and returning ``msvcrt.dll`` -- a C runtime that does not share its
+``errno`` with the one the :mod:`!_ctypes` extension module is linked against
+-- the compiler version is now reported as unknown, so
+:func:`!ctypes.util.find_msvcrt` and ``find_library('c')`` return ``None``,
+matching builds made with modern versions of MSVC.


### PR DESCRIPTION
Fixes #154199

`Python/getversion.c` formats the compiler identification with `"%.80s"`. The banner
that `PC/pyconfig.h` emits for clang-cl builds is
`"[Clang " __clang_version__ "] 64 bit (AMD64) with MSC v.<n> CRT]"`, and official LLVM
Windows binaries have an 86-character `__clang_version__` (version + repo URL + full
commit hash), so the tail carrying the `"MSC v."` marker is always cut off.

`ctypes.util._get_build_version()` looks for that marker and, not finding it, fell back
to `return 6` — "assume the compiler is MSVC 6". `find_msvcrt()` then maps version 6 to
`msvcrt.dll` and `find_library('c')` returns it. That CRT does not share its `errno` with
the ucrt that `_ctypes` is linked against, so `ctypes.get_errno()` silently returns stale
values after a failing call. No exception is raised — the caller just gets wrong data.

This reports the build version as unknown instead, so `find_msvcrt()` and
`find_library('c')` return `None` exactly as they already do on modern MSVC builds
(where `_get_build_version()` returns 14.x and the "CRT is no longer directly loadable"
branch from bpo-23606 applies). `find_msvcrt()` already had a `version is None` guard, so
this simply routes truncated banners into the existing safe path.

While fixing that I found a second manifestation of the same truncation: when the cut
lands *inside* the version digits, the marker is present but the number is not, and
`s, rest = sys.version[i:].split(" ", 1)` raises
`ValueError: not enough values to unpack` out of `find_library('c')` — worse than a wrong
return value. `partition()` handles both cases. Happy to split that into its own PR if
you would rather keep this one to the single change.

The documented contract is unchanged: `Doc/library/ctypes.rst` already says `find_msvcrt()`
returns `None` "if the name of the library cannot be determined", and that `find_library("c")`
fails on Windows. Only the undocumented MSVC-6 fallback is removed.

## Testing

Added `FindLibraryWindows` to `Lib/test/test_ctypes/test_find.py`. It patches `sys.version`
with `unittest.mock`, so it exercises the fix on any Windows build — a clang-cl build is not
needed to run it. It covers a truncated clang banner, a truncation inside the marker, and a
real MSVC banner (asserting 14.4 / `None`, so the MSVC path is pinned against regression).

On a local clang-cl free-threaded build, `python -m test test_ctypes`:

- before: `run=674 failures=1` (`test_errno.Test.test_open`: `AssertionError: 0 != 2`) — FAILURE
- after: `run=678 skipped=40` — SUCCESS

`test_open` now skips with `'Unable to find C library'`, identical to an MSVC build. Three
tests move from run to skipped (`test_errno.test_open`, `test_loading.test_find`,
`test_callbacks.test_issue_8959_a`); all three already skip on MSVC builds, so this converges
clang-cl onto the reference platform rather than reducing coverage. Verified no MSVC
regression by mocking real banners: `MSC v.1944` -> 14.4, `MSC v.1600` -> `msvcr100.dll`,
`MSC v.1200` -> `msvcrt.dll` (a genuine MSVC 6 build is unaffected).

The root cause is arguably the `"%.80s"` precision in `Python/getversion.c` — `sys.version`
also ends mid-hash without its closing bracket on these builds, and it broke
`sysconfig.get_platform()` the same way in gh-145410. I have not touched it here since that
would change `sys.version` content for every consumer, but it may be worth a separate issue.
