### PR TITLE
gh-154218: Fix test_posix_fallocate on file systems that do not support posix_fallocate()

### DIFF
--- a/Lib/test/test_os/test_posix.py
+++ b/Lib/test/test_os/test_posix.py
@@ -415,8 +415,10 @@ class PosixTester(unittest.TestCase):
             if inst.errno == errno.EINVAL and sys.platform.startswith(
                 ('sunos', 'freebsd', 'openbsd', 'gnukfreebsd')):
                 raise unittest.SkipTest("test may fail on ZFS filesystems")
-            elif inst.errno == errno.EOPNOTSUPP and sys.platform.startswith("netbsd"):
-                raise unittest.SkipTest("test may fail on FFS filesystems")
+            elif inst.errno == errno.EOPNOTSUPP:
+                # ZFS on FreeBSD, FFS on NetBSD, etc.
+                raise unittest.SkipTest(
+                    "the file system does not support posix_fallocate()")
             else:
                 raise
         finally:


### PR DESCRIPTION
Skip on EOPNOTSUPP regardless of platform: it always means that the file system does not support `posix_fallocate()` (ZFS on FreeBSD, FFS on NetBSD). Tested on FreeBSD 15.1 with a ZFS root (skips) and Linux with ext4 (runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-154218 -->
* Issue: gh-154218
<!-- /gh-issue-number -->
