### PR TITLE
gh-145030: Fix asyncio write pipe transport for named FIFOs on macOS

### DIFF
--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -658,18 +658,19 @@ class _UnixWritePipeTransport(transports._FlowControlMixin,
         # On AIX, the reader trick (to be notified when the read end of the
         # socket is closed) only works for sockets. On other platforms it
         # works for pipes and sockets. (Exception: OS X 10.4?  Issue #19294.)
-        # On Apple platforms (macOS/iOS/tvOS/watchOS), the trick misfires for
-        # named FIFOs (but not for pipes created with os.pipe(), which have
-        # st_nlink == 0): the write end polls as readable whenever unread
-        # data sits in the FIFO, and no event is delivered when the read end
-        # is closed, so it can only ever report a false disconnection
-        # (gh-145030).
-        is_apple = sys.platform in {"darwin", "ios", "tvos", "watchos"}
-        is_named_fifo_on_apple = (is_apple and is_fifo
-                                  and pipe_stat.st_nlink > 0)
+        # On macOS, the trick misfires for named FIFOs (but not for pipes
+        # created with os.pipe(), which have st_nlink == 0): the write end
+        # polls as readable whenever unread data sits in the FIFO, and no
+        # event is delivered when the read end is closed, so it can only
+        # ever report a false disconnection (gh-145030). The same xnu
+        # behaviour applies on iOS/tvOS/watchOS (sys.platform is not
+        # "darwin" there).
+        is_named_fifo_on_macos = (
+            sys.platform in {"darwin", "ios", "tvos", "watchos"}
+            and is_fifo and pipe_stat.st_nlink > 0)
         if is_socket or (is_fifo
                          and not sys.platform.startswith("aix")
-                         and not is_named_fifo_on_apple):
+                         and not is_named_fifo_on_macos):
             # only start reading when connection_made() has been called
             self._loop.call_soon(self._loop._add_reader,
                                  self._fileno, self._read_ready)

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -658,16 +658,18 @@ class _UnixWritePipeTransport(transports._FlowControlMixin,
         # On AIX, the reader trick (to be notified when the read end of the
         # socket is closed) only works for sockets. On other platforms it
         # works for pipes and sockets. (Exception: OS X 10.4?  Issue #19294.)
-        # On macOS, the trick misfires for named FIFOs (but not for pipes
-        # created with os.pipe(), which have st_nlink == 0): the write end
-        # polls as readable whenever unread data sits in the FIFO, and no
-        # event is delivered when the read end is closed, so it can only
-        # ever report a false disconnection (gh-145030).
-        is_named_fifo_on_macos = (sys.platform == "darwin"
-                                  and is_fifo and pipe_stat.st_nlink > 0)
+        # On Apple platforms (macOS/iOS/tvOS/watchOS), the trick misfires for
+        # named FIFOs (but not for pipes created with os.pipe(), which have
+        # st_nlink == 0): the write end polls as readable whenever unread
+        # data sits in the FIFO, and no event is delivered when the read end
+        # is closed, so it can only ever report a false disconnection
+        # (gh-145030).
+        is_apple = sys.platform in {"darwin", "ios", "tvos", "watchos"}
+        is_named_fifo_on_apple = (is_apple and is_fifo
+                                  and pipe_stat.st_nlink > 0)
         if is_socket or (is_fifo
                          and not sys.platform.startswith("aix")
-                         and not is_named_fifo_on_macos):
+                         and not is_named_fifo_on_apple):
             # only start reading when connection_made() has been called
             self._loop.call_soon(self._loop._add_reader,
                                  self._fileno, self._read_ready)

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -665,12 +665,12 @@ class _UnixWritePipeTransport(transports._FlowControlMixin,
         # ever report a false disconnection (gh-145030). The same xnu
         # behaviour applies on iOS/tvOS/watchOS (sys.platform is not
         # "darwin" there).
-        is_named_fifo_on_macos = (
+        is_named_fifo_on_apple = (
             sys.platform in {"darwin", "ios", "tvos", "watchos"}
             and is_fifo and pipe_stat.st_nlink > 0)
         if is_socket or (is_fifo
                          and not sys.platform.startswith("aix")
-                         and not is_named_fifo_on_macos):
+                         and not is_named_fifo_on_apple):
             # only start reading when connection_made() has been called
             self._loop.call_soon(self._loop._add_reader,
                                  self._fileno, self._read_ready)

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -640,7 +640,8 @@ class _UnixWritePipeTransport(transports._FlowControlMixin,
         self._conn_lost = 0
         self._closing = False  # Set when close() or write_eof() called.
 
-        mode = os.fstat(self._fileno).st_mode
+        pipe_stat = os.fstat(self._fileno)
+        mode = pipe_stat.st_mode
         is_char = stat.S_ISCHR(mode)
         is_fifo = stat.S_ISFIFO(mode)
         is_socket = stat.S_ISSOCK(mode)
@@ -657,7 +658,16 @@ class _UnixWritePipeTransport(transports._FlowControlMixin,
         # On AIX, the reader trick (to be notified when the read end of the
         # socket is closed) only works for sockets. On other platforms it
         # works for pipes and sockets. (Exception: OS X 10.4?  Issue #19294.)
-        if is_socket or (is_fifo and not sys.platform.startswith("aix")):
+        # On macOS, the trick misfires for named FIFOs (but not for pipes
+        # created with os.pipe(), which have st_nlink == 0): the write end
+        # polls as readable whenever unread data sits in the FIFO, and no
+        # event is delivered when the read end is closed, so it can only
+        # ever report a false disconnection (gh-145030).
+        is_named_fifo_on_macos = (sys.platform == "darwin"
+                                  and is_fifo and pipe_stat.st_nlink > 0)
+        if is_socket or (is_fifo
+                         and not sys.platform.startswith("aix")
+                         and not is_named_fifo_on_macos):
             # only start reading when connection_made() has been called
             self._loop.call_soon(self._loop._add_reader,
                                  self._fileno, self._read_ready)

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1729,10 +1729,10 @@ class EventLoopTestsMixin:
                          "Don't support pipes for Windows")
     @unittest.skipUnless(hasattr(os, 'mkfifo'), 'requires os.mkfifo()')
     def test_write_named_fifo_unread_data(self):
-        # gh-145030: on Apple platforms, the write end of a named FIFO
-        # polls as readable while unread data sits in the FIFO, which
-        # made the transport misinterpret the event as the reader hanging
-        # up and close itself.
+        # gh-145030: on macOS, the write end of a named FIFO polls as
+        # readable while unread data sits in the FIFO, which made the
+        # transport misinterpret the event as the reader hanging up
+        # and close itself.
         path = os_helper.TESTFN
         os.mkfifo(path)
         self.addCleanup(os_helper.unlink, path)

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1727,6 +1727,47 @@ class EventLoopTestsMixin:
 
     @unittest.skipUnless(sys.platform != 'win32',
                          "Don't support pipes for Windows")
+    @unittest.skipUnless(hasattr(os, 'mkfifo'), 'requires os.mkfifo()')
+    def test_write_named_fifo_unread_data(self):
+        # gh-145030: on macOS, the write end of a named FIFO polls as
+        # readable while unread data sits in the FIFO, which made the
+        # transport misinterpret the event as the reader hanging up
+        # and close itself.
+        path = os_helper.TESTFN
+        os.mkfifo(path)
+        self.addCleanup(os_helper.unlink, path)
+        rfd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+        self.addCleanup(os.close, rfd)
+        wfd = os.open(path, os.O_WRONLY | os.O_NONBLOCK)
+        pipeobj = io.open(wfd, 'wb', 1024)
+
+        proto = MyWritePipeProto(loop=self.loop)
+        connect = self.loop.connect_write_pipe(lambda: proto, pipeobj)
+        transport, p = self.loop.run_until_complete(connect)
+        self.assertIs(p, proto)
+        self.assertEqual('CONNECTED', proto.state)
+
+        transport.write(b'1')
+        # Iterate the event loop while the data stays unread in the FIFO;
+        # the transport must not detect a false disconnection.
+        for _ in range(10):
+            test_utils.run_briefly(self.loop)
+        self.assertEqual('CONNECTED', proto.state)
+        self.assertFalse(transport.is_closing())
+        self.assertEqual(b'1', os.read(rfd, 1024))
+
+        transport.write(b'2345')
+        for _ in range(10):
+            test_utils.run_briefly(self.loop)
+        self.assertEqual('CONNECTED', proto.state)
+        self.assertEqual(b'2345', os.read(rfd, 1024))
+
+        transport.close()
+        self.loop.run_until_complete(proto.done)
+        self.assertEqual('CLOSED', proto.state)
+
+    @unittest.skipUnless(sys.platform != 'win32',
+                         "Don't support pipes for Windows")
     def test_write_pipe_disconnect_on_close(self):
         rsock, wsock = socket.socketpair()
         rsock.setblocking(False)

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1735,6 +1735,7 @@ class EventLoopTestsMixin:
         # and close itself.
         path = os_helper.TESTFN
         os.mkfifo(path)
+        self.assertNotEqual(os.stat(path).st_nlink, 0)
         self.addCleanup(os_helper.unlink, path)
         rfd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
         self.addCleanup(os.close, rfd)

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1729,10 +1729,10 @@ class EventLoopTestsMixin:
                          "Don't support pipes for Windows")
     @unittest.skipUnless(hasattr(os, 'mkfifo'), 'requires os.mkfifo()')
     def test_write_named_fifo_unread_data(self):
-        # gh-145030: on macOS, the write end of a named FIFO polls as
-        # readable while unread data sits in the FIFO, which made the
-        # transport misinterpret the event as the reader hanging up
-        # and close itself.
+        # gh-145030: on Apple platforms, the write end of a named FIFO
+        # polls as readable while unread data sits in the FIFO, which
+        # made the transport misinterpret the event as the reader hanging
+        # up and close itself.
         path = os_helper.TESTFN
         os.mkfifo(path)
         self.addCleanup(os_helper.unlink, path)

--- a/Misc/NEWS.d/next/Library/2026-07-20-12-40-00.gh-issue-145030.TFJm6k.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-20-12-40-00.gh-issue-145030.TFJm6k.rst
@@ -1,0 +1,3 @@
+Fix :mod:`asyncio` write pipe transports for named FIFOs on macOS.  Unread
+data sitting in the FIFO made the transport misinterpret a poll event as
+the reader disconnecting, wrongly closing the transport.

--- a/Misc/NEWS.d/next/Library/2026-07-20-12-40-00.gh-issue-145030.TFJm6k.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-20-12-40-00.gh-issue-145030.TFJm6k.rst
@@ -1,3 +1,3 @@
-Fix :mod:`asyncio` write pipe transports for named FIFOs on Apple platforms.
-Unread data sitting in the FIFO made the transport misinterpret a poll
-event as the reader disconnecting, wrongly closing the transport.
+Fix :mod:`asyncio` write pipe transports for named FIFOs on macOS.  Unread
+data sitting in the FIFO made the transport misinterpret a poll event as
+the reader disconnecting, wrongly closing the transport.

--- a/Misc/NEWS.d/next/Library/2026-07-20-12-40-00.gh-issue-145030.TFJm6k.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-20-12-40-00.gh-issue-145030.TFJm6k.rst
@@ -1,3 +1,3 @@
-Fix :mod:`asyncio` write pipe transports for named FIFOs on macOS.  Unread
-data sitting in the FIFO made the transport misinterpret a poll event as
-the reader disconnecting, wrongly closing the transport.
+Fix :mod:`asyncio` write pipe transports for named FIFOs on Apple platforms.
+Unread data sitting in the FIFO made the transport misinterpret a poll
+event as the reader disconnecting, wrongly closing the transport.


### PR DESCRIPTION
Fixes #145030

On macOS, the write end of a named FIFO polls as readable whenever unread data sits in the FIFO (the kernel does not check the fd's access mode,unlike Linux), so the "reader trick" _UnixWritePipeTransport uses to detect
the peer closing misfired and closed the transport, making the next drain() raise ConnectionResetError. The trick also cannot detect a genuine hangup for named FIFOs on macOS: closing the read end produces no event, and
kqueue's EV_EOF tracks writers rather than readers.

Skip registering the reader for named FIFOs on macOS, matching the existing AIX carve-out; a closed peer is still detected on the next write via EPIPE. Anonymous os.pipe() pipes are unaffected (st_nlink == 0) and keep the
current behaviour. Adds a regression test that keeps unread data in a FIFO while iterating the loop, which fails without the fix on macOS.


<!-- gh-issue-number: gh-145030 -->
* Issue: gh-145030
<!-- /gh-issue-number -->