### PR TITLE
gh-154227: Fix os.posix_openpt() on OpenBSD

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-07-20-14-00-00.gh-issue-154227.openpt.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-20-14-00-00.gh-issue-154227.openpt.rst
@@ -1,0 +1,2 @@
+Fix :func:`os.posix_openpt` on OpenBSD, where it rejected the
+:data:`~os.O_CLOEXEC` flag.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -9186,7 +9186,9 @@ os_posix_openpt_impl(PyObject *module, int oflag)
 {
     int fd;
 
-#if defined(O_CLOEXEC)
+    // OpenBSD posix_openpt() rejects any flag other than O_RDWR and
+    // O_NOCTTY; the fd is made non-inheritable below in any case.
+#if defined(O_CLOEXEC) && !defined(__OpenBSD__)
     oflag |= O_CLOEXEC;
 #endif
 


### PR DESCRIPTION
OpenBSD `posix_openpt(3)` rejects any flag other than `O_RDWR` and `O_NOCTTY`, so `os.posix_openpt()` always failed with EINVAL. Skip `O_CLOEXEC` on OpenBSD; the fd is made non-inheritable immediately afterwards in any case. Verified on OpenBSD 7.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-154227 -->
* Issue: gh-154227
<!-- /gh-issue-number -->
