### PR TITLE
gh-154226: Fix test_posix_pty_functions on Solaris

### DIFF
--- a/Lib/test/test_os/test_os.py
+++ b/Lib/test/test_os/test_os.py
@@ -4727,6 +4727,13 @@ class PseudoterminalTests(unittest.TestCase):
         son_path = os.ptsname(mother_fd)
         son_fd = os.open(son_path, os.O_RDWR|os.O_NOCTTY)
         self.addCleanup(os.close, son_fd)
+        if sys.platform.startswith('sunos'):
+            # The slave is not a terminal until these STREAMS modules
+            # are pushed onto it.
+            import fcntl
+            I_PUSH = 0x5302
+            fcntl.ioctl(son_fd, I_PUSH, b'ptem\0')
+            fcntl.ioctl(son_fd, I_PUSH, b'ldterm\0')
         self.assertEqual(os.ptsname(mother_fd), os.ttyname(son_fd))
 
     @warnings_helper.ignore_fork_in_thread_deprecation_warnings()

--- a/Misc/NEWS.d/next/Tests/2026-07-20-14-05-00.gh-issue-154226.ptytest.rst
+++ b/Misc/NEWS.d/next/Tests/2026-07-20-14-05-00.gh-issue-154226.ptytest.rst
@@ -1,0 +1,2 @@
+Fix ``test_posix_pty_functions`` in :mod:`!test.test_os` on Solaris
+and illumos.

--- a/Misc/NEWS.d/next/Tests/2026-07-20-14-05-00.gh-issue-154226.ptytest.rst
+++ b/Misc/NEWS.d/next/Tests/2026-07-20-14-05-00.gh-issue-154226.ptytest.rst
@@ -1,2 +1,0 @@
-Fix ``test_posix_pty_functions`` in :mod:`!test.test_os` on Solaris
-and illumos.


### PR DESCRIPTION
On System V-derived systems the pty slave is not a terminal until the `ptem` and `ldterm` STREAMS modules are pushed onto it, so `os.ttyname()` failed with ENOTTY. Push them on `sunos`. Verified on illumos (passes) and Linux (unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-154226 -->
* Issue: gh-154226
<!-- /gh-issue-number -->
