### PR TITLE
Bump `profiling.sampling.cli._SYNC_TIMEOUT_SEC` to fix failures on slow Buildbots

### DIFF
--- a/Lib/profiling/sampling/cli.py
+++ b/Lib/profiling/sampling/cli.py
@@ -87,8 +87,8 @@ Use `python -m profiling.sampling <command> --help` for command-specific help.""
 
 
 # Constants for socket synchronization
-_SYNC_TIMEOUT_SEC = 5.0
-_PROCESS_KILL_TIMEOUT_SEC = 2.0
+_SYNC_TIMEOUT_SEC = 15.0
+_PROCESS_KILL_TIMEOUT_SEC = 5.0
 _READY_MESSAGE = b"ready"
 _RECV_BUFFER_SIZE = 1024
 _BINARY_PROFILE_HEADER_SIZE = 64


### PR DESCRIPTION
See for example, [this run](https://buildbot.python.org/#/builders/2248/builds/45):
```
test_sort (test.test_profiling.test_tracing_profiler.TestCommandLine.test_sort) ... ok
======================================================================
ERROR: test_run_failed_module_live (test.test_profiling.test_sampling_profiler.test_live_collector_ui.TestLiveModeErrors.test_run_failed_module_live)
Test that running a existing module that fails exits with clean error.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/var/lib/buildbot/workers/rise-riscv64-3/3.x.rise-riscv64-3.nogil/build/Lib/profiling/sampling/cli.py", line 302, in _run_with_sync
    _wait_for_ready_signal(sync_sock, process, _SYNC_TIMEOUT_SEC)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/buildbot/workers/rise-riscv64-3/3.x.rise-riscv64-3.nogil/build/Lib/profiling/sampling/cli.py", line 246, in _wait_for_ready_signal
    raise socket.timeout("timed out")
TimeoutError: timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/lib/buildbot/workers/rise-riscv64-3/3.x.rise-riscv64-3.nogil/build/Lib/test/test_profiling/test_sampling_profiler/test_live_collector_ui.py", line 875, in test_run_failed_module_live
    main()
    ~~~~^^
  File "/var/lib/buildbot/workers/rise-riscv64-3/3.x.rise-riscv64-3.nogil/build/Lib/profiling/sampling/cli.py", line 989, in main
    _main()
    ~~~~~^^
  File "/var/lib/buildbot/workers/rise-riscv64-3/3.x.rise-riscv64-3.nogil/build/Lib/profiling/sampling/cli.py", line 1145, in _main
    handler(args)
    ~~~~~~~^^^^^^
  File "/var/lib/buildbot/workers/rise-riscv64-3/3.x.rise-riscv64-3.nogil/build/Lib/profiling/sampling/cli.py", line 1251, in _handle_run
    _handle_live_run(args)
    ~~~~~~~~~~~~~~~~^^^^^^
  File "/var/lib/buildbot/workers/rise-riscv64-3/3.x.rise-riscv64-3.nogil/build/Lib/profiling/sampling/cli.py", line 1365, in _handle_live_run
    sys.exit(f"Error: {e}")
    ~~~~~~~~^^^^^^^^^^^^^^^
SystemExit: Error: Process failed to signal readiness within timeout
```

On this slow Buildbot the child interpreter simply couldn't finish startup and connect within 5 seconds. I propose we bump the socket synchronisation constants to allow a little more leeway for such machines.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
