### PR TITLE
Fix typo "dellocation" in C API Type Object Structures documentation

### DIFF
--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -3051,7 +3051,7 @@ Buffer Object Structures
 
    * Resource cleanup when the counter reaches zero must be done atomically,
      as the final release may race with concurrent releases from other
-     threads and dellocation must only happen once.
+     threads and deallocation must only happen once.
 
    The exporter MUST use the :c:member:`~Py_buffer.internal` field to keep
    track of buffer-specific resources. This field is guaranteed to remain


### PR DESCRIPTION
Fix typo "dellocation" in C API Type Object Structures documentation

## Method

```console
% brew install typos-cli

% typos Doc/c-api/typeobj.rst
error: `dellocation` should be `deallocation`
     ╭▸ Doc/c-api/typeobj.rst:3054:18
     │
3054 │      threads and dellocation must only happen once.
     ╰╴                 ━━━━━━━━━━━

% typos --write-changes Doc/c-api/typeobj.rst
```

## Other Considerations Taken

- [x] Confirm this is not an intentional typo.
- [x] Confirm this is not a duplicate issue/PR.
