### PR TITLE
gh-154258: Fix mmap.resize() crash on NetBSD growing a shared anonymous mapping

### DIFF
--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -907,9 +907,10 @@ class MmapTests(unittest.TestCase):
 
         with mmap.mmap(-1, start_size) as m:
             m[:] = data
-            if sys.platform.startswith(('linux', 'android')):
-                # Can't expand a shared anonymous mapping on Linux.
-                # See https://bugzilla.kernel.org/show_bug.cgi?id=8691
+            if sys.platform.startswith(('linux', 'android', 'netbsd')):
+                # Can't expand a shared anonymous mapping on Linux
+                # (see https://bugzilla.kernel.org/show_bug.cgi?id=8691)
+                # or NetBSD.
                 with self.assertRaises(ValueError):
                     m.resize(new_size)
             else:

--- a/Misc/NEWS.d/next/Library/2026-07-20-18-30-00.gh-issue-154258.mmapresize.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-20-18-30-00.gh-issue-154258.mmapresize.rst
@@ -1,0 +1,3 @@
+Fix a crash in :meth:`mmap.mmap.resize` on NetBSD when growing a shared
+anonymous mapping.  :meth:`!resize` now raises :exc:`ValueError` in this
+case, as it already did on Linux.

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -969,10 +969,13 @@ mmap_mmap_resize_impl(mmap_object *self, Py_ssize_t new_size)
 #ifdef UNIX
         void *newmap;
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__NetBSD__)
+        // Linux mremap() refuses to grow a shared anonymous mapping, and
+        // NetBSD mremap() returns a mapping whose grown region is not backed,
+        // so accessing it crashes.  Reject it here in both cases.
         if (self->fd == -1 && !(self->flags & MAP_PRIVATE) && new_size > self->size) {
             PyErr_Format(PyExc_ValueError,
-                "mmap: can't expand a shared anonymous mapping on Linux");
+                "mmap: can't expand a shared anonymous mapping");
             return NULL;
         }
 #endif


### PR DESCRIPTION
On NetBSD, `mmap.resize()` crashed (SIGSEGV) when growing a shared anonymous mapping, because NetBSD `mremap()` returns a mapping whose grown region is not backed (same behaviour as the Linux kernel bug the code already guards against, https://bugzilla.kernel.org/show_bug.cgi?id=8691). Reject it with `ValueError`, as is already done on Linux.

Verified on NetBSD 10 (crash gone, `resize()` now raises `ValueError`, `test_mmap` passes) and on Linux and FreeBSD (unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-154258 -->
* Issue: gh-154258
<!-- /gh-issue-number -->
