### PR TITLE
gh-154260: Fix test_flush_parameters on DragonFly BSD

### DIFF
--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1175,8 +1175,8 @@ class MmapTests(unittest.TestCase):
             if hasattr(mmap, 'MS_INVALIDATE'):
                 m.flush(PAGESIZE * 2, flags=mmap.MS_INVALIDATE)
             if hasattr(mmap, 'MS_ASYNC') and hasattr(mmap, 'MS_INVALIDATE'):
-                if sys.platform == 'freebsd':
-                    # FreeBSD doesn't support this combination
+                if sys.platform.startswith(('freebsd', 'dragonfly')):
+                    # FreeBSD and DragonFly don't support this combination
                     with self.assertRaises(OSError) as cm:
                         m.flush(0, PAGESIZE, flags=mmap.MS_ASYNC | mmap.MS_INVALIDATE)
                     self.assertEqual(cm.exception.errno, errno.EINVAL)


### PR DESCRIPTION
DragonFly BSD, like FreeBSD, rejects `mmap.flush()` with `MS_ASYNC | MS_INVALIDATE` (EINVAL). The test special-cased this only for `sys.platform == 'freebsd'`, but DragonFly's `sys.platform` is `'dragonfly6'`, so it took the else branch expecting success. Use `sys.platform.startswith(('freebsd', 'dragonfly'))`, which also future-proofs the FreeBSD match against a versioned `sys.platform`.

Verified on DragonFly 6 (now passes), FreeBSD and Linux (unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-154260 -->
* Issue: gh-154260
<!-- /gh-issue-number -->
