### PR TITLE
gh-154272: Skip forkserver tests when the start method is unavailable

### DIFF
--- a/Lib/test/test_concurrent_futures/util.py
+++ b/Lib/test/test_concurrent_futures/util.py
@@ -139,6 +139,8 @@ class ProcessPoolForkserverMixin(ExecutorMixin):
             self.skipTest("require unix system")
         if support.check_sanitizer(thread=True):
             self.skipTest("TSAN doesn't support threads after fork")
+        if "forkserver" not in multiprocessing.get_all_start_methods():
+            self.skipTest("forkserver start method is not available")
         return super().get_context()
 
     def create_event(self):

--- a/Lib/test/test_multiprocessing_forkserver/__init__.py
+++ b/Lib/test/test_multiprocessing_forkserver/__init__.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import os.path
 import sys
 import unittest
@@ -11,6 +12,11 @@ if sys.platform in ("win32", "cygwin"):
 
 if not support.has_fork_support:
     raise unittest.SkipTest("requires working os.fork()")
+
+# The forkserver start method requires passing file descriptors over a Unix
+# socket, which is not available on every platform (e.g. Solaris/illumos).
+if "forkserver" not in multiprocessing.get_all_start_methods():
+    raise unittest.SkipTest("forkserver start method is not available")
 
 def load_tests(*args):
     return support.load_package_tests(os.path.dirname(__file__), *args)


### PR DESCRIPTION
On platforms where `forkserver` is unavailable (`'forkserver' not in multiprocessing.get_all_start_methods()`), some tests error instead of skipping: `concurrent_futures` `ProcessPoolForkserver*` (via `get_context('forkserver')` → `ValueError`), `test_init`'s `test_forkserver`, and `test_multiprocessing_forkserver.test_preload` (direct `get_context` in `setUp`). Guard the forkserver test package in its `__init__.py` and add `get_all_start_methods()` checks to the concurrent_futures mixin and `test_forkserver`.

Related: GH-154271 (makes forkserver available on Solaris/illumos; this is the independent test fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-154272 -->
* Issue: gh-154272
<!-- /gh-issue-number -->
