### PR TITLE
gh-154279: Skip readline completion tests that fail on DragonFly and illumos

### DIFF
--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -5167,8 +5167,9 @@ class PdbTestReadline(unittest.TestCase):
 
         self.assertIn('I love Python', output)
 
-    @unittest.skipIf(sys.platform.startswith('freebsd'),
-                     '\\x08 is not interpreted as backspace on FreeBSD')
+    @unittest.skipIf(sys.platform.startswith(('freebsd', 'dragonfly', 'sunos')),
+                     '\\x08 does not remove the auto-indentation with '
+                     'GNU readline on this platform')
     def test_multiline_auto_indent(self):
         script = textwrap.dedent("""
             import pdb; pdb.Pdb().set_trace()
@@ -5207,8 +5208,9 @@ class PdbTestReadline(unittest.TestCase):
 
         self.assertIn('42', output)
 
-    @unittest.skipIf(sys.platform.startswith('freebsd'),
-                     '\\x08 is not interpreted as backspace on FreeBSD')
+    @unittest.skipIf(sys.platform.startswith(('freebsd', 'dragonfly', 'sunos')),
+                     '\\x08 does not remove the auto-indentation with '
+                     'GNU readline on this platform')
     def test_multiline_indent_completion(self):
         script = textwrap.dedent("""
             import pdb; pdb.Pdb().set_trace()

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -378,10 +378,10 @@ class Completion(unittest.TestCase):
         self.assertIn("main", candidates)
         self.assertIn("temp", candidates)
 
-    @unittest.skipIf(sys.platform.startswith("freebsd"),
+    @unittest.skipIf(sys.platform.startswith(("freebsd", "dragonfly", "sunos")),
                     "Two actual tabs are inserted when there are no matching"
                     " completions in the pseudo-terminal opened by run_pty()"
-                    " on FreeBSD")
+                    " on this platform")
     def test_complete_no_match(self):
         input_ = b"xyzzy\t\t\b\b\b\b\b\b\b.quit\n"
         # Set NO_COLOR to disable coloring for self.PS1.


### PR DESCRIPTION
These readline completion tests are already skipped on FreeBSD (gh-133558), where a backspace does not remove the auto-indentation in the pseudo-terminal opened by `run_pty()`. The same failures occur on DragonFly and illumos, so extend the skips.

NetBSD and OpenBSD are not affected.

<!-- gh-issue-number: gh-154279 -->
* Issue: gh-154279
<!-- /gh-issue-number -->