### PR TITLE
gh-154283: Make threading.get_native_id() unique across processes on DragonFly

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-07-20-21-36-40.gh-issue-154283.Xip7xE.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-20-21-36-40.gh-issue-154283.Xip7xE.rst
@@ -1,0 +1,2 @@
+On DragonFly BSD, :func:`threading.get_native_id` now returns a value that is
+unique across processes, matching the other platforms.

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -399,8 +399,8 @@ PyThread_get_thread_native_id(void)
     lwpid_t native_id;
     native_id = _lwp_self();
 #elif defined(__DragonFly__)
-    lwpid_t native_id;
-    native_id = lwp_gettid();
+    // lwp_gettid() is only unique within a process, so combine it with the pid.
+    unsigned long native_id = (unsigned long)getpid() << 32 | lwp_gettid();
 #elif defined(__sun__) && SIZEOF_LONG >= 8
     unsigned long native_id = (unsigned long)getpid() << 32 | thr_self();
 #endif


### PR DESCRIPTION
On DragonFly BSD `lwp_gettid()` is only unique within a process (the main thread is always LWP 1), so `threading.get_native_id()` returned the same value in every process. Combine it with the process id, like Solaris (gh-137884) already does with `thr_self()`.

<!-- gh-issue-number: gh-154283 -->
* Issue: gh-154283
<!-- /gh-issue-number -->