### PR TITLE
[3.14] gh-154279: Skip readline completion tests that fail on DragonFly and illumos (GH-154280)

### DIFF
--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -5013,8 +5013,9 @@ class PdbTestReadline(unittest.TestCase):
 
         self.assertIn(b'I love Python', output)
 
-    @unittest.skipIf(sys.platform.startswith('freebsd'),
-                     '\\x08 is not interpreted as backspace on FreeBSD')
+    @unittest.skipIf(sys.platform.startswith(('freebsd', 'dragonfly', 'sunos')),
+                     '\\x08 does not remove the auto-indentation with '
+                     'GNU readline on this platform')
     def test_multiline_auto_indent(self):
         script = textwrap.dedent("""
             import pdb; pdb.Pdb().set_trace()
@@ -5053,8 +5054,9 @@ class PdbTestReadline(unittest.TestCase):
 
         self.assertIn(b'42', output)
 
-    @unittest.skipIf(sys.platform.startswith('freebsd'),
-                     '\\x08 is not interpreted as backspace on FreeBSD')
+    @unittest.skipIf(sys.platform.startswith(('freebsd', 'dragonfly', 'sunos')),
+                     '\\x08 does not remove the auto-indentation with '
+                     'GNU readline on this platform')
     def test_multiline_indent_completion(self):
         script = textwrap.dedent("""
             import pdb; pdb.Pdb().set_trace()


### PR DESCRIPTION
Manual backport of GH-154280 to 3.14.

They are already skipped on FreeBSD, where a backspace does not remove the auto-indentation. The same happens on DragonFly and illumos.

The sqlite3 CLI test (`test_complete_no_match`) does not exist on 3.14, so only the `test_pdb` tests are skipped here — which is why the automatic backport could not be applied.

<!-- gh-issue-number: gh-154279 -->
* Issue: gh-154279
<!-- /gh-issue-number -->