### PR TITLE
gh-154289: Fix test_socket.testGetServBy on DragonFly

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1302,7 +1302,8 @@ class GeneralModuleTests(unittest.TestCase):
         # protocol, at least for modern Linuxes.
         if (
             sys.platform.startswith(
-                ('linux', 'android', 'freebsd', 'netbsd', 'gnukfreebsd'))
+                ('linux', 'android', 'freebsd', 'dragonfly', 'netbsd',
+                 'gnukfreebsd'))
             or is_apple
         ):
             # avoid the 'echo' service on this platform, as there is an


### PR DESCRIPTION
DragonFly lists `echo 4/ddp` before `echo 7/tcp` in /etc/services, like FreeBSD, so avoid the `echo` service there too.

<!-- gh-issue-number: gh-154289 -->
* Issue: gh-154289
<!-- /gh-issue-number -->
