### PR TITLE
gh-154291: Fix socket.has_dualstack_ipv6() on DragonFly BSD

### DIFF
--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -900,7 +900,9 @@ def has_dualstack_ipv6():
     try:
         with socket(AF_INET6, SOCK_STREAM) as sock:
             sock.setsockopt(IPPROTO_IPV6, IPV6_V6ONLY, 0)
-            return True
+            # On some platforms (e.g. DragonFly BSD) setting IPV6_V6ONLY to 0
+            # silently has no effect, so check that it was actually cleared.
+            return sock.getsockopt(IPPROTO_IPV6, IPV6_V6ONLY) == 0
     except error:
         return False
 

--- a/Misc/NEWS.d/next/Library/2026-07-20-22-03-44.gh-issue-154291.Mi5HeQ.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-20-22-03-44.gh-issue-154291.Mi5HeQ.rst
@@ -1,0 +1,3 @@
+Fix :func:`socket.has_dualstack_ipv6` to return ``False`` on platforms such as
+DragonFly BSD where setting :data:`~socket.IPV6_V6ONLY` to 0 silently has no
+effect.

--- a/Misc/NEWS.d/next/Library/2026-07-20-22-03-44.gh-issue-154291.Mi5HeQ.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-20-22-03-44.gh-issue-154291.Mi5HeQ.rst
@@ -1,3 +1,3 @@
 Fix :func:`socket.has_dualstack_ipv6` to return ``False`` on platforms such as
-DragonFly BSD where setting :data:`~socket.IPV6_V6ONLY` to 0 silently has no
+DragonFly BSD where setting ``IPV6_V6ONLY`` to 0 silently has no
 effect.


### PR DESCRIPTION
On DragonFly BSD `setsockopt(IPPROTO_IPV6, IPV6_V6ONLY, 0)` succeeds without actually clearing the flag, so `has_dualstack_ipv6()` returned True even though dualstack sockets do not work. Verify with `getsockopt` that `IPV6_V6ONLY` was actually cleared.

<!-- gh-issue-number: gh-154291 -->
* Issue: gh-154291
<!-- /gh-issue-number -->
