### PR TITLE
[3.13] gh-154283: Make threading.get_native_id() unique across processes on DragonFly (GH-154287)

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-07-20-21-36-40.gh-issue-154283.Xip7xE.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-20-21-36-40.gh-issue-154283.Xip7xE.rst
@@ -1,0 +1,2 @@
+On DragonFly BSD, :func:`threading.get_native_id` now returns a value that is
+unique across processes, matching the other platforms.

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -407,8 +407,8 @@ PyThread_get_thread_native_id(void)
     lwpid_t native_id;
     native_id = _lwp_self();
 #elif defined(__DragonFly__)
-    lwpid_t native_id;
-    native_id = lwp_gettid();
+    // lwp_gettid() is only unique within a process, so combine it with the pid.
+    unsigned long native_id = (unsigned long)getpid() << 32 | lwp_gettid();
 #endif
     return (unsigned long) native_id;
 }


### PR DESCRIPTION
Manual backport of GH-154287 to 3.13.

On DragonFly BSD `lwp_gettid()` is only unique within a process (the main thread is always LWP 1), so combine it with the process id, like Solaris.

The `__sun__` branch does not exist on 3.13, which is why the automatic backport could not apply.

<!-- gh-issue-number: gh-154283 -->
* Issue: gh-154283
<!-- /gh-issue-number -->
