### PR TITLE
gh-154303: Skip test_sqlite3 CLI completion tests on OpenBSD

### DIFF
--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -223,6 +223,9 @@ class Completion(unittest.TestCase):
         readline = import_module("readline")
         if readline.backend == "editline":
             raise unittest.SkipTest("libedit readline is not supported")
+        if sys.platform.startswith("openbsd"):
+            # OpenBSD's readline does not honor "completion-query-items 0".
+            raise unittest.SkipTest("OpenBSD readline hangs on completion")
 
     def write_input(self, input_, env=None):
         script = textwrap.dedent("""


### PR DESCRIPTION
OpenBSD's readline does not honor `completion-query-items 0`, so completing many candidates blocks on a "Display all N? (y or n)" prompt that hangs the pseudo-terminal opened by `run_pty()`. Skip the whole `Completion` class on OpenBSD, like the existing libedit skip.

<!-- gh-issue-number: gh-154303 -->
* Issue: gh-154303
<!-- /gh-issue-number -->
