### PR TITLE
gh-154307: Fix TemporaryDirectory cleanup on DragonFly BSD

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -929,7 +929,8 @@ class TemporaryDirectory:
     @classmethod
     def _rmtree(cls, name, ignore_errors=False, repeated=False):
         def onexc(func, path, exc):
-            if isinstance(exc, PermissionError):
+            # On DragonFly BSD, UF_NOUNLINK removal fails with EISDIR, not EPERM.
+            if isinstance(exc, (PermissionError, IsADirectoryError)):
                 if repeated and path == name:
                     if ignore_errors:
                         return

--- a/Misc/NEWS.d/next/Library/2026-07-21-01-13-39.gh-issue-154307.UNFKL4.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-21-01-13-39.gh-issue-154307.UNFKL4.rst
@@ -1,0 +1,3 @@
+Fix :meth:`tempfile.TemporaryDirectory.cleanup` on DragonFly BSD, where removing
+a file with the ``UF_NOUNLINK`` flag failed with ``EISDIR`` instead of
+``EPERM``.


### PR DESCRIPTION
On DragonFly BSD, removing a file or directory with the `UF_NOUNLINK` flag fails with `EISDIR` (`IsADirectoryError`) instead of `EPERM`, so `TemporaryDirectory.cleanup()`'s `onexc` handler did not reset the flags. Handle `IsADirectoryError` the same as `PermissionError`.

<!-- gh-issue-number: gh-154307 -->
* Issue: gh-154307
<!-- /gh-issue-number -->
