### PR TITLE
gh-154308: Clear file flags in os_helper.rmtree()

### DIFF
--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -467,12 +467,23 @@ else:
 
         def _rmtree_inner(path):
             from test.support import _force_run
+            # Clear file flags (e.g. UF_IMMUTABLE, UF_NOUNLINK on BSD).
+            if hasattr(os, 'chflags'):
+                try:
+                    os.chflags(path, 0)
+                except OSError:
+                    pass
             for name in _force_run(path, os.listdir, path):
                 fullname = os.path.join(path, name)
                 try:
                     mode = os.lstat(fullname).st_mode
                 except OSError:
                     mode = 0
+                if hasattr(os, 'lchflags'):
+                    try:
+                        os.lchflags(fullname, 0)
+                    except OSError:
+                        pass
                 if stat.S_ISDIR(mode):
                     _rmtree_inner(fullname)
                     _force_run(path, os.rmdir, fullname)


### PR DESCRIPTION
On BSD a test may leave files/directories with flags such as `UF_IMMUTABLE` or `UF_NOUNLINK` set, preventing removal. `os_helper.rmtree()` now clears the flags with `os.chflags()`/`os.lchflags()` before removing, so cleaning up a temporary directory does not fail. Surfaced as a regrtest worker crash on DragonFly (gh-154307).

<!-- gh-issue-number: gh-154308 -->
* Issue: gh-154308
<!-- /gh-issue-number -->
