### PR TITLE
gh-154320: Fix swapped __defaults__/__kwdefaults__ in annotationlib docs

### DIFF
--- a/Doc/library/annotationlib.rst
+++ b/Doc/library/annotationlib.rst
@@ -535,9 +535,9 @@ following attributes:
   :attr:`~Format.VALUE_WITH_FAKE_GLOBALS`.
 * A :ref:`code object <code-objects>` ``__code__`` containing the compiled code for the
   annotate function.
-* Optional: A tuple of the function's positional defaults ``__kwdefaults__``, if the
+* Optional: A tuple of the function's positional defaults ``__defaults__``, if the
   function represented by ``__code__`` uses any positional defaults.
-* Optional: A dict of the function's keyword defaults ``__defaults__``, if the function
+* Optional: A dict of the function's keyword defaults ``__kwdefaults__``, if the function
   represented by ``__code__`` uses any keyword defaults.
 * Optional: All other :ref:`function attributes <inspect-types>`.
 


### PR DESCRIPTION
## Description

In `Doc/library/annotationlib.rst`, under **Creating a custom callable annotate function**, the bullet list swapped attribute names:

- said positional defaults are `__kwdefaults__`
- said keyword defaults are `__defaults__`

Correct Python semantics:

- `__defaults__` — tuple of positional defaults
- `__kwdefaults__` — dict of keyword-only defaults

The example class body already used the correct attributes; only the prose was wrong.

## Linked Issue

Closes #154320


<!-- gh-issue-number: gh-154320 -->
* Issue: gh-154320
<!-- /gh-issue-number -->
