### PR TITLE
gh-80678: Document the preferred delimiters of csv.Sniffer

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -322,6 +322,12 @@ The :mod:`!csv` module defines the following classes:
       in particular if it is a single column,
       so there is no delimiter to find.
 
+      If several combinations fit the sample equally well ---
+      for example if both ``','`` and ``';'`` split every row consistently ---
+      the delimiters ``','``, ``'\t'``, ``';'``, ``' '`` and ``':'``
+      are preferred, in this order,
+      no matter how many times each of them occurs.
+
       .. versionchanged:: next
          The dialect is now deduced by trial parsing
          and the results may differ from those of earlier Python versions.

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -260,6 +260,10 @@ class Sniffer:
         beginning, then, after eliminating the combinations which are
         clearly worse than the leader, a several times larger part,
         and so on.
+
+        If several combinations fit the sample equally well, the
+        delimiters listed in the preferred attribute are preferred, in
+        that order, no matter how many times each of them occurs.
         """
         import re
         from collections import defaultdict


### PR DESCRIPTION
The list of preferred delimiters exists since the module was added in 2003 and has never been documented, so it is only discoverable by reading the source. It decides the result whenever several candidates fit the sample equally well, no matter how many times each of them occurs — the case reported in the issue, `a;b;c;d,e;f;g;h`, is still detected as `,`.

Document this in the `Sniffer.sniff()` documentation and docstring. The `preferred` attribute itself stays undocumented.


<!-- gh-issue-number: gh-80678 -->
* Issue: gh-80678
<!-- /gh-issue-number -->
