### PR TITLE
[3.13] gh-154275: Do not crash on deeply nested `__parameters__` in `GenericAlias` (GH-154277)

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -45,11 +45,7 @@ import typing
 import weakref
 import types
 
-from test.support import (
-    captured_stderr, cpython_only, infinite_recursion, requires_docstrings, import_helper,
-    exceeds_recursion_limit, skip_if_huge_c_stack, skip_wasi_stack_overflow,
-    skip_emscripten_stack_overflow,
-)
+from test.support import captured_stderr, cpython_only, infinite_recursion, requires_docstrings, import_helper
 from test.support.testcase import ExtraAssertions
 from test.typinganndata import ann_module695, mod_generics_cache, _typed_dict_helper
 
@@ -4829,17 +4825,6 @@ class GenericTests(BaseTestCase):
         class MM2(collections.abc.MutableMapping, MutableMapping[str, str]):
             pass
         self.assertEqual(MM2.__bases__, (collections.abc.MutableMapping, Generic))
-
-    @cpython_only
-    @skip_if_huge_c_stack()
-    @skip_wasi_stack_overflow()
-    @skip_emscripten_stack_overflow()
-    def test_parameters_deep_recursion(self):
-        x = [0]
-        for _ in range(exceeds_recursion_limit()):
-            x = [x]
-        with self.assertRaisesRegex(RecursionError, "in __parameter__ calculation"):
-            list[x].__parameters__
 
     def test_orig_bases(self):
         T = TypeVar('T')

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -45,7 +45,11 @@ import typing
 import weakref
 import types
 
-from test.support import captured_stderr, cpython_only, infinite_recursion, requires_docstrings, import_helper
+from test.support import (
+    captured_stderr, cpython_only, infinite_recursion, requires_docstrings, import_helper,
+    exceeds_recursion_limit, skip_if_huge_c_stack, skip_wasi_stack_overflow,
+    skip_emscripten_stack_overflow,
+)
 from test.support.testcase import ExtraAssertions
 from test.typinganndata import ann_module695, mod_generics_cache, _typed_dict_helper
 
@@ -4825,6 +4829,17 @@ class GenericTests(BaseTestCase):
         class MM2(collections.abc.MutableMapping, MutableMapping[str, str]):
             pass
         self.assertEqual(MM2.__bases__, (collections.abc.MutableMapping, Generic))
+
+    @cpython_only
+    @skip_if_huge_c_stack()
+    @skip_wasi_stack_overflow()
+    @skip_emscripten_stack_overflow()
+    def test_parameters_deep_recursion(self):
+        x = [0]
+        for _ in range(exceeds_recursion_limit()):
+            x = [x]
+        with self.assertRaisesRegex(RecursionError, "in __parameter__ calculation"):
+            list[x].__parameters__
 
     def test_orig_bases(self):
         T = TypeVar('T')

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-20-20-16-08.gh-issue-154275.l961cA.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-20-20-16-08.gh-issue-154275.l961cA.rst
@@ -1,0 +1,2 @@
+Fix a crash when getting deeply nested ``__parameters__`` from a
+:class:`types.GenericAlias` objects.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -244,11 +244,16 @@ tuple_extend(PyObject **dst, Py_ssize_t dstindex,
 PyObject *
 _Py_make_parameters(PyObject *args)
 {
+    if (Py_EnterRecursiveCall(" in __parameter__ calculation")) {
+        return NULL;
+    }
+
     Py_ssize_t nargs = PyTuple_GET_SIZE(args);
     Py_ssize_t len = nargs;
     PyObject *parameters = PyTuple_New(len);
-    if (parameters == NULL)
-        return NULL;
+    if (parameters == NULL) {
+        goto cleanup;
+    }
     Py_ssize_t iparam = 0;
     for (Py_ssize_t iarg = 0; iarg < nargs; iarg++) {
         PyObject *t = PyTuple_GET_ITEM(args, iarg);
@@ -258,8 +263,7 @@ _Py_make_parameters(PyObject *args)
         }
         int rc = PyObject_HasAttrWithError(t, &_Py_ID(__typing_subst__));
         if (rc < 0) {
-            Py_DECREF(parameters);
-            return NULL;
+            goto error;
         }
         if (rc) {
             iparam += tuple_add(parameters, iparam, t);
@@ -268,8 +272,7 @@ _Py_make_parameters(PyObject *args)
             PyObject *subparams;
             if (PyObject_GetOptionalAttr(t, &_Py_ID(__parameters__),
                                      &subparams) < 0) {
-                Py_DECREF(parameters);
-                return NULL;
+                goto error;
             }
             if (subparams && PyTuple_Check(subparams)) {
                 Py_ssize_t len2 = PyTuple_GET_SIZE(subparams);
@@ -278,7 +281,7 @@ _Py_make_parameters(PyObject *args)
                     len += needed;
                     if (_PyTuple_Resize(&parameters, len) < 0) {
                         Py_DECREF(subparams);
-                        return NULL;
+                        goto cleanup;
                     }
                 }
                 for (Py_ssize_t j = 0; j < len2; j++) {
@@ -291,11 +294,16 @@ _Py_make_parameters(PyObject *args)
     }
     if (iparam < len) {
         if (_PyTuple_Resize(&parameters, iparam) < 0) {
-            Py_XDECREF(parameters);
-            return NULL;
+            goto error;
         }
     }
     return parameters;
+
+error:
+    Py_XDECREF(parameters);
+cleanup:
+    Py_LeaveRecursiveCall();
+    return NULL;
 }
 
 /* If obj is a generic alias, substitute type variables params

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -297,6 +297,7 @@ _Py_make_parameters(PyObject *args)
             goto error;
         }
     }
+    Py_LeaveRecursiveCall();
     return parameters;
 
 error:


### PR DESCRIPTION
(cherry picked from commit 1034e07b7d55642c3a46252e6b0a631c2df588d2)


<!-- gh-issue-number: gh-154275 -->
* Issue: gh-154275
<!-- /gh-issue-number -->
