### PR TITLE
gh-154335: Allow disabling terminal colors in Tachyon's `pstats_collector` module

### DIFF
--- a/Lib/profiling/sampling/pstats_collector.py
+++ b/Lib/profiling/sampling/pstats_collector.py
@@ -1,11 +1,12 @@
 import collections
 import marshal
 import pstats
-lazy from _colorize import ANSIColors
+from _colorize import get_colors
 
 from .collector import Collector, extract_lineno
 from .constants import MICROSECONDS_PER_SECOND, PROFILING_MODE_CPU
 
+ANSIColors = get_colors()
 
 class PstatsCollector(Collector):
     aggregating = True

--- a/Lib/profiling/sampling/pstats_collector.py
+++ b/Lib/profiling/sampling/pstats_collector.py
@@ -1,12 +1,10 @@
 import collections
 import marshal
 import pstats
-from _colorize import get_colors
+lazy from _colorize import get_colors
 
 from .collector import Collector, extract_lineno
 from .constants import MICROSECONDS_PER_SECOND, PROFILING_MODE_CPU
-
-ANSIColors = get_colors()
 
 class PstatsCollector(Collector):
     aggregating = True
@@ -179,6 +177,8 @@ class PstatsCollector(Collector):
         }
 
         # Print header with colors and proper alignment
+        ANSIColors = get_colors()
+
         print(f"{ANSIColors.BOLD_BLUE}Profile Stats:{ANSIColors.RESET}")
 
         header_nsamples = f"{ANSIColors.BOLD_BLUE}{'nsamples':>{col_widths['nsamples']}}{ANSIColors.RESET}"
@@ -270,6 +270,8 @@ class PstatsCollector(Collector):
 
     def _print_summary(self, stats_list, total_samples):
         """Print summary of interesting functions."""
+        ANSIColors = get_colors()
+
         print(
             f"\n{ANSIColors.BOLD_BLUE}Summary of Interesting Functions:{ANSIColors.RESET}"
         )

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -6,10 +6,11 @@ import sys
 import sysconfig
 import time
 from collections import deque
-lazy from _colorize import ANSIColors
+from _colorize import get_colors
 
 from .binary_collector import BinaryCollector
 
+ANSIColors = get_colors()
 
 @contextlib.contextmanager
 def _pause_threads(unwinder, blocking):

--- a/Lib/profiling/sampling/sample.py
+++ b/Lib/profiling/sampling/sample.py
@@ -6,11 +6,9 @@ import sys
 import sysconfig
 import time
 from collections import deque
-from _colorize import get_colors
+lazy from _colorize import get_colors
 
 from .binary_collector import BinaryCollector
-
-ANSIColors = get_colors()
 
 @contextlib.contextmanager
 def _pause_threads(unwinder, blocking):
@@ -273,6 +271,8 @@ class SampleProfiler:
         )  # Max time = Min Hz
 
         # Build cache stats string if stats collection is enabled
+        ANSIColors = get_colors()
+
         cache_stats_str = ""
         if self.collect_stats:
             try:
@@ -305,6 +305,8 @@ class SampleProfiler:
             stats = self.unwinder.get_stats()
         except RuntimeError:
             return  # Stats not enabled
+
+        ANSIColors = get_colors()
 
         print(f"\n{ANSIColors.BOLD_BLUE}{'='*50}{ANSIColors.RESET}")
         print(f"{ANSIColors.BOLD_BLUE}Unwinder Statistics:{ANSIColors.RESET}")
@@ -399,6 +401,8 @@ class SampleProfiler:
             stats = collector.get_stats()
         except (ValueError, RuntimeError):
             return  # Collector closed or stats unavailable
+
+        ANSIColors = get_colors()
 
         print(f"  {ANSIColors.CYAN}Binary Encoding:{ANSIColors.RESET}")
 

--- a/Lib/test/test_profiling/test_sampling_profiler/test_profiler.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_profiler.py
@@ -751,6 +751,7 @@ class TestPrintSampledStats(unittest.TestCase):
                 and not "calls" in line  # Skip summary lines
                 and not "total time" in line  # Skip summary lines
                 and not "cumulative time" in line
+                and not "filename:lineno(function)" in line  # Skip header line
             ):  # Skip summary lines
                 data_lines.append(line)
 

--- a/Misc/NEWS.d/next/Library/2026-07-21-12-23-48.gh-issue-154335.SRf8Gr.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-21-12-23-48.gh-issue-154335.SRf8Gr.rst
@@ -1,0 +1,1 @@
+Allow disabling terminal coloring for Tachyon's pstats collector.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This PR uses `_colorize.get_colors()` instead of the `_colorize.ANSIColors` enum. That way, one can disable terminal coloring through ANSI escape codes with e.g. setting certain env vars, such as `NO_COLOR=1`. 

I couldn't find an appropriate place for a test (and also I wasn't sure what's the best way to test this). Please let me know what your preference is regarding a test, and I'm happy to add it.


<!-- gh-issue-number: gh-154335 -->
* Issue: gh-154335
<!-- /gh-issue-number -->
