### PR TITLE
gh-154352: Fix killing a worker process in regrtest on OpenBSD

### DIFF
--- a/Lib/test/libregrtest/run_workers.py
+++ b/Lib/test/libregrtest/run_workers.py
@@ -147,9 +147,12 @@ class WorkerThread(threading.Thread):
 
         use_killpg = USE_PROCESS_GROUP
         if use_killpg:
-            parent_sid = os.getsid(0)
-            sid = os.getsid(popen.pid)
-            use_killpg = (sid != parent_sid)
+            try:
+                use_killpg = (os.getsid(popen.pid) != os.getsid(0))
+            except PermissionError:
+                # On OpenBSD getsid() is only allowed for a process in the
+                # same session, so the failure means that it is not.
+                use_killpg = True
 
         if use_killpg:
             what = f"{self} process group"


### PR DESCRIPTION
`os.getsid()` is only allowed for a process in the same session on OpenBSD, and worker processes are started in their own session, so determining whether to kill the process group failed with `PermissionError`.

<!-- gh-issue-number: gh-154352 -->
* Issue: gh-154352
<!-- /gh-issue-number -->
