### PR TITLE
gh-154359: Optimize UserList type checks to use list directly

### DIFF
--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -137,7 +137,7 @@ Other functions
    :term:`bytes-like objects <bytes-like object>`
    *a* and *b* are equal, otherwise ``False``,
    using a "constant-time compare" to reduce the risk of
-   `timing attacks <https://codahale.com/a-lesson-in-timing-attacks/>`_.
+   `timing attacks <https://web.archive.org/web/20211122171120/https://codahale.com/a-lesson-in-timing-attacks/>`_.
    See :func:`hmac.compare_digest` for additional details.
 
 

--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -137,7 +137,7 @@ Other functions
    :term:`bytes-like objects <bytes-like object>`
    *a* and *b* are equal, otherwise ``False``,
    using a "constant-time compare" to reduce the risk of
-   `timing attacks <https://web.archive.org/web/20211122171120/https://codahale.com/a-lesson-in-timing-attacks/>`_.
+   `timing attacks <https://web.archive.org/web/20250815071532/https://codahale.com/a-lesson-in-timing-attacks/>`__.
    See :func:`hmac.compare_digest` for additional details.
 
 

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -1286,7 +1286,7 @@ class UserList(_collections_abc.MutableSequence):
         self.data = []
         if initlist is not None:
             # XXX should this accept an arbitrary sequence?
-            if type(initlist) == type(self.data):
+            if type(initlist) is list:
                 self.data[:] = initlist
             elif isinstance(initlist, UserList):
                 self.data[:] = initlist.data[:]
@@ -1335,21 +1335,21 @@ class UserList(_collections_abc.MutableSequence):
     def __add__(self, other):
         if isinstance(other, UserList):
             return self.__class__(self.data + other.data)
-        elif isinstance(other, type(self.data)):
+        elif isinstance(other, list):
             return self.__class__(self.data + other)
         return self.__class__(self.data + list(other))
 
     def __radd__(self, other):
         if isinstance(other, UserList):
             return self.__class__(other.data + self.data)
-        elif isinstance(other, type(self.data)):
+        elif isinstance(other, list):
             return self.__class__(other + self.data)
         return self.__class__(list(other) + self.data)
 
     def __iadd__(self, other):
         if isinstance(other, UserList):
             self.data += other.data
-        elif isinstance(other, type(self.data)):
+        elif isinstance(other, list):
             self.data += other
         else:
             self.data += list(other)

--- a/Misc/NEWS.d/next/Library/2026-07-21-13-33-00.gh-issue-154359.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-21-13-33-00.gh-issue-154359.rst
@@ -1,0 +1,1 @@
+Optimize the type checks in :class:`collections.UserList` to use the :class:`list` type directly instead of ``type(self.data)``.


### PR DESCRIPTION
This PR optimizes the type checking within `UserList` inside the `collections` module. 

Since `self.data` is hardcoded to be an empty list `[]` at the beginning of `UserList.__init__`, the expression `type(self.data)` will always evaluate to the `list` type. We can replace `type(initlist) == type(self.data)` with a direct and more idiomatic `type(initlist) is list` identity check, bypassing the unnecessary `type()` call and attribute lookup while avoiding the slight anti-pattern of using the `==` operator to compare singleton type objects. The same optimization applies to the `__add__`, `__radd__`, and `__iadd__` magic methods.

I ran the `test_collections` suite and verified that everything passes successfully with these changes.

Fixes #154359

<!-- gh-issue-number: gh-154359 -->
* Issue: gh-154359
<!-- /gh-issue-number -->
