### PR TITLE
gh-154366: Fix test_asyncio.test_sendfile timing out on DragonFly BSD

### DIFF
--- a/Lib/test/test_asyncio/test_sendfile.py
+++ b/Lib/test/test_asyncio/test_sendfile.py
@@ -98,7 +98,12 @@ class SendfileBase:
     # 64 KiB page configuration.
     DATA = b"x" * (1024 * 17 * 64 + 1)
     # Reduce socket buffer size to test on relative small data sets.
-    BUF_SIZE = 4 * 1024   # 4 KiB
+    if sys.platform.startswith('dragonfly'):
+        # A smaller buffer makes every window update wait 100 ms for the
+        # delayed ACK timer.
+        BUF_SIZE = 32 * 1024  # 32 KiB
+    else:
+        BUF_SIZE = 4 * 1024   # 4 KiB
 
     def create_event_loop(self):
         raise NotImplementedError


### PR DESCRIPTION
A 4 KiB receive buffer makes DragonFly defer every window update to the delayed ACK timer, so each buffer worth of data costs 100 ms and the tests time out.

Use a larger socket buffer there. It is still smaller than the default write buffer limit, so the protocol is paused long before all data is sent.

<!-- gh-issue-number: gh-154366 -->
* Issue: gh-154366
<!-- /gh-issue-number -->
