### PR TITLE
gh-154357: Fix race condition in test_simpledialog by explicitly setting focus to entry

### DIFF
--- a/Lib/test/test_tkinter/test_simpledialog.py
+++ b/Lib/test/test_tkinter/test_simpledialog.py
@@ -444,11 +444,13 @@ class QueryDialogTest(AbstractTkTest, unittest.TestCase):
         d.focus_force()
         d.update()
         return d
-    # Temporary commit to trigger CI testing
+    
     def enter(self, d, value, key='<Return>'):
         d.entry.delete(0, 'end')
         d.entry.insert(0, value)
-        d.event_generate(key)
+        d.entry.focus_set()
+        d.update_idletasks()
+        d.entry.event_generate(key)
         d.update()
 
     # --- Prompt and entry ---

--- a/Lib/test/test_tkinter/test_simpledialog.py
+++ b/Lib/test/test_tkinter/test_simpledialog.py
@@ -444,7 +444,7 @@ class QueryDialogTest(AbstractTkTest, unittest.TestCase):
         d.focus_force()
         d.update()
         return d
-    
+
     def enter(self, d, value, key='<Return>'):
         d.entry.delete(0, 'end')
         d.entry.insert(0, value)

--- a/Lib/test/test_tkinter/test_simpledialog.py
+++ b/Lib/test/test_tkinter/test_simpledialog.py
@@ -444,7 +444,7 @@ class QueryDialogTest(AbstractTkTest, unittest.TestCase):
         d.focus_force()
         d.update()
         return d
-
+    # Temporary commit to trigger CI testing
     def enter(self, d, value, key='<Return>'):
         d.entry.delete(0, 'end')
         d.entry.insert(0, value)

--- a/Misc/NEWS.d/next/Library/2026-07-21-14-49-05.gh-issue-154357.YaqVLI.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-21-14-49-05.gh-issue-154357.YaqVLI.rst
@@ -1,0 +1,1 @@
+Fix race condition in :mod:`tkinter.simpledialog` tests by explicitly setting focus to entry before generating events.


### PR DESCRIPTION
Fixes gh-154357.

### Summary of Changes
In `Lib/test/test_tkinter/test_simpledialog.py`, `enter()` was generating `<Return>` events directly on the top-level dialog `d` without ensuring `d.entry` had active focus. On headless or slow CI runners, this caused key events to get dropped, leaving `d.result` as `None` and leading to flaky failures in `test_boundary_values_accepted`.

This PR fixes the race condition by:
1. Explicitly focusing `d.entry` via `d.entry.focus_set()`.
2. Flushing pending idle events with `d.update_idletasks()` before generating the key event directly on `d.entry`.

Cc @serhiy-storchaka