### PR TITLE
Document itertools.tee's internal batching

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -757,6 +757,14 @@ loops that truncate the stream.
    most or all of the data before another iterator starts, it is faster to use
    :func:`list` instead of :func:`tee`.
 
+   .. impl-detail::
+
+      Internally, CPython's :func:`tee` groups cached items into fixed-size
+      batches (57 items each currently) and only frees a batch once all
+      iterators have consumed it. Memory usage is thus bounded by the gap
+      between the fastest and slowest iterator plus up to one batch, not by
+      that gap alone.
+
 
 .. function:: zip_longest(*iterables, fillvalue=None)
 


### PR DESCRIPTION
Add an impl-detail note to itertools.tee, explaining that CPython caches items in fixed-size batches of 57 items currently. This is relevant for iterators with memory-intensive items.

A small example showing the batching in action:

```python
from itertools import tee

class LoudLifecycle:
    def __init__(self, i):
        self.i = i
        print(f"INIT {self.i}")

    def __del__(self):
        print(f"DEL {self.i}")

def my_iter():
    for i in range(100):
        yield LoudLifecycle(i)

a, b = tee(my_iter())

for _ in zip(a, b):
    pass

```