### PR TITLE
gh-154377: Add `python-version` to `pyvenv.cfg` (PEP 838)

### DIFF
--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -146,6 +146,9 @@ class BasicTest(BaseTest):
         self.assertIn('home = %s' % path, data)
         self.assertIn('executable = %s' %
                       os.path.realpath(sys.executable), data)
+        self.assertIn("python-version = %d.%d" % (sys.version_info.major,
+                                                  sys.version_info.minor),
+                      data)
         copies = '' if os.name=='nt' else ' --copies'
         cmd = (f'command = {sys.executable} -m venv{copies} --without-pip '
                f'--without-scm-ignore-files {self.env_dir}')

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -232,6 +232,8 @@ class EnvBuilder:
                 incl = 'false'
             f.write('include-system-site-packages = %s\n' % incl)
             f.write('version = %d.%d.%d\n' % sys.version_info[:3])
+            f.write('python-version = %d.%d\n' % (sys.version_info.major,
+                                                  sys.version_info.minor))
             if self.prompt is not None:
                 f.write(f'prompt = {self.prompt!r}\n')
             f.write('executable = %s\n' % os.path.realpath(sys.executable))

--- a/Misc/NEWS.d/next/Library/2026-07-21-17-29-19.gh-issue-154377.pep838.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-21-17-29-19.gh-issue-154377.pep838.rst
@@ -1,0 +1,2 @@
+Add a ``python-version`` key to ``pyvenv.cfg`` files created by :mod:`venv`.
+This implements :pep:`838`.


### PR DESCRIPTION
Draft PR accompanying [PEP 838](https://peps.python.org/pep-0838/): Add `python-version` to `pyvenv.cfg`

Part of https://github.com/python/cpython/issues/154377.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-154377 -->
* Issue: gh-154377
<!-- /gh-issue-number -->
