### PR TITLE
gh-154389: Do not use uuid_create() on OpenBSD

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-07-21-20-34-05.gh-issue-154389.DlTiii.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-21-20-34-05.gh-issue-154389.DlTiii.rst
@@ -1,0 +1,3 @@
+Fix :func:`uuid.uuid1` on OpenBSD:
+it returned a version 4 UUID,
+because ``uuid_create()`` generates random UUIDs on this platform.

--- a/configure
+++ b/configure
@@ -15294,9 +15294,10 @@ then :
 
 fi
 
-# gh-124228: While the libuuid library is available on NetBSD, it supports only UUID version 4.
+# gh-124228: While the libuuid library is available on NetBSD and OpenBSD,
+# it supports only UUID version 4.
 # This restriction inhibits the proper generation of time-based UUIDs.
-if test "$ac_sys_system" = "NetBSD"; then
+if test "$ac_sys_system" = "NetBSD" || test "$ac_sys_system" = "OpenBSD"; then
   have_uuid=missing
   printf "%s\n" "#define HAVE_UUID_H 0" >>confdefs.h
 

--- a/configure.ac
+++ b/configure.ac
@@ -4070,9 +4070,10 @@ AS_VAR_IF([ac_cv_have_uuid_generate_time_safe], [yes], [
   AC_DEFINE([HAVE_UUID_GENERATE_TIME_SAFE], [1])
 ])
 
-# gh-124228: While the libuuid library is available on NetBSD, it supports only UUID version 4.
+# gh-124228: While the libuuid library is available on NetBSD and OpenBSD,
+# it supports only UUID version 4.
 # This restriction inhibits the proper generation of time-based UUIDs.
-if test "$ac_sys_system" = "NetBSD"; then
+if test "$ac_sys_system" = "NetBSD" || test "$ac_sys_system" = "OpenBSD"; then
   have_uuid=missing
   AC_DEFINE([HAVE_UUID_H], [0])
 fi


### PR DESCRIPTION
Like NetBSD, OpenBSD generates version 4 UUIDs in `uuid_create()`, so it cannot be used for `uuid.uuid1()`. Extend the existing gh-124228 condition to OpenBSD.

FreeBSD and DragonFly BSD provide the same function but generate version 1 UUIDs, so they are not affected.

<!-- gh-issue-number: gh-154389 -->
* Issue: gh-154389
<!-- /gh-issue-number -->
