### PR TITLE
gh-154395: Skip test_environment_is_not_modified without rl_change_environment

### DIFF
--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -5,6 +5,7 @@ import codecs
 import locale
 import os
 import sys
+import sysconfig
 import tempfile
 import textwrap
 import threading
@@ -413,6 +414,8 @@ readline.write_history_file(history_file)
         # So, we've only tested that the read did not fail.
         # See TestHistoryManipulation for the full test.
 
+    @unittest.skipUnless(sysconfig.get_config_var("HAVE_RL_CHANGE_ENVIRONMENT"),
+                         "readline can modify the environment")
     def test_environment_is_not_modified(self):
         # os.environ contains environment at the time "os" module was loaded, so
         # before the "readline" module is loaded.


### PR DESCRIPTION
`rl_change_environment` only exists since readline 6.3. Without it readline sets `LINES` and `COLUMNS`, and there is nothing we can do about it.

<!-- gh-issue-number: gh-154395 -->
* Issue: gh-154395
<!-- /gh-issue-number -->
