### PR TITLE
gh-154394: Skip test_tcsendbreak on OpenBSD

### DIFF
--- a/Lib/test/test_termios.py
+++ b/Lib/test/test_termios.py
@@ -117,7 +117,7 @@ class TestFunctions(unittest.TestCase):
     @support.skip_android_selinux('tcsendbreak')
     def test_tcsendbreak(self):
         with skip_enotty_error(self, 'tcsendbreak',
-                               ('freebsd', 'netbsd', 'cygwin')):
+                               ('freebsd', 'netbsd', 'openbsd', 'cygwin')):
             termios.tcsendbreak(self.fd, 1)
             termios.tcsendbreak(self.stream, 1)
 


### PR DESCRIPTION
`tcsendbreak()` fails with `ENOTTY` for pseudo-terminals on OpenBSD, like on FreeBSD, NetBSD and Cygwin.

<!-- gh-issue-number: gh-154394 -->
* Issue: gh-154394
<!-- /gh-issue-number -->
