### PR TITLE
gh-154399: Fix venv activate.csh in a non-interactive shell

### DIFF
--- a/Lib/venv/scripts/posix/activate.csh
+++ b/Lib/venv/scripts/posix/activate.csh
@@ -16,10 +16,12 @@ setenv PATH "$VIRTUAL_ENV/"__VENV_BIN_NAME__":$PATH"
 setenv VIRTUAL_ENV_PROMPT __VENV_PROMPT__
 
 
-set _OLD_VIRTUAL_PROMPT="$prompt"
+if ($?prompt) then
+    set _OLD_VIRTUAL_PROMPT="$prompt"
 
-if (! "$?VIRTUAL_ENV_DISABLE_PROMPT") then
-    set prompt = "("__VENV_PROMPT__") $prompt:q"
+    if (! "$?VIRTUAL_ENV_DISABLE_PROMPT") then
+        set prompt = "("__VENV_PROMPT__") $prompt:q"
+    endif
 endif
 
 alias pydoc python -m pydoc

--- a/Misc/NEWS.d/next/Library/2026-07-21-21-36-59.gh-issue-154399.VSa6oH.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-21-21-36-59.gh-issue-154399.VSa6oH.rst
@@ -1,0 +1,3 @@
+Fix :mod:`venv` activation in a non-interactive csh:
+``activate.csh`` no longer fails
+when the ``prompt`` variable is not set.


### PR DESCRIPTION
`activate.csh` saved the prompt unconditionally, but `prompt` only exists in interactive shells, and csh fails on an undefined variable.

With csh the error is fatal, with tcsh it silently aborts sourcing, so the `pydoc` alias and `rehash` at the end of the script are skipped.

<!-- gh-issue-number: gh-154399 -->
* Issue: gh-154399
<!-- /gh-issue-number -->
