### PR TITLE
[3.14] gh-154394: Skip test_tcsendbreak on OpenBSD (GH-154397)

### DIFF
--- a/Lib/test/test_termios.py
+++ b/Lib/test/test_termios.py
@@ -104,7 +104,7 @@ class TestFunctions(unittest.TestCase):
         try:
             termios.tcsendbreak(self.fd, 1)
         except termios.error as exc:
-            if exc.args[0] == errno.ENOTTY and sys.platform.startswith(('freebsd', "netbsd")):
+            if exc.args[0] == errno.ENOTTY and sys.platform.startswith(('freebsd', 'netbsd', 'openbsd')):
                 self.skipTest('termios.tcsendbreak() is not supported '
                               'with pseudo-terminals (?) on this platform')
             raise


### PR DESCRIPTION
`tcsendbreak()` fails with `ENOTTY` for pseudo-terminals on OpenBSD, like on FreeBSD and NetBSD.

Manual backport of GH-154397: `skip_enotty_error()` only exists on the main branch (it was added in gh-149879 for Cygwin), so the platform is added to the inline check instead.

<!-- gh-issue-number: gh-154394 -->
* Issue: gh-154394
<!-- /gh-issue-number -->
