### PR TITLE
gh-154414: Skip test_tcsendbreak on DragonFly BSD

### DIFF
--- a/Lib/test/test_termios.py
+++ b/Lib/test/test_termios.py
@@ -117,7 +117,7 @@ class TestFunctions(unittest.TestCase):
     @support.skip_android_selinux('tcsendbreak')
     def test_tcsendbreak(self):
         with skip_enotty_error(self, 'tcsendbreak',
-                               ('freebsd', 'netbsd', 'openbsd', 'cygwin')):
+                               ('freebsd', 'netbsd', 'openbsd', 'dragonfly', 'cygwin')):
             termios.tcsendbreak(self.fd, 1)
             termios.tcsendbreak(self.stream, 1)
 


### PR DESCRIPTION
`tcsendbreak()` fails with `ENOTTY` for pseudo-terminals on DragonFly BSD, like on FreeBSD, NetBSD, OpenBSD and Cygwin.

Follow-up to gh-154394: it was not noticed there because `test_termios` hung earlier on DragonFly BSD.

<!-- gh-issue-number: gh-154414 -->
* Issue: gh-154414
<!-- /gh-issue-number -->
