### PR TITLE
gh-154416: Fix hanging test_tcflow on DragonFly BSD

### DIFF
--- a/Lib/test/test_termios.py
+++ b/Lib/test/test_termios.py
@@ -194,6 +194,9 @@ class TestFunctions(unittest.TestCase):
             termios.tcflow(self.fd, termios.TCOON)
             termios.tcflow(self.fd, termios.TCIOFF)
             termios.tcflow(self.fd, termios.TCION)
+            # Discard the transmitted STOP and START characters,
+            # otherwise closing the pseudo-terminal can block.
+            termios.tcflush(self.fd, termios.TCOFLUSH)
 
     @support.skip_android_selinux('tcflow')
     def test_tcflow_errors(self):


### PR DESCRIPTION
`TCIOFF` and `TCION` transmit STOP and START characters. On DragonFly BSD closing the pseudo-terminal then waits for them to be read, which never happens. Discard them instead.

<!-- gh-issue-number: gh-154416 -->
* Issue: gh-154416
<!-- /gh-issue-number -->
