### PR TITLE
gh-154419: Find the fish shell in test_venv

### DIFF
--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -783,8 +783,16 @@ class BasicTest(BaseTest):
         shadows one of those builtins (a common pattern for `.`-style directory
         navigators) must not hijack the prompt or break status restoration.
         """
-        fish = shutil.which('fish')
-        if fish is None:
+        # Some systems have an unrelated "fish" game (see fish(6)), which
+        # can precede the fish shell in PATH.
+        for dirname in None, *os.get_exec_path():
+            fish = shutil.which('fish', path=dirname)
+            if fish is not None and subprocess.run(
+                    [fish, '-c', 'echo $FISH_VERSION'],
+                    stdin=subprocess.DEVNULL,
+                    capture_output=True).stdout.strip():
+                break
+        else:
             self.skipTest('fish required for this test')
         rmtree(self.env_dir)
         builder = venv.EnvBuilder(clear=True)


### PR DESCRIPTION
`shutil.which('fish')` can find the unrelated "Go Fish" game (see fish(6)), which is shipped on NetBSD, OpenBSD and DragonFly BSD. On DragonFly BSD `/usr/games` precedes `/usr/local/bin` in `PATH`, so the game is found even when the fish shell is installed.

Search `PATH` for an executable which behaves like the fish shell instead. Verified with the fish shell installed on Linux, DragonFly BSD, NetBSD, OpenBSD and Solaris: the test now runs on all of them.

<!-- gh-issue-number: gh-154419 -->
* Issue: gh-154419
<!-- /gh-issue-number -->
