### PR TITLE
[3.14] gh-154416: Fix hanging test_tcflow on DragonFly BSD (GH-154417)

### DIFF
--- a/Lib/test/test_termios.py
+++ b/Lib/test/test_termios.py
@@ -180,6 +180,9 @@ class TestFunctions(unittest.TestCase):
         termios.tcflow(self.fd, termios.TCOON)
         termios.tcflow(self.fd, termios.TCIOFF)
         termios.tcflow(self.fd, termios.TCION)
+        # Discard the transmitted STOP and START characters,
+        # otherwise closing the pseudo-terminal can block.
+        termios.tcflush(self.fd, termios.TCOFLUSH)
 
     @support.skip_android_selinux('tcflow')
     def test_tcflow_errors(self):


### PR DESCRIPTION
`TCIOFF` and `TCION` transmit STOP and START characters. On DragonFly BSD closing the pseudo-terminal then waits for them to be read, which never happens.

Manual backport of GH-154417: the `skip_enotty_error()` wrapper only exists on the main branch.

<!-- gh-issue-number: gh-154416 -->
* Issue: gh-154416
<!-- /gh-issue-number -->
