### PR TITLE
[3.13] gh-154414: Skip test_tcsendbreak on DragonFly BSD (GH-154415)

### DIFF
--- a/Lib/test/test_termios.py
+++ b/Lib/test/test_termios.py
@@ -97,7 +97,7 @@ class TestFunctions(unittest.TestCase):
         try:
             termios.tcsendbreak(self.fd, 1)
         except termios.error as exc:
-            if exc.args[0] == errno.ENOTTY and sys.platform.startswith(('freebsd', 'netbsd', 'openbsd')):
+            if exc.args[0] == errno.ENOTTY and sys.platform.startswith(('freebsd', 'netbsd', 'openbsd', 'dragonfly')):
                 self.skipTest('termios.tcsendbreak() is not supported '
                               'with pseudo-terminals (?) on this platform')
             raise


### PR DESCRIPTION
`tcsendbreak()` fails with `ENOTTY` for pseudo-terminals on DragonFly BSD, like on FreeBSD, NetBSD and OpenBSD.

Manual backport of GH-154415: `skip_enotty_error()` only exists on the main branch, so the platform is added to the inline check.

<!-- gh-issue-number: gh-154414 -->
* Issue: gh-154414
<!-- /gh-issue-number -->
