### PR TITLE
gh-154401: Skip fetching the thread state for non-GC types in `_Py_Dealloc`

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-22-14-30-00.gh-issue-154429.Qk9mZ2.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-22-14-30-00.gh-issue-154429.Qk9mZ2.rst
@@ -1,0 +1,2 @@
+Slightly speed up deallocation of objects that are not tracked by the garbage
+collector, such as :class:`int`, :class:`float` and :class:`str`.

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -3292,13 +3292,20 @@ _Py_Dealloc(PyObject *op)
     PyTypeObject *type = Py_TYPE(op);
     unsigned long gc_flag = type->tp_flags & Py_TPFLAGS_HAVE_GC;
     destructor dealloc = type->tp_dealloc;
-    PyThreadState *tstate = _PyThreadState_GET();
-    intptr_t margin = _Py_RecursionLimit_GetMargin(tstate);
-    if (margin < 2 && gc_flag) {
-        _PyTrash_thread_deposit_object(tstate, (PyObject *)op);
-        return;
+    PyThreadState *tstate = NULL;
+    intptr_t margin = 0;
+    if (gc_flag) {
+        tstate = _PyThreadState_GET();
+        margin = _Py_RecursionLimit_GetMargin(tstate);
+        if (margin < 2) {
+            _PyTrash_thread_deposit_object(tstate, (PyObject *)op);
+            return;
+        }
     }
 #ifdef Py_DEBUG
+    if (tstate == NULL) {
+        tstate = _PyThreadState_GET();
+    }
 #if !defined(Py_GIL_DISABLED) && !defined(Py_STACKREF_DEBUG)
     /* This assertion doesn't hold for the free-threading build, as
      * PyStackRef_CLOSE_SPECIALIZED is not implemented */
@@ -3340,7 +3347,7 @@ _Py_Dealloc(PyObject *op)
     Py_XDECREF(old_exc);
     Py_DECREF(type);
 #endif
-    if (tstate->delete_later && margin >= 4 && gc_flag) {
+    if (gc_flag && tstate->delete_later && margin >= 4) {
         _PyTrash_thread_destroy_chain(tstate);
     }
 }


### PR DESCRIPTION
Demonstration for 

<!-- gh-issue-number: gh-154401 -->
* Issue: gh-154401
<!-- /gh-issue-number -->


