### PR TITLE
gh-154387: Fix `structseq_repr` mislabeling of unnamed `PyStructSequence` fields

### DIFF
--- a/Lib/test/test_structseq.py
+++ b/Lib/test/test_structseq.py
@@ -48,6 +48,15 @@ class StructSeqTest(unittest.TestCase):
         self.assertIn("st_ino=", rep)
         self.assertIn("st_dev=", rep)
 
+        # Issue #154387: unnamed fields should not be mislabeled with named field names.
+        st = os.stat_result(range(10))
+        rep = repr(st)
+        self.assertEqual(
+            rep,
+            "os.stat_result(st_mode=0, st_ino=1, st_dev=2, st_nlink=3, "
+            "st_uid=4, st_gid=5, st_size=6, 7, 8, 9)"
+        )
+
     def test_concat(self):
         t1 = time.gmtime()
         t2 = t1 + tuple(t1)

--- a/Misc/NEWS.d/next/Build/2026-07-09-10-37-00.gh-issue-118860.abc123.rst
+++ b/Misc/NEWS.d/next/Build/2026-07-09-10-37-00.gh-issue-118860.abc123.rst
@@ -1,1 +1,0 @@
-Clarify the use of ``Py_OutDir`` and ``PC/layout`` for customizing the build output directory in ``PCbuild/readme.txt``.

--- a/Misc/NEWS.d/next/Build/2026-07-09-10-37-00.gh-issue-118860.abc123.rst
+++ b/Misc/NEWS.d/next/Build/2026-07-09-10-37-00.gh-issue-118860.abc123.rst
@@ -1,0 +1,1 @@
+Clarify the use of ``Py_OutDir`` and ``PC/layout`` for customizing the build output directory in ``PCbuild/readme.txt``.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-22-13-35-00.gh-issue-154387.abc123.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-22-13-35-00.gh-issue-154387.abc123.rst
@@ -1,0 +1,1 @@
+Fix :c:func:`structseq_repr` mislabeling unnamed :c:type:`PyStructSequence` fields. Patch by Pranav Choudhary.

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -305,20 +305,23 @@ structseq_repr(PyObject *op)
         }
 
         // Write name
-        const char *name_utf8 = typ->tp_members[i].name;
-        if (name_utf8 == NULL) {
-            PyErr_Format(PyExc_SystemError,
-                         "In structseq_repr(), member %zd name is NULL"
-                         " for type %.500s", i, typ->tp_name);
-            goto error;
-        }
-        if (PyUnicodeWriter_WriteUTF8(writer, name_utf8, -1) < 0) {
-            goto error;
+        const char *name_utf8 = NULL;
+        Py_ssize_t expected_offset = offsetof(PyStructSequence, ob_item) + i * sizeof(PyObject*);
+        for (Py_ssize_t k = 0; typ->tp_members[k].name != NULL; k++) {
+            if (typ->tp_members[k].offset == expected_offset) {
+                name_utf8 = typ->tp_members[k].name;
+                break;
+            }
         }
 
-        // Write "=" + repr(value)
-        if (PyUnicodeWriter_WriteChar(writer, '=') < 0) {
-            goto error;
+        if (name_utf8 != NULL) {
+            if (PyUnicodeWriter_WriteUTF8(writer, name_utf8, -1) < 0) {
+                goto error;
+            }
+            // Write "="
+            if (PyUnicodeWriter_WriteChar(writer, '=') < 0) {
+                goto error;
+            }
         }
         PyObject *value = PyStructSequence_GetItem((PyObject*)obj, i);
         assert(value != NULL);

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -23,7 +23,7 @@ external dependencies. To build, simply run the "build.bat" script without
 any arguments. After this succeeds, you can open the "pcbuild.sln"
 solution in Visual Studio to continue development.
 
-To build an installer package, refer to the README in the Tools/msi folder.
+To build an installer package, refer to PC/layout.
 
 The solution currently supports two platforms.  The Win32 platform is
 used to build standard x86-compatible 32-bit binaries, output into the
@@ -105,25 +105,6 @@ the 32-bit Win32 platform.  It accepts several arguments to change
 this behavior, try `build.bat -h` to learn more.
 
 
-Custom Output Directory
------------------------
-
-If you want to move the build outputs to a different directory, use the
-`Py_OutDir` property either as a standard MSBuild `/p:Py_OutDir=` argument
-(for example, `build.bat "/p:Py_OutDir=C:\MyOutput"`) or an environment
-variable. Using the standard MSBuild `/p:OutDir=` property will more
-directly override the output location, which may result in a broken build.
-
-However, be aware that the compiled binaries probably won't run directly from
-that location. If you want to make an install-shaped layout without creating the
-installer, build CPython normally first, and then use the `PC/layout` script
-with the runtime you just built, or using the `--build` and `--source` options
-to specify the directories:
-    python.bat PC/layout --<options>
-Use `-h` with that command to see all available options for customizing the
-layout.
-
-
 C Runtime
 ---------
 
@@ -159,12 +140,6 @@ CPython in different ways:
 pythonw
     pythonw.exe, a variant of python.exe that doesn't open a Command
     Prompt window
-pylauncher
-    py.exe, the Python Launcher for Windows, see
-        https://docs.python.org/3/using/windows.html#launcher
-pywlauncher
-    pyw.exe, a variant of py.exe that doesn't open a Command Prompt
-    window
 _testembed
     _testembed.exe, a small program that embeds Python for testing
     purposes, used by test_capi.py
@@ -175,8 +150,6 @@ _freeze_module
     _freeze_module.exe, used to regenerate frozen modules in Python
     after changes have been made to the corresponding source files
     (e.g. Lib\importlib\_bootstrap.py).
-pyshellext
-    pyshellext.dll, the shell extension deployed with the launcher
 python3dll
     python3.dll, the PEP 384 Stable ABI dll
     (not installed on free-threaded builds)
@@ -266,7 +239,7 @@ _sqlite3
         https://www.sqlite.org/
 
 _tkinter
-    Wraps version 9.0.3 of the Tk windowing system, which is downloaded
+    Wraps version 9.0.4 of the Tk windowing system, which is downloaded
     from our binaries repository at
     https://github.com/python/cpython-bin-deps.
 
@@ -439,8 +412,6 @@ _testclinic_limited extension, the file Modules/_testclinic_limited.c:
 * Save and exit Visual Studio.
 * Add `;_testclinic_limited` to `<TestModules Include="...">` in
   PCbuild\pcbuild.proj.
-* Update "exts" in Tools\msi\lib\lib_files.wxs file or in
-  Tools\msi\test\test_files.wxs file (for tests).
 * PC\layout\main.py needs updating if you add a test-only extension whose name
   doesn't start with "_test".
 * Add the extension to PCbuild\readme.txt (this file).

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -108,12 +108,21 @@ this behavior, try `build.bat -h` to learn more.
 Custom Output Directory
 -----------------------
 
-If you want to move the build outputs to a different directory, do not use the standard MSBuild `/p:OutDir=` property, as CPython has many assumptions about where the source repository is relative to the built files. 
-Instead, you can override the output directory by setting `Py_OutDir` (for example, `build.bat "/p:Py_OutDir=C:\MyOutput"`). 
+If you want to move the build outputs to a different directory, do not use the
+standard MSBuild `/p:OutDir=` property, as CPython has many assumptions about
+where the source repository is relative to the built files. Instead, you can
+override the output directory by setting `Py_OutDir` as an environment
+variable or by passing it to build.bat (for example,
+`build.bat "/p:Py_OutDir=C:\MyOutput"`).
 
-However, be aware that the compiled binaries probably won't run directly from that location. If you want to make an install-shaped layout without creating the installer, build CPython normally first, and then use the `PC/layout` script with the runtime you just built:
+However, be aware that the compiled binaries probably won't run directly from
+that location. If you want to make an install-shaped layout without creating the
+installer, build CPython normally first, and then use the `PC/layout` script
+with the runtime you just built, or using the `--build` and `--source` options
+to specify the directories:
     python.bat PC/layout --<options>
-Use `-h` with that command to see all available options for customizing the layout.
+Use `-h` with that command to see all available options for customizing the
+layout.
 
 
 C Runtime

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -108,12 +108,11 @@ this behavior, try `build.bat -h` to learn more.
 Custom Output Directory
 -----------------------
 
-If you want to move the build outputs to a different directory, do not use the
-standard MSBuild `/p:OutDir=` property, as CPython has many assumptions about
-where the source repository is relative to the built files. Instead, you can
-override the output directory by setting `Py_OutDir` as an environment
-variable or by passing it to build.bat (for example,
-`build.bat "/p:Py_OutDir=C:\MyOutput"`).
+If you want to move the build outputs to a different directory, use the
+`Py_OutDir` property either as a standard MSBuild `/p:Py_OutDir=` argument
+(for example, `build.bat "/p:Py_OutDir=C:\MyOutput"`) or an environment
+variable. Using the standard MSBuild `/p:OutDir=` property will more
+directly override the output location, which may result in a broken build.
 
 However, be aware that the compiled binaries probably won't run directly from
 that location. If you want to make an install-shaped layout without creating the

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -105,6 +105,17 @@ the 32-bit Win32 platform.  It accepts several arguments to change
 this behavior, try `build.bat -h` to learn more.
 
 
+Custom Output Directory
+-----------------------
+
+If you want to move the build outputs to a different directory, do not use the standard MSBuild `/p:OutDir=` property, as CPython has many assumptions about where the source repository is relative to the built files. 
+Instead, you can override the output directory by setting `Py_OutDir` (for example, `build.bat "/p:Py_OutDir=C:\MyOutput"`). 
+
+However, be aware that the compiled binaries probably won't run directly from that location. If you want to make an install-shaped layout without creating the installer, build CPython normally first, and then use the `PC/layout` script with the runtime you just built:
+    python.bat PC/layout --<options>
+Use `-h` with that command to see all available options for customizing the layout.
+
+
 C Runtime
 ---------
 


### PR DESCRIPTION
Fixes #154387.

`structseq_repr` incorrectly assumed that all fields printed were sequentially named fields from `tp_members`. When an unnamed field was encountered (like the timestamp float variants in `os.stat_result`), it would continue indexing into `tp_members` array, erroneously labeling unnamed field values with subsequent named field labels from the struct sequence definition.

This PR fixes the bug by resolving the field name accurately based on the expected offset rather than the sequential index, correctly printing unnamed fields without labels and accurately matching named fields.

<!-- gh-issue-number: gh-154387 -->
* Issue: gh-154387
<!-- /gh-issue-number -->
