### PR TITLE
gh-154435: Fix os.posix_fadvise() and os.posix_fallocate() on DragonFly BSD

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-07-22-10-30-08.gh-issue-154435.xCxm0T.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-22-10-30-08.gh-issue-154435.xCxm0T.rst
@@ -1,0 +1,3 @@
+Fix :func:`os.posix_fadvise` and :func:`os.posix_fallocate` on DragonFly BSD:
+they raised :exc:`OSError` with a meaningless error code,
+because these functions return -1 and set ``errno`` there.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -13508,6 +13508,10 @@ os_posix_fallocate_impl(PyObject *module, int fd, Py_off_t offset,
         Py_BEGIN_ALLOW_THREADS
         result = posix_fallocate(fd, offset, length);
         Py_END_ALLOW_THREADS
+        // DragonFly BSD returns -1 and sets errno.
+        if (result == -1) {
+            result = errno;
+        }
     } while (result == EINTR && !(async_err = PyErr_CheckSignals()));
 
     if (result == 0)
@@ -13555,6 +13559,10 @@ os_posix_fadvise_impl(PyObject *module, int fd, Py_off_t offset,
         Py_BEGIN_ALLOW_THREADS
         result = posix_fadvise(fd, offset, length, advice);
         Py_END_ALLOW_THREADS
+        // DragonFly BSD returns -1 and sets errno.
+        if (result == -1) {
+            result = errno;
+        }
     } while (result == EINTR && !(async_err = PyErr_CheckSignals()));
 
     if (result == 0)


### PR DESCRIPTION
POSIX specifies that these functions return the error number and do not set `errno`, but on DragonFly BSD they return -1 and set `errno`, so `OSError` was raised with `[Errno -1]`.

Use `errno` if the function returns -1. This also fixes retrying on `EINTR`, which compared the returned value with `EINTR`.

<!-- gh-issue-number: gh-154435 -->
* Issue: gh-154435
<!-- /gh-issue-number -->
