### PR TITLE
gh-154437: Fix test_getcwd_long_path on DragonFly BSD

### DIFF
--- a/Lib/test/test_os/test_os.py
+++ b/Lib/test/test_os/test_os.py
@@ -156,7 +156,8 @@ class MiscTests(unittest.TestCase):
                         # ("The filename or extension is too long")
                         break
                     except OSError as exc:
-                        if exc.errno == errno.ENAMETOOLONG:
+                        # DragonFly BSD raises EFAULT for a too long path.
+                        if exc.errno in (errno.ENAMETOOLONG, errno.EFAULT):
                             break
                         else:
                             raise


### PR DESCRIPTION
DragonFly BSD raises `EFAULT` instead of `ENAMETOOLONG` when the path exceeds `PATH_MAX`.

<!-- gh-issue-number: gh-154437 -->
* Issue: gh-154437
<!-- /gh-issue-number -->
