### PR TITLE
[3.13] gh-154427: Check the access time in UtimeTests only if it is stored (GH-154428)

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -791,11 +791,18 @@ class UtimeTests(unittest.TestCase):
                 or (st.st_mtime != st[8])
                 or (st.st_ctime != st[9]))
 
+    def support_atime(self, filename):
+        # Heuristic to check if the filesystem stores the access time.
+        # Use whole seconds, to not depend on the timestamp resolution.
+        os.utime(filename, (1, 2))
+        return os.stat(filename).st_atime == 1
+
     def _test_utime(self, set_time, filename=None):
         if not filename:
             filename = self.fname
 
         support_subsecond = self.support_subsecond(filename)
+        support_atime = self.support_atime(filename)
         if support_subsecond:
             # Timestamp with a resolution of 1 microsecond (10^-6).
             #
@@ -814,12 +821,15 @@ class UtimeTests(unittest.TestCase):
         st = os.stat(filename)
 
         if support_subsecond:
-            self.assertAlmostEqual(st.st_atime, atime_ns * 1e-9, delta=1e-6)
+            if support_atime:
+                self.assertAlmostEqual(st.st_atime, atime_ns * 1e-9, delta=1e-6)
             self.assertAlmostEqual(st.st_mtime, mtime_ns * 1e-9, delta=1e-6)
         else:
-            self.assertEqual(st.st_atime, atime_ns * 1e-9)
+            if support_atime:
+                self.assertEqual(st.st_atime, atime_ns * 1e-9)
             self.assertEqual(st.st_mtime, mtime_ns * 1e-9)
-        self.assertEqual(st.st_atime_ns, atime_ns)
+        if support_atime:
+            self.assertEqual(st.st_atime_ns, atime_ns)
         self.assertEqual(st.st_mtime_ns, mtime_ns)
 
     def test_utime(self):


### PR DESCRIPTION
HAMMER2 on DragonFly BSD does not store the access time and `os.stat()` returns the modification time instead.

Manual backport of GH-154428: in 3.13 the tests live in `Lib/test/test_os.py` and `_test_utime()` has no Emscripten branch, so the assertions are guarded in their 3.13 form.

<!-- gh-issue-number: gh-154427 -->
* Issue: gh-154427
<!-- /gh-issue-number -->
