### PR TITLE
gh-154441: Skip the scheduler tests if the API requires privileges

### DIFF
--- a/Lib/test/test_os/test_posix.py
+++ b/Lib/test/test_os/test_posix.py
@@ -46,7 +46,8 @@ def _supports_sched():
     try:
         posix.sched_getscheduler(0)
     except OSError as e:
-        if e.errno == errno.ENOSYS:
+        # DragonFly BSD requires privileges to use the scheduler API.
+        if e.errno in (errno.ENOSYS, errno.EPERM):
             return False
     return True
 
@@ -1453,6 +1454,7 @@ class PosixTester(unittest.TestCase):
         del sched_priority, param  # should not crash
         support.gc_collect()  # just to be sure
 
+    @requires_sched
     @unittest.skipUnless(hasattr(posix, "sched_rr_get_interval"), "no function")
     def test_sched_rr_get_interval(self):
         try:


### PR DESCRIPTION
DragonFly BSD requires privileges to use the scheduler API, even for the calling process, so `sched_getscheduler(0)` fails with `EPERM`. Handle it like `ENOSYS`, which was added in gh-78831 for musl.

`test_sched_rr_get_interval` was the only scheduler test without `@requires_sched`.

<!-- gh-issue-number: gh-154441 -->
* Issue: gh-154441
<!-- /gh-issue-number -->
