### PR TITLE
gh-154443: Fix test_makedev on DragonFly BSD

### DIFF
--- a/Lib/test/test_os/test_posix.py
+++ b/Lib/test/test_os/test_posix.py
@@ -823,8 +823,7 @@ class PosixTester(unittest.TestCase):
         # a special case for NODEV, on others this is just an implementation
         # artifact.
         if (hasattr(posix, 'NODEV') and
-            sys.platform.startswith(('linux', 'macos', 'freebsd', 'dragonfly',
-                                     'sunos'))):
+            sys.platform.startswith(('linux', 'macos', 'freebsd', 'sunos'))):
             NODEV = posix.NODEV
             self.assertEqual(posix.major(NODEV), NODEV)
             self.assertEqual(posix.minor(NODEV), NODEV)


### PR DESCRIPTION
`major()` and `minor()` on DragonFly BSD have no special case for `NODEV`, they just extract bit fields, so `major(NODEV)` is 255, not `NODEV`. Remove DragonFly BSD from the list of platforms preserving `NODEV`.

<!-- gh-issue-number: gh-154443 -->
* Issue: gh-154443
<!-- /gh-issue-number -->
