### PR TITLE
gh-154348: fix data race on nogil build about `sys.monitoring.use_tool_id()`

### DIFF
--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -2166,6 +2166,10 @@ check_valid_tool(int tool_id)
     return 0;
 }
 
+// Protects the interp->monitoring_tool_names array against concurrent
+// use_tool_id/clear_tool_id/free_tool_id/get_tool calls.
+static PyMutex monitoring_tool_names_mutex;
+
 /*[clinic input]
 monitoring.use_tool_id
 
@@ -2187,11 +2191,14 @@ monitoring_use_tool_id_impl(PyObject *module, int tool_id, PyObject *name)
         return NULL;
     }
     PyInterpreterState *interp = _PyInterpreterState_GET();
+    PyMutex_Lock(&monitoring_tool_names_mutex);
     if (interp->monitoring_tool_names[tool_id] != NULL) {
         PyErr_Format(PyExc_ValueError, "tool %d is already in use", tool_id);
+        PyMutex_Unlock(&monitoring_tool_names_mutex);
         return NULL;
     }
     interp->monitoring_tool_names[tool_id] = Py_NewRef(name);
+    PyMutex_Unlock(&monitoring_tool_names_mutex);
     Py_RETURN_NONE;
 }
 
@@ -2213,11 +2220,14 @@ monitoring_clear_tool_id_impl(PyObject *module, int tool_id)
 
     PyInterpreterState *interp = _PyInterpreterState_GET();
 
+    PyMutex_Lock(&monitoring_tool_names_mutex);
     if (interp->monitoring_tool_names[tool_id] != NULL) {
         if (_PyMonitoring_ClearToolId(tool_id) < 0) {
+            PyMutex_Unlock(&monitoring_tool_names_mutex);
             return NULL;
         }
     }
+    PyMutex_Unlock(&monitoring_tool_names_mutex);
 
     Py_RETURN_NONE;
 }
@@ -2239,13 +2249,16 @@ monitoring_free_tool_id_impl(PyObject *module, int tool_id)
     }
     PyInterpreterState *interp = _PyInterpreterState_GET();
 
+    PyMutex_Lock(&monitoring_tool_names_mutex);
     if (interp->monitoring_tool_names[tool_id] != NULL) {
         if (_PyMonitoring_ClearToolId(tool_id) < 0) {
+            PyMutex_Unlock(&monitoring_tool_names_mutex);
             return NULL;
         }
     }
 
     Py_CLEAR(interp->monitoring_tool_names[tool_id]);
+    PyMutex_Unlock(&monitoring_tool_names_mutex);
     Py_RETURN_NONE;
 }
 
@@ -2267,11 +2280,15 @@ monitoring_get_tool_impl(PyObject *module, int tool_id)
         return NULL;
     }
     PyInterpreterState *interp = _PyInterpreterState_GET();
+    PyMutex_Lock(&monitoring_tool_names_mutex);
     PyObject *name = interp->monitoring_tool_names[tool_id];
     if (name == NULL) {
+        PyMutex_Unlock(&monitoring_tool_names_mutex);
         Py_RETURN_NONE;
     }
-    return Py_NewRef(name);
+    PyObject *ret = Py_NewRef(name);
+    PyMutex_Unlock(&monitoring_tool_names_mutex);
+    return ret;
 }
 
 /*[clinic input]


### PR DESCRIPTION
As reported in #154348 (found by devdanzin's [fusil](https://github.com/devdanzin/fusil)), `interp->monitoring_tool_names[tool_id]` for `sys.monitoring` is accessed without any synchronization, which is a data race on free-threaded build.

The fix is straightforward, just add a dedicated `PyMutex` and serialize all access on `monitoring_tool_names`

Testing
  - The reproducer (8 threads × 6000 rounds) now runs clean under a TSAN build.
  - This PR only adds a mutex, so basic functional behavior is unchanged.

Notes for reviewer:
- Of course the writer need a lock, but why reader (i.e. `monitoring.get_tool`) needs one as well? Because it reads the pointer and then increfs it. A concurrent `free_tool_id` can run `Py_CLEAR` (drop the last reference and free the object) in between, turning the `Py_NewRef` into a use-after-free.
- The clear/free paths calls `_PyMonitoring_ClearToolId`, which internally does a stop-the-world. Is it safe to hold a PyMutex across STW? This is safe, because a thread blocked on `PyMutex_Lock` detaches its thread state, so it is seen as stopped.


<!-- gh-issue-number: gh-154348 -->
* Issue: gh-154348
<!-- /gh-issue-number -->
