### PR TITLE
gh-154460: Do not use wcsftime() on OpenBSD

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-07-22-13-00-00.gh-issue-154460.wCsFtM.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-22-13-00-00.gh-issue-154460.wCsFtM.rst
@@ -1,0 +1,2 @@
+Fix :func:`time.strftime` and :meth:`datetime.datetime.strftime` returning a
+wrong ISO 8601 week number (``%V``) on OpenBSD.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -763,8 +763,9 @@ Other codes may be available on your platform.  See documentation for\n\
 the C library strftime function.\n"
 
 #ifdef HAVE_STRFTIME
-// OpenBSD's wcsftime() computes %V incorrectly: it returns 53 if the ISO 8601
-// week belongs to other year than tm_year.  strftime() is correct.
+// gh-154460: OpenBSD's wcsftime() computes %V incorrectly: it returns 53
+// whenever the ISO 8601 week belongs to a different year than tm_year.
+// strftime() is not affected.
 #ifdef __OpenBSD__
 #  undef HAVE_WCSFTIME
 #endif

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -763,6 +763,12 @@ Other codes may be available on your platform.  See documentation for\n\
 the C library strftime function.\n"
 
 #ifdef HAVE_STRFTIME
+// OpenBSD's wcsftime() computes %V incorrectly: it returns 53 if the ISO 8601
+// week belongs to other year than tm_year.  strftime() is correct.
+#ifdef __OpenBSD__
+#  undef HAVE_WCSFTIME
+#endif
+
 #ifdef HAVE_WCSFTIME
 #define time_char wchar_t
 #define format_time wcsftime


### PR DESCRIPTION
OpenBSD's `wcsftime()` returns 53 for `%V` whenever the ISO 8601 week belongs to other year than `tm_year`, while its `strftime()` is correct. Both carry the same obsolete XPG4-1994 override, but `strftime.c` guards it with `#ifdef XPG4_1994_04_09` (never defined) and `wcsftime.c` lost that guard when it was created in 2011. Reported to bugs@openbsd.org.

`HAVE_WCSFTIME` is used only here, and OpenBSD supports only the C and UTF-8 encodings for `LC_CTYPE`, so decoding the result of `strftime()` with the locale encoding is safe.

Verified on OpenBSD 7.9: `%G-%V` now matches `date.isocalendar()` for all tested dates, and 16 `test_strptime` failures are gone.

<!-- gh-issue-number: gh-154460 -->
* Issue: gh-154460
<!-- /gh-issue-number -->
