### PR TITLE
gh-154465: Add configure flag to exclude emscripten_syscalls.c

### DIFF
--- a/configure
+++ b/configure
@@ -1102,6 +1102,7 @@ enable_framework
 with_app_store_compliance
 enable_wasm_dynamic_linking
 enable_wasm_pthreads
+enable_emscripten_syscalls
 with_suffix
 enable_shared
 with_static_libpython
@@ -1842,6 +1843,10 @@ Optional Features:
                           loader to handle imports
   --enable-wasm-pthreads  Enable pthread emulation for WebAssembly (default is
                           no)
+  --disable-emscripten-syscalls
+                          Disable the Emscripten syscall overrides in
+                          Python/emscripten_syscalls.c (default is enabled for
+                          Emscripten)
   --enable-shared         enable building a shared Python library (default is
                           no)
   --enable-static-libpython-for-interpreter
@@ -7495,6 +7500,30 @@ fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $enable_wasm_pthreads" >&5
 printf "%s\n" "$enable_wasm_pthreads" >&6; }
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for --enable-emscripten-syscalls" >&5
+printf %s "checking for --enable-emscripten-syscalls... " >&6; }
+# Check whether --enable-emscripten-syscalls was given.
+if test ${enable_emscripten_syscalls+y}
+then :
+  enableval=$enable_emscripten_syscalls;
+  case $ac_sys_system in #(
+  Emscripten) :
+     ;; #(
+  *) :
+    as_fn_error $? "--enable-emscripten-syscalls only applies to Emscripten" "$LINENO" 5
+   ;;
+esac
+
+else case e in #(
+  e)
+  enable_emscripten_syscalls=yes
+ ;;
+esac
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $enable_emscripten_syscalls" >&5
+printf "%s\n" "$enable_emscripten_syscalls" >&6; }
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for --with-suffix" >&5
 printf %s "checking for --with-suffix... " >&6; }
@@ -20031,7 +20060,13 @@ PLATFORM_OBJS=
 case $ac_sys_system in #(
   Emscripten) :
 
-    as_fn_append PLATFORM_OBJS ' Python/emscripten_signal.o Python/emscripten_trampoline.o Python/emscripten_trampoline_wasm.o Python/emscripten_syscalls.o'
+    as_fn_append PLATFORM_OBJS ' Python/emscripten_signal.o Python/emscripten_trampoline.o Python/emscripten_trampoline_wasm.o'
+    if test "x$enable_emscripten_syscalls" = xyes
+then :
+
+      as_fn_append PLATFORM_OBJS ' Python/emscripten_syscalls.o'
+
+fi
     as_fn_append PLATFORM_HEADERS ' $(srcdir)/Include/internal/pycore_emscripten_signal.h $(srcdir)/Include/internal/pycore_emscripten_trampoline.h'
    ;; #(
   *) :

--- a/configure.ac
+++ b/configure.ac
@@ -1356,6 +1356,20 @@ AC_ARG_ENABLE([wasm-pthreads],
 ])
 AC_MSG_RESULT([$enable_wasm_pthreads])
 
+AC_MSG_CHECKING([for --enable-emscripten-syscalls])
+AC_ARG_ENABLE([emscripten-syscalls],
+  [AS_HELP_STRING([--disable-emscripten-syscalls],
+                  [Disable the Emscripten syscall overrides in Python/emscripten_syscalls.c (default is enabled for Emscripten)])],
+[
+  AS_CASE([$ac_sys_system],
+    [Emscripten], [],
+    [AC_MSG_ERROR([--enable-emscripten-syscalls only applies to Emscripten])]
+  )
+], [
+  enable_emscripten_syscalls=yes
+])
+AC_MSG_RESULT([$enable_emscripten_syscalls])
+
 AC_MSG_CHECKING([for --with-suffix])
 AC_ARG_WITH([suffix],
             [AS_HELP_STRING([--with-suffix=SUFFIX], [set executable suffix to SUFFIX (default is empty, yes is mapped to '.exe')])],
@@ -5368,7 +5382,10 @@ PLATFORM_OBJS=
 
 AS_CASE([$ac_sys_system],
   [Emscripten], [
-    AS_VAR_APPEND([PLATFORM_OBJS], [' Python/emscripten_signal.o Python/emscripten_trampoline.o Python/emscripten_trampoline_wasm.o Python/emscripten_syscalls.o'])
+    AS_VAR_APPEND([PLATFORM_OBJS], [' Python/emscripten_signal.o Python/emscripten_trampoline.o Python/emscripten_trampoline_wasm.o'])
+    AS_VAR_IF([enable_emscripten_syscalls], [yes], [
+      AS_VAR_APPEND([PLATFORM_OBJS], [' Python/emscripten_syscalls.o'])
+    ])
     AS_VAR_APPEND([PLATFORM_HEADERS], [' $(srcdir)/Include/internal/pycore_emscripten_signal.h $(srcdir)/Include/internal/pycore_emscripten_trampoline.h'])
   ],
 )


### PR DESCRIPTION
Pyodide doesn't want to include emscripten_syscalls.c in the build since it links a different version of it. This adds a configure flag to drop it.

<!-- gh-issue-number: gh-154465 -->
* Issue: gh-154465
<!-- /gh-issue-number -->
