### PR TITLE
[3.14] gh-154272: Skip forkserver tests when the start method is unavailable (GH-154274)

### DIFF
--- a/Lib/test/test_concurrent_futures/util.py
+++ b/Lib/test/test_concurrent_futures/util.py
@@ -138,6 +138,8 @@ class ProcessPoolForkserverMixin(ExecutorMixin):
             self.skipTest("require unix system")
         if support.check_sanitizer(thread=True):
             self.skipTest("TSAN doesn't support threads after fork")
+        if "forkserver" not in multiprocessing.get_all_start_methods():
+            self.skipTest("forkserver start method is not available")
         return super().get_context()
 
     def create_event(self):

--- a/Lib/test/test_multiprocessing_forkserver/__init__.py
+++ b/Lib/test/test_multiprocessing_forkserver/__init__.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import os.path
 import sys
 import unittest
@@ -8,6 +9,11 @@ if support.PGO:
 
 if sys.platform == "win32":
     raise unittest.SkipTest("forkserver is not available on Windows")
+
+# The forkserver start method requires passing file descriptors over a Unix
+# socket, which is not available on every platform (e.g. Solaris/illumos).
+if "forkserver" not in multiprocessing.get_all_start_methods():
+    raise unittest.SkipTest("forkserver start method is not available")
 
 def load_tests(*args):
     return support.load_package_tests(os.path.dirname(__file__), *args)


### PR DESCRIPTION
Manual backport of GH-154274; miss-islington could not apply it cleanly.

The conflict is only in `Lib/test/test_multiprocessing_forkserver/__init__.py`: main has a `support.has_fork_support` guard above the new check, which is not in 3.14. Only the new check is backported.
(cherry picked from commit 13e3f8aa839d71285f3408241b0518da499eac39)

Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>

<!-- gh-issue-number: gh-154272 -->
* Issue: gh-154272
<!-- /gh-issue-number -->
