### PR TITLE
gh-154388: Document Python install variants

### DIFF
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -272,6 +272,25 @@ New runtime versions may be added using ``py install``. One or more tags may be
 specified, and the special tag ``default`` may be used to select the default.
 Ranges are not supported for installation.
 
+CPython publishes multiple runtime variants. For most users,
+``PythonCore`` is recommended and provides the standard CPython runtime.
+
+``PythonTest`` includes the standard runtime together with the test suite
+and debugging symbols. It is intended for contributors or users who need
+these additional files for testing or debugging Python.
+
+``PythonEmbed`` provides a minimal embeddable distribution for
+applications that bundle Python rather than for interactive use.
+
+To see the available runtime variants, run::
+
+   py list --online
+
+To install a specific variant, include it in the tag passed to
+``py install``::
+
+   py install PythonTest\3.14
+
 The ``--source=<URL>`` option allows overriding the online index that is used to
 obtain runtimes. This may be used with an offline index, as shown in
 :ref:`pymanager-offline`.


### PR DESCRIPTION
## Summary

This PR documents the CPython runtime variants available through `py install`.

It adds a short description of the published `PythonCore`, `PythonTest`, and `PythonEmbed` variants to the **Installing runtimes** section of the Windows documentation, clarifying that these are CPython-published runtime variants rather than features of the Python install manager.

## Issue

Closes gh-154388.

## Testing

- Built the documentation successfully with:

  ```bash
  make -C Doc html
  ```

- Verified that the documentation builds successfully with `--fail-on-warning` and that the new content renders correctly in the generated HTML.