### PR TITLE
gh-73458: Fix logging.config.listen() on a host without an IPv4 address

### DIFF
--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -32,6 +32,7 @@ import logging.handlers
 import os
 import queue
 import re
+import socket
 import struct
 import threading
 import traceback
@@ -1004,6 +1005,15 @@ def listen(port=DEFAULT_LOGGING_CONFIG_PORT, verify=None):
 
         def __init__(self, host='localhost', port=DEFAULT_LOGGING_CONFIG_PORT,
                      handler=None, ready=None, verify=None):
+            # The host can have no IPv4 address, for example if "localhost"
+            # is only aliased to ::1.  Leave resolution errors to the server.
+            try:
+                infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+            except OSError:
+                pass
+            else:
+                if not any(info[0] == socket.AF_INET for info in infos):
+                    self.address_family = infos[0][0]
             ThreadingTCPServer.__init__(self, (host, port), handler)
             with logging._lock:
                 self.abort = 0
@@ -1035,9 +1045,14 @@ def listen(port=DEFAULT_LOGGING_CONFIG_PORT, verify=None):
             self.ready = threading.Event()
 
         def run(self):
-            server = self.rcvr(port=self.port, handler=self.hdlr,
-                               ready=self.ready,
-                               verify=self.verify)
+            try:
+                server = self.rcvr(port=self.port, handler=self.hdlr,
+                                   ready=self.ready,
+                                   verify=self.verify)
+            except BaseException:
+                # Do not leave the caller waiting for ready forever.
+                self.ready.set()
+                raise
             if self.port == 0:
                 self.port = server.server_address[1]
             self.ready.set()

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -3765,6 +3765,7 @@ class ConfigDictTest(BaseTest):
             ('ERROR', '2'),
         ], pat=r"^[\w.]+ -> (\w+): (\d+)$")
 
+    @support.requires_working_socket()
     def test_listen_server_error(self):
         # The "ready" event should be set even if the server fails to start.
         t = logging.config.listen(-1)

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -3643,14 +3643,14 @@ class ConfigDictTest(BaseTest):
         # Ask for a randomly assigned port (by using port 0)
         t = logging.config.listen(0, verify)
         t.start()
-        t.ready.wait()
+        self.assertTrue(t.ready.wait(support.LONG_TIMEOUT),
+                        msg='the listener did not start')
         # Now get the port allocated
         port = t.port
         t.ready.clear()
         try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(2.0)
-            sock.connect(('localhost', port))
+            # The server can listen on IPv6, so do not force a family.
+            sock = socket.create_connection(('localhost', port), timeout=2.0)
 
             slen = struct.pack('>L', len(text))
             s = slen + text
@@ -3764,6 +3764,17 @@ class ConfigDictTest(BaseTest):
             ('INFO', '1'),
             ('ERROR', '2'),
         ], pat=r"^[\w.]+ -> (\w+): (\d+)$")
+
+    def test_listen_server_error(self):
+        # The "ready" event should be set even if the server fails to start.
+        t = logging.config.listen(-1)
+        t.daemon = True
+        with threading_helper.catch_threading_exception() as cm:
+            t.start()
+            self.assertTrue(t.ready.wait(support.SHORT_TIMEOUT),
+                            msg='the listener did not report the failure')
+            threading_helper.join_thread(t)
+            self.assertIs(cm.exc_type, OverflowError)
 
     def test_bad_format(self):
         self.assertRaises(ValueError, self.apply_config, self.bad_format)

--- a/Misc/NEWS.d/next/Library/2026-07-22-13-01-24.gh-issue-73458.byxSPi.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-22-13-01-24.gh-issue-73458.byxSPi.rst
@@ -1,0 +1,5 @@
+Fix :func:`logging.config.listen`: it left the caller waiting for the
+``ready`` event forever if the server could not be started,
+for example if the port was invalid or already in use.
+It now also binds to an IPv6 address if the host has no IPv4 address,
+for example if ``localhost`` is only aliased to ``::1``.


### PR DESCRIPTION
`logging.config.listen()` cannot be used on a host without an IPv4 address, and any failure to start the server leaves the caller waiting forever.

The server is created in a thread which set the `ready` event only after a successful start, so if the receiver could not be constructed, the thread died and `t.ready.wait()` blocked forever. This is the hang reported in gh-73458 and gh-82076. It happens for any failure to start, not only on IPv6 hosts: an invalid or already used port hangs the caller too.

`ConfigSocketReceiver` also inherited `address_family = AF_INET` from `ThreadingTCPServer` while binding the name `localhost`, so the bind fails if `localhost` has no IPv4 address. The family is now taken from the resolved address, but only when there is no IPv4 address, so dual-stack hosts keep binding IPv4 as before. Resolution errors are left to the server, so an invalid port still reports the same exception as before.

Verified by patching `socket.getaddrinfo()` so that `localhost` resolves only to `::1`: before the change the client gets `ConnectionRefusedError`, after it the connection is made over `AF_INET6` and the configuration is delivered. With ports `-1`, `65536`, `99999`, `'http'`, `'nosuchservice'`, `None` and `1.5` the raised exception types are unchanged; only the hang is gone.

The test no longer forces `AF_INET` when connecting, and the waits for `ready` now have a timeout, so a regression fails instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-73458 -->
* Issue: gh-73458
<!-- /gh-issue-number -->
<!-- gh-issue-number: gh-82076 -->
* Issue: gh-82076
<!-- /gh-issue-number -->
