### PR TITLE
gh-152685: Apply PEP 479 to StopIteration thrown into a not-yet-started generator

### DIFF
--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -266,6 +266,22 @@ class AsyncGenTest(unittest.TestCase):
                                     'async generator.*StopIteration'):
             to_list(gen())
 
+    def test_async_gen_athrow_stopiteration_not_started(self):
+        # gh-152685: StopIteration and StopAsyncIteration thrown into an
+        # async generator that hasn't started yet are wrapped in a
+        # RuntimeError, like for a started one.
+        async def gen():
+            yield 123
+
+        for exc, msg in [
+            (StopIteration, 'async generator raised StopIteration'),
+            (StopAsyncIteration, 'async generator raised StopAsyncIteration'),
+        ]:
+            with self.subTest(exc=exc):
+                agen = gen()
+                with self.assertRaisesRegex(RuntimeError, msg):
+                    agen.athrow(exc).send(None)
+
     def test_async_gen_exception_07(self):
         def sync_gen():
             try:

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -555,6 +555,17 @@ class CoroutineTest(unittest.TestCase):
 
             run_async(foo())
 
+    def test_throw_stopiteration_not_started(self):
+        # gh-152685: StopIteration thrown into a coroutine that hasn't
+        # started yet is wrapped in a RuntimeError, like for a started one.
+        async def foo():
+            return 1
+
+        coro = foo()
+        with self.assertRaisesRegex(
+                RuntimeError, "coroutine raised StopIteration"):
+            coro.throw(StopIteration)
+
     def test_func_3(self):
         async def foo():
             raise StopIteration

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -898,6 +898,51 @@ class GeneratorThrowTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as cm:
             gen.throw(ValueError)
 
+    def test_throw_stopiteration_not_started(self):
+        # Throwing StopIteration into a not-yet-started generator must be
+        # wrapped in a RuntimeError, the same as for a started one
+        # (PEP 479, gh-152685).
+        def g():
+            yield
+
+        for started in (False, True):
+            with self.subTest(started=started):
+                gen = g()
+                if started:
+                    next(gen)
+                with self.assertRaisesRegex(RuntimeError,
+                                            'generator raised StopIteration'):
+                    gen.throw(StopIteration)
+                # The generator is finished afterwards.
+                self.assertRaises(StopIteration, next, gen)
+
+        # A StopIteration subclass is wrapped too.
+        class MyStop(StopIteration):
+            pass
+        with self.assertRaises(RuntimeError):
+            g().throw(MyStop)
+
+        # The original StopIteration is kept as cause and context.
+        try:
+            g().throw(StopIteration)
+        except RuntimeError as exc:
+            self.assertIs(type(exc.__cause__), StopIteration)
+            self.assertIs(type(exc.__context__), StopIteration)
+            self.assertTrue(exc.__suppress_context__)
+        else:
+            self.fail('RuntimeError not raised')
+
+        # A non-StopIteration exception is still propagated unchanged.
+        with self.assertRaises(ValueError):
+            g().throw(ValueError)
+
+    def test_throw_stopiteration_not_started_genexpr(self):
+        # Same as test_throw_stopiteration_not_started, for a generator
+        # expression (gh-152685).
+        with self.assertRaisesRegex(RuntimeError,
+                                    'generator raised StopIteration'):
+            (x for x in ()).throw(StopIteration)
+
 
 class GeneratorStackTraceTest(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-22-11-04-33.gh-issue-152685.ixWsPB.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-22-11-04-33.gh-issue-152685.ixWsPB.rst
@@ -1,0 +1,5 @@
+Calling ``throw(StopIteration)`` on a generator, generator expression,
+coroutine, or asynchronous generator that has not started running now raises
+:exc:`RuntimeError`, consistent with :pep:`479` and with throwing into an
+already-started generator. Previously the :exc:`StopIteration` escaped
+unchanged. Patch by Joel Walker.

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -315,9 +315,30 @@ gen_send_ex2(PyGenObject *gen, PyObject *arg, PyObject **presult, int exc)
         }
     }
     else {
-        assert(!PyErr_ExceptionMatches(PyExc_StopIteration));
-        assert(!PyAsyncGen_CheckExact(gen) ||
-            !PyErr_ExceptionMatches(PyExc_StopAsyncIteration));
+        /* The frame propagated an exception. A StopIteration (or, in an async
+         * generator, a StopAsyncIteration) raised inside the frame is normally
+         * turned into a RuntimeError by the frame's own PEP 479 handler. That
+         * handler does not cover the prologue where a not-yet-started generator
+         * resumes, so throwing such an exception into one reaches here
+         * unconverted (gh-152685). Apply the conversion so PEP 479 still
+         * holds. */
+        const char *msg = NULL;
+        if (_PyErr_ExceptionMatches(tstate, PyExc_StopIteration)) {
+            msg = "generator raised StopIteration";
+            if (PyAsyncGen_CheckExact(gen)) {
+                msg = "async generator raised StopIteration";
+            }
+            else if (PyCoro_CheckExact(gen)) {
+                msg = "coroutine raised StopIteration";
+            }
+        }
+        else if (PyAsyncGen_CheckExact(gen) &&
+                 _PyErr_ExceptionMatches(tstate, PyExc_StopAsyncIteration)) {
+            msg = "async generator raised StopAsyncIteration";
+        }
+        if (msg != NULL) {
+            _PyErr_FormatFromCauseTstate(tstate, PyExc_RuntimeError, "%s", msg);
+        }
     }
 
     *presult = result;


### PR DESCRIPTION
`gen.throw(StopIteration)` on a generator that hasn't started yet lets the StopIteration escape unchanged instead of converting it to RuntimeError. A debug build trips the `!PyErr_ExceptionMatches(PyExc_StopIteration)` assert in `gen_send_ex2`; a release build silently violates PEP 479 (the issue shows a transaction manager committing where it should roll back).

Root cause: PEP 479 is implemented by a bytecode handler whose exception table covers the generator body but not the prologue. A generator created by `RETURN_GENERATOR` resumes at the following `POP_TOP`, so a throw into it faults at `instr_ptr - 1`, the `RETURN_GENERATOR` slot, before the handler's range. Extending the table doesn't work cleanly: the handler records one unwind depth, which differs between the prologue and the body (and between generator functions and generator expressions), and covering `RETURN_GENERATOR` would also cover it during the call that creates the generator.

Instead, convert at the point the exception would otherwise escape. When a generator frame propagates a StopIteration (or, for an async generator, a StopAsyncIteration), `gen_send_ex2` raises RuntimeError with the original chained as cause and context, matching the in-body handler. This path is only reachable via the throw-into-unstarted case: a started generator's own handler converts first, and `gen_close` never enters an unstarted frame. Tests cover generators, generator expressions, coroutines, and async generators, and check that a non-StopIteration throw still propagates unchanged.

Fixes #152685


<!-- gh-issue-number: gh-152685 -->
* Issue: gh-152685
<!-- /gh-issue-number -->
