### PR TITLE
gh-154431: Use existing `runtime->audit_hooks.mutex` instead of a new one

### DIFF
--- a/Include/internal/pycore_interp_structs.h
+++ b/Include/internal/pycore_interp_structs.h
@@ -977,7 +977,6 @@ struct _is {
     struct _obmalloc_state *obmalloc;
 
     PyObject *audit_hooks;
-    PyMutex audit_hooks_mutex;
     PyType_WatchCallback type_watchers[TYPE_MAX_WATCHERS];
     PyCode_WatchCallback code_watchers[CODE_MAX_WATCHERS];
     PyContext_WatchCallback context_watchers[CONTEXT_MAX_WATCHERS];

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -578,7 +578,6 @@ init_interpreter(PyInterpreterState *interp,
     llist_init(&interp->mem_free_queue.head);
     llist_init(&interp->asyncio_tasks_head);
     interp->asyncio_tasks_lock = (PyMutex){0};
-    interp->audit_hooks_mutex = (PyMutex){0};
     for (int i = 0; i < _PY_MONITORING_UNGROUPED_EVENTS; i++) {
         interp->monitors.tools[i] = 0;
     }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -537,7 +537,7 @@ sys_addaudithook_impl(PyObject *module, PyObject *hook)
     }
 
     PyInterpreterState *interp = tstate->interp;
-    PyMutex mutex = interp->audit_hooks_mutex;
+    PyMutex mutex = interp->runtime->audit_hooks.mutex;
     PyMutex_Lock(&mutex);
 
     if (interp->audit_hooks == NULL) {


### PR DESCRIPTION


<!-- gh-issue-number: gh-154431 -->
* Issue: gh-154431
<!-- /gh-issue-number -->
