### PR TITLE
gh-153903: wrap_dll_function: copy doc, etc from wrapped stub

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -708,9 +708,7 @@ Specifying function pointers using type annotations
 
       @wrap_dll_function(dll_to_wrap)
       def function_ptr_name(arg_name: ctypes_type, ...) -> ctypes_type:
-         """Optional docstring."""
-         # There should be no body
-         pass
+         """Optional docstring. There should be no function body."""
 
    The body of the decorated function is ignored, and any parameters that are
    missing type annotations are skipped. The names of the parameters are ignored

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -708,6 +708,7 @@ Specifying function pointers using type annotations
 
       @wrap_dll_function(dll_to_wrap)
       def function_ptr_name(arg_name: ctypes_type, ...) -> ctypes_type:
+         """Optional docstring."""
          # There should be no body
          pass
 

--- a/Lib/ctypes/util.py
+++ b/Lib/ctypes/util.py
@@ -590,6 +590,8 @@ def wrap_dll_function(dll):
 
         ptr.restype = restype
         ptr.argtypes = tuple(annotations.values())
+        functools.update_wrapper(ptr, func, updated=())
+
         return ptr
 
     return decorator

--- a/Lib/test/test_ctypes/test_funcptr.py
+++ b/Lib/test/test_ctypes/test_funcptr.py
@@ -134,12 +134,14 @@ class CFuncPtrTestCase(unittest.TestCase, StructCheckMixin):
     def test_wrap_dll_function(self):
         @wrap_dll_function(ctypes.pythonapi)
         def PyObject_GetAttr(op: ctypes.py_object, attr: ctypes.py_object) -> ctypes.py_object:
+            """Call the PythonAPI function underlying getattr"""
             pass
 
         class Foo:
             a = "abc"
 
         self.assertEqual(PyObject_GetAttr(Foo, "a"), "abc")
+        self.assertEqual(PyObject_GetAttr.__doc__, "Call the PythonAPI function underlying getattr")
 
         with self.assertRaises(AttributeError):
             @wrap_dll_function(ctypes.pythonapi)


### PR DESCRIPTION
Discussed https://github.com/python/cpython/issues/153903#issuecomment-5039230052, it is a nice quality of life feature if docstrings from the user-written stub are also copied over.

This calls `functools.update_wrapper`, similar to the `ctypes.util.struct` decorator that calls `functools.wraps`


cc @ZeroIntensity 

<!-- gh-issue-number: gh-153903 -->
* Issue: gh-153903
<!-- /gh-issue-number -->
