### PR TITLE
gh-59060: Support IPv6 in logging.handlers.DatagramHandler

### DIFF
--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -594,6 +594,9 @@ over UDP sockets.
       If ``port`` is specified as ``None``, a Unix domain socket is created
       using the value in ``host`` - otherwise, a UDP socket is created.
 
+   .. versionchanged:: next
+      Added support for IPv6.
+
    .. method:: emit()
 
       Pickles the record's attribute dictionary and writes it to the socket in

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -349,6 +349,11 @@ logging
   before the rotation interval expires.
   (Contributed by Iván Márton and Serhiy Storchaka in :gh:`84649`.)
 
+* :class:`~logging.handlers.DatagramHandler` now supports IPv6.
+  Previously it always created an IPv4 socket, so sending to an IPv6 address
+  failed and the log record was silently lost.
+  (Contributed by Serhiy Storchaka in :gh:`59060`.)
+
 
 lzma
 ----

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -758,6 +758,16 @@ class DatagramHandler(SocketHandler):
             family = socket.AF_UNIX
         else:
             family = socket.AF_INET
+            # The host can have no IPv4 address, for example if it is an
+            # IPv6 address.  Leave resolution errors to sendto().
+            try:
+                infos = socket.getaddrinfo(self.host, self.port,
+                                           type=socket.SOCK_DGRAM)
+            except OSError:
+                pass
+            else:
+                if not any(info[0] == family for info in infos):
+                    family = infos[0][0]
         s = socket.socket(family, socket.SOCK_DGRAM)
         return s
 

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -1982,7 +1982,7 @@ class DatagramHandlerTest(BaseTest):
         server.ready.wait()
         hcls = logging.handlers.DatagramHandler
         if isinstance(server.server_address, tuple):
-            self.sock_hdlr = hcls('localhost', server.port)
+            self.sock_hdlr = hcls(self.address[0], server.port)
         else:
             self.sock_hdlr = hcls(server.server_address, None)
         self.log_output = ''
@@ -2015,11 +2015,28 @@ class DatagramHandlerTest(BaseTest):
             self.skipTest(self.server_exception)
         logger = logging.getLogger("udp")
         logger.error("spam")
-        self.handled.wait()
+        self.handled.wait(support.LONG_TIMEOUT)
         self.handled.clear()
         logger.error("eggs")
-        self.handled.wait()
+        self.handled.wait(support.LONG_TIMEOUT)
         self.assertEqual(self.log_output, "spam\neggs\n")
+
+@unittest.skipUnless(socket_helper.IPV6_ENABLED,
+                     'IPv6 support required for this test.')
+class IPv6DatagramHandlerTest(DatagramHandlerTest):
+
+    """Test for DatagramHandler with IPv6 host."""
+
+    server_class = TestUDPServer
+    address = ('::1', 0)
+
+    def setUp(self):
+        self.server_class.address_family = socket.AF_INET6
+        super().setUp()
+
+    def tearDown(self):
+        self.server_class.address_family = socket.AF_INET
+        super().tearDown()
 
 @unittest.skipUnless(hasattr(socket, "AF_UNIX"), "Unix sockets required")
 class UnixDatagramHandlerTest(DatagramHandlerTest):

--- a/Misc/NEWS.d/next/Library/2026-07-22-16-20-17.gh-issue-59060.1nZ8hJ.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-22-16-20-17.gh-issue-59060.1nZ8hJ.rst
@@ -1,0 +1,4 @@
+:class:`logging.handlers.DatagramHandler` now supports IPv6:
+it creates an IPv6 socket if the host has no IPv4 address.
+Previously it always created an IPv4 socket,
+so the log records were silently lost.


### PR DESCRIPTION
`DatagramHandler` always created an IPv4 socket, so it could not send to an IPv6 address.

Sending to `::1` failed with `gaierror(-9, 'Address family for hostname not supported')`, and since `emit()` passes such errors to `handleError()`, the log record was silently lost. This is why the problem went unnoticed for so long.

The socket family is now taken from the resolved address, but only if the host has no IPv4 address, so on dual-stack hosts an IPv4 socket is still created as before. Resolution errors are left to `sendto()`.

`SocketHandler` (which uses `socket.create_connection()`) and `SysLogHandler` (which iterates over `socket.getaddrinfo()` results) already support IPv6, so `DatagramHandler` was the only remaining gap.

The new `IPv6DatagramHandlerTest` mirrors the existing `IPv6SysLogHandlerTest`; it fails without the fix and passes with it. The waits in `DatagramHandlerTest` got a timeout, because otherwise a failure hangs the test instead of reporting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-59060 -->
* Issue: gh-59060
<!-- /gh-issue-number -->
