### PR TITLE
gh-154272: Skip more forkserver tests if the start method is unavailable

### DIFF
--- a/Lib/test/test_concurrent_futures/test_init.py
+++ b/Lib/test/test_concurrent_futures/test_init.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import multiprocessing
 import queue
 import time
 import unittest
@@ -147,8 +148,8 @@ class FailingInitializerResourcesTest(unittest.TestCase):
         self._test(ProcessPoolSpawnFailingInitializerTest)
 
     @support.skip_if_sanitizer("TSAN doesn't support threads after fork", thread=True)
-    @unittest.skipIf(sys.platform == "cygwin",
-                     "Forkserver is not available on Cygwin")
+    @unittest.skipUnless("forkserver" in multiprocessing.get_all_start_methods(),
+                         "forkserver start method is not available")
     def test_forkserver(self):
         self._test(ProcessPoolForkserverFailingInitializerTest)
 

--- a/Lib/test/test_profiling/test_tracing_profiler.py
+++ b/Lib/test/test_profiling/test_tracing_profiler.py
@@ -1,4 +1,5 @@
 """Test suite for the cProfile module."""
+import multiprocessing
 import sys
 import unittest
 
@@ -220,8 +221,8 @@ class TestCommandLine(unittest.TestCase):
         # gh-140729: test use Process in cProfile.
         self._test_process_run_pickle('spawn')
 
-    @unittest.skipIf(sys.platform == 'win32',
-                     "No 'forkserver' start method on Windows")
+    @unittest.skipUnless("forkserver" in multiprocessing.get_all_start_methods(),
+                         "forkserver start method is not available")
     def test_process_forkserver_pickle(self):
         # gh-140729: test use Process in cProfile.
         self._test_process_run_pickle('forkserver')


### PR DESCRIPTION
`test_forkserver` and `test_process_forkserver_pickle` were guarded by platform name (Cygwin and Windows) rather than by whether the `forkserver` start method exists, so they still failed on illumos.

Verified there, where `get_all_start_methods()` returns `['spawn', 'fork']`: both now skip, and the full suite goes from 5 failing files to 3.

<!-- gh-issue-number: gh-154272 -->
* Issue: gh-154272
<!-- /gh-issue-number -->
