### PR TITLE
gh-154502: Disable junk filling in the OpenBSD allocator in test_capi

### DIFF
--- a/Lib/test/test_capi/test_mem.py
+++ b/Lib/test/test_capi/test_mem.py
@@ -24,9 +24,12 @@ class PyMemDebugTests(unittest.TestCase):
             out = assert_python_failure(
                 '-c', code,
                 PYTHONMALLOC=self.PYTHONMALLOC,
-                # FreeBSD: instruct jemalloc to not fill freed() memory
-                # with junk byte 0x5a, see JEMALLOC(3)
+                # Instruct the system allocator to not fill freed() memory
+                # with junk bytes:
+                # FreeBSD: jemalloc, see JEMALLOC(3).
                 MALLOC_CONF="junk:false",
+                # OpenBSD: see MALLOC.CONF(5).
+                MALLOC_OPTIONS="j",
             )
         stderr = out.err
         return stderr.decode('ascii', 'replace')
@@ -102,7 +105,9 @@ class PyMemDebugTests(unittest.TestCase):
         assert_python_ok(
             '-c', code,
             PYTHONMALLOC=self.PYTHONMALLOC,
+            # See the comment in check() above.
             MALLOC_CONF="junk:false",
+            MALLOC_OPTIONS="j",
         )
 
     def test_pyobject_null_is_freed(self):


### PR DESCRIPTION
OpenBSD's allocator fills freed memory with junk by default and is configured by `MALLOC_OPTIONS`, not by jemalloc's `MALLOC_CONF`, so the pattern written by the debug hooks did not survive `free()` and `test_pyobject_freed_is_freed` failed.

Verified on OpenBSD 7.9: `test_capi` FAILURE -> SUCCESS.

<!-- gh-issue-number: gh-154502 -->
* Issue: gh-154502
<!-- /gh-issue-number -->
