### PR TITLE
gh-82535: Ignore address resolution failure in SysLogHandler constructor

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -901,7 +901,11 @@ class SysLogHandler(logging.Handler):
         self.socktype = socktype
         self.timeout = timeout
         self.socket = None
-        self.createSocket()
+        # The address is resolved again when emitting an event.
+        try:
+            self.createSocket()
+        except socket.gaierror:
+            pass
 
     def _connect_unixsocket(self, address):
         use_socktype = self.socktype

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -2156,6 +2156,24 @@ class IPv6SysLogHandlerTest(SysLogHandlerTest):
         super(IPv6SysLogHandlerTest, self).tearDown()
 
 @support.requires_working_socket()
+class UnresolvableSysLogAddressTest(BaseTest):
+
+    """Test for SysLogHandler with a temporarily unresolvable address."""
+
+    @patch('socket.getaddrinfo')
+    def test_unresolvable_address(self, mock_getaddrinfo):
+        # The address can be unresolvable when the handler is created.
+        mock_getaddrinfo.side_effect = socket.gaierror
+        hdlr = logging.handlers.SysLogHandler(('localhost', 514))
+        self.addCleanup(hdlr.close)
+        self.assertIsNone(hdlr.socket)
+        # It is resolved again when a record is emitted.
+        calls = mock_getaddrinfo.call_count
+        with support.captured_stderr():
+            hdlr.emit(logging.makeLogRecord({'msg': 'sp\xe4m'}))
+        self.assertGreater(mock_getaddrinfo.call_count, calls)
+
+@support.requires_working_socket()
 @threading_helper.requires_working_threading()
 class HTTPHandlerTest(BaseTest):
     """Test for HTTPHandler."""

--- a/Misc/NEWS.d/next/Library/2026-07-22-19-21-20.gh-issue-82535.METFqd.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-22-19-21-20.gh-issue-82535.METFqd.rst
@@ -1,0 +1,3 @@
+:class:`logging.handlers.SysLogHandler` no longer fails
+if the address cannot be resolved when the handler is created.
+The address is resolved again when a record is emitted.


### PR DESCRIPTION
`SysLogHandler` resolves the address in the constructor, so creating a handler fails if the address is temporarily unresolvable, for example if DNS is not available yet.

Only the resolution failure is ignored, and the address is resolved again when a record is emitted. `TimeoutError` and `ConnectionRefusedError` are still raised from the constructor, so the behaviour added in gh-126400 is not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-82535 -->
* Issue: gh-82535
<!-- /gh-issue-number -->
