### PR TITLE
[3.14] gh-154272: Skip more forkserver tests if the start method is unavailable (GH-154499)

### DIFF
--- a/Lib/test/test_concurrent_futures/test_init.py
+++ b/Lib/test/test_concurrent_futures/test_init.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import multiprocessing
 import queue
 import time
 import unittest
@@ -144,6 +145,8 @@ class FailingInitializerResourcesTest(unittest.TestCase):
         self._test(ProcessPoolSpawnFailingInitializerTest)
 
     @support.skip_if_sanitizer("TSAN doesn't support threads after fork", thread=True)
+    @unittest.skipUnless("forkserver" in multiprocessing.get_all_start_methods(),
+                         "forkserver start method is not available")
     def test_forkserver(self):
         self._test(ProcessPoolForkserverFailingInitializerTest)
 


### PR DESCRIPTION
Manual backport of GH-154499; the Cygwin guard it replaces is main-only, so it does not apply cleanly.

On this branch `test_process_forkserver_pickle` does not exist, so only the `test_init.py` change is backported.
(cherry picked from commit a2a846678e54b1b5defdccd451c573679094ff02)

Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>

<!-- gh-issue-number: gh-154272 -->
* Issue: gh-154272
<!-- /gh-issue-number -->
