### PR TITLE
gh-153852: Fix data race in hash cal for Decimal

### DIFF
--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -31,6 +31,7 @@
 
 #include <Python.h>
 #include "pycore_object.h"        // _PyObject_VisitType()
+#include "pycore_pyatomic_ft_wrappers.h"  // FT_ATOMIC_LOAD_SSIZE_RELAXED() and FT_ATOMIC_STORE_SSIZE_RELAXED()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_tuple.h"         // _PyTuple_FromPair
 #include "pycore_typeobject.h"
@@ -5921,11 +5922,13 @@ static Py_hash_t
 dec_hash(PyObject *op)
 {
     PyDecObject *self = _PyDecObject_CAST(op);
-    if (self->hash == -1) {
-        self->hash = _dec_hash(self);
+    Py_hash_t hash = FT_ATOMIC_LOAD_SSIZE_RELAXED(self->hash);
+    if (hash == -1) {
+        hash = _dec_hash(self);
+        FT_ATOMIC_STORE_SSIZE_RELAXED(self->hash, hash);
     }
 
-    return self->hash;
+    return hash;
 }
 
 /*[clinic input]


### PR DESCRIPTION
As reported in [TSAN0005 in #153852](https://gist.github.com/devdanzin/4ece3c7d20810f1ad33e2b204ccf33e4), there is a harmless data race in decimal's hash calculation. On a no-GIL build, two threads hashing the same decimal object for the first time concurrently produce a data race on `self->hash`. Fortunately, this is harmless because it is value-benign—both threads compute the exact same hash value. However, it is indeed an unsynchronized read-then-write, and ThreadSanitizer will report this issue.

A similar thing occurs in Unicode's hash calculation, which also uses a caching mechanism similar to decimal. In PR #134892, @colesbury mentioned:
> Hash can be computed and assigned concurrently so to avoid a data race in free-threaded build: 
> #ifdef Py_GIL_DISABLED
>        return _Py_atomic_load_ssize_relaxed(&_PyASCIIObject_CAST(op)->hash);

Perhaps decimal could adopt the same approach here. But of course, since this potential data race is value-benign, I'm totally OK if we just leave this as is.

Reproduce:
- ./configure --disable-gil --with-thread-sanitizer
- make -j
- TSAN_OPTIONS="halt_on_error=1 symbolize=1 history_size=4"  ./python repro_dec_hash.py
- [repro_dec_hash.py](https://github.com/user-attachments/files/30290632/repro_dec_hash.py)


<!-- gh-issue-number: gh-153852 -->
* Issue: gh-153852
<!-- /gh-issue-number -->
