### PR TITLE
gh-138252: Document OpenSSL version requirements for the ssl signature-algorithm APIs

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -230,6 +230,9 @@ Signature algorithms
    :meth:`SSLContext.set_client_sigalgs` and
    :meth:`SSLContext.set_server_sigalgs` methods.
 
+   This function requires OpenSSL 3.4 or later; it raises
+   :exc:`NotImplementedError` when linked against an older version.
+
    .. versionadded:: 3.15
 
 
@@ -1323,6 +1326,9 @@ SSL sockets also have the following additional methods and attributes:
    authentication on this connection, or ``None`` if no connection has been
    established or client authentication didn't occur.
 
+   This method requires OpenSSL 3.5 or later; it raises
+   :exc:`NotImplementedError` when linked against an older version.
+
    .. versionadded:: 3.15
 
 .. method:: SSLSocket.server_sigalg()
@@ -1330,6 +1336,9 @@ SSL sockets also have the following additional methods and attributes:
    Return the signature algorithm used by the server to complete the TLS
    handshake on this connection, or ``None`` if no connection has been
    established or the cipher suite has no signature.
+
+   This method requires OpenSSL 3.5 or later; it raises
+   :exc:`NotImplementedError` when linked against an older version.
 
    .. versionadded:: 3.15
 


### PR DESCRIPTION
This is a small documentation follow-up to the signature-algorithm support added in gh-138252.

Three of those APIs require a specific OpenSSL version, but the reference docs don't mention it. `ssl.get_sigalgs()` requires OpenSSL 3.4 or later, and `SSLSocket.client_sigalg()` and `SSLSocket.server_sigalg()` require 3.5 or later. On an older version each raises `NotImplementedError`. The requirement is already stated in the What's New in 3.15 entry and enforced in the C code (`Modules/_ssl.c`), so this just brings the three reference entries in line.

A companion PR, #154518, adds the same kind of note to `SSLSocket.group()` and `SSLContext.get_groups()`.

This is documentation only, so there is no news entry.
