### PR TITLE
gh-154525: Fix curses getcchar() failure on ncurses older than 6.3

### DIFF
--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -151,6 +151,16 @@ typedef chtype attr_t;           /* No attr_t type is available */
 #define _CURSES_PAIR_CONTENT_FUNC       pair_content
 #endif  /* _NCURSES_EXTENDED_COLOR_FUNCS */
 
+/* getcchar() returned ERR for a non-NULL opts before ncurses 6.3 (patch
+   20210116, https://invisible-island.net/ncurses/), so read a cchar_t's color
+   pair through the plain short slot rather than the extended-color opts slot on
+   older libraries.  setcchar() is unaffected: it accepts opts on every version. */
+#if _NCURSES_EXTENDED_COLOR_FUNCS && NCURSES_VERSION_PATCH+0 >= 20210116
+#define _NCURSES_GETCCHAR_EXTENDED_PAIR 1
+#else
+#define _NCURSES_GETCCHAR_EXTENDED_PAIR 0
+#endif
+
 typedef struct {
     PyObject *error;                // curses exception type
     PyTypeObject *window_type;      // exposed by PyCursesWindow_Type
@@ -763,7 +773,7 @@ curses_getcchar(const cchar_t *wcval, wchar_t *wstr, attr_t *attrs, int *pair)
     /* getcchar() is not guaranteed to write the text of an empty cell, so make
        the output an empty string by default. */
     wstr[0] = L'\0';
-#if _NCURSES_EXTENDED_COLOR_FUNCS
+#if _NCURSES_GETCCHAR_EXTENDED_PAIR
     int rtn = getcchar(wcval, wstr, attrs, &spair, pair);
 #else
     int rtn = getcchar(wcval, wstr, attrs, &spair, NULL);

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -151,16 +151,6 @@ typedef chtype attr_t;           /* No attr_t type is available */
 #define _CURSES_PAIR_CONTENT_FUNC       pair_content
 #endif  /* _NCURSES_EXTENDED_COLOR_FUNCS */
 
-/* getcchar() returned ERR for a non-NULL opts before ncurses 6.3 (patch
-   20210116, https://invisible-island.net/ncurses/), so read a cchar_t's color
-   pair through the plain short slot rather than the extended-color opts slot on
-   older libraries.  setcchar() is unaffected: it accepts opts on every version. */
-#if _NCURSES_EXTENDED_COLOR_FUNCS && NCURSES_VERSION_PATCH+0 >= 20210116
-#define _NCURSES_GETCCHAR_EXTENDED_PAIR 1
-#else
-#define _NCURSES_GETCCHAR_EXTENDED_PAIR 0
-#endif
-
 typedef struct {
     PyObject *error;                // curses exception type
     PyTypeObject *window_type;      // exposed by PyCursesWindow_Type
@@ -773,7 +763,9 @@ curses_getcchar(const cchar_t *wcval, wchar_t *wstr, attr_t *attrs, int *pair)
     /* getcchar() is not guaranteed to write the text of an empty cell, so make
        the output an empty string by default. */
     wstr[0] = L'\0';
-#if _NCURSES_GETCCHAR_EXTENDED_PAIR
+    /* getcchar()'s opts slot returns the extended color pair, but ncurses
+       returned ERR for a non-NULL opts until 6.3 (patch 20210116). */
+#if _NCURSES_EXTENDED_COLOR_FUNCS && NCURSES_VERSION_PATCH+0 >= 20210116
     int rtn = getcchar(wcval, wstr, attrs, &spair, pair);
 #else
     int rtn = getcchar(wcval, wstr, attrs, &spair, NULL);


### PR DESCRIPTION
`getcchar()` rejected a non-NULL `opts` argument before ncurses 6.3 (patch 20210116). `curses_getcchar()` passes the color pair through `opts`, so on ncurses 6.1 and 6.2 every wide-character cell read failed with `getcchar() returned ERR`, breaking `complexchar`, `in_wch()`, `getbkgrnd()`, and (via gh-153395) headless `test_curses`.

Read the pair through the short slot on older ncurses. main-only -- the `opts` path and `complexchar` are 3.16-only.


<!-- gh-issue-number: gh-154525 -->
* Issue: gh-154525
<!-- /gh-issue-number -->
