### PR TITLE
gh-79366: Fix a race condition when removing a logging handler

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1709,7 +1709,11 @@ class Logger(Filterer):
         """
         with _lock:
             if hdlr in self.handlers:
-                self.handlers.remove(hdlr)
+                # Replace the list instead of mutating it in place, so that
+                # callHandlers() can iterate it without a lock (gh-79366).
+                handlers = self.handlers.copy()
+                handlers.remove(hdlr)
+                self.handlers = handlers
 
     def hasHandlers(self):
         """

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -814,6 +814,23 @@ class HandlerTest(BaseTest):
 
             support.wait_process(pid, exitcode=0)
 
+    def test_remove_handler_while_emitting(self):
+        # Removing a handler while callHandlers() iterates over the handlers
+        # should not cause the following handlers to be skipped (gh-79366).
+        logger = logging.Logger('test_remove_handler_while_emitting')
+        calls = []
+        class RemovingHandler(logging.Handler):
+            def emit(self, record):
+                calls.append('removing')
+                logger.removeHandler(self)
+        class CountingHandler(logging.Handler):
+            def emit(self, record):
+                calls.append('counting')
+        logger.addHandler(RemovingHandler())
+        logger.addHandler(CountingHandler())
+        logger.error('spam')
+        self.assertEqual(calls, ['removing', 'counting'])
+
 
 class BadStream(object):
     def write(self, data):

--- a/Misc/NEWS.d/next/Library/2026-07-23-06-53-01.gh-issue-79366.3gMT7I.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-23-06-53-01.gh-issue-79366.3gMT7I.rst
@@ -1,0 +1,3 @@
+Fixed a race condition in :mod:`logging`:
+if a handler was removed while a record was being emitted,
+the following handlers of the same logger could be skipped.


### PR DESCRIPTION
`removeHandler()` removed the handler from the list in place. If a handler was removed while `callHandlers()` was iterating over the same list, whether from another thread or from within an `emit()` call, the following handlers of the same logger could be skipped, so records were not passed to them.

`removeHandler()` now replaces the list with a copy instead of mutating it in place, so `callHandlers()` always iterates over a consistent list without needing to acquire the lock. Adding a handler already appends to the end, so it cannot cause a handler to be skipped and is left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-79366 -->
* Issue: gh-79366
<!-- /gh-issue-number -->
