### PR TITLE
gh-154539: Use atomic read and write with `should_auto_add_history`

### DIFF
--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -841,7 +841,7 @@ readline_set_auto_history_impl(PyObject *module,
                                int _should_auto_add_history)
 /*[clinic end generated code: output=619c6968246fd82b input=3d413073a1a03355]*/
 {
-    should_auto_add_history = _should_auto_add_history;
+    FT_ATOMIC_STORE_INT_RELAXED(should_auto_add_history, _should_auto_add_history);
     Py_RETURN_NONE;
 }
 
@@ -1590,7 +1590,7 @@ call_readline(FILE *sys_stdin, FILE *sys_stdout, const char *prompt)
 
     /* we have a valid line */
     n = strlen(p);
-    if (should_auto_add_history && n > 0) {
+    if (FT_ATOMIC_LOAD_INT_RELAXED(should_auto_add_history) && n > 0) {
         const char *line;
         int length = _py_get_history_length_lock_held();
         if (length > 0) {


### PR DESCRIPTION
Fix the variable race problem [TSAN-0025](https://gist.github.com/devdanzin/f0b4f8859da46e985f23aa9cadaaa4c9) in gh-153852

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-154539 -->
* Issue: gh-154539
<!-- /gh-issue-number -->
