### PR TITLE
gh-154481: Fix reading multi-frame Zstandard members in zipfile

### DIFF
--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -715,6 +715,36 @@ class ZstdTestsWithSourceFile(AbstractTestsWithSourceFile,
                               unittest.TestCase):
     compression = zipfile.ZIP_ZSTANDARD
 
+    def test_read_multiframe(self):
+        first = b'first frame' * 20
+        second = b'second frame' * 20
+        data = first + second
+
+        class MultiframeCompressor:
+            def compress(self, value):
+                value = bytes(value)
+                return (zipfile.zstd.compress(value[:len(first)]) +
+                        zipfile.zstd.compress(value[len(first):]))
+
+            def flush(self):
+                return b''
+
+        archive = io.BytesIO()
+        with mock.patch.object(zipfile, '_get_compressor',
+                               return_value=MultiframeCompressor()):
+            with zipfile.ZipFile(archive, 'w', self.compression) as zipfp:
+                zipfp.writestr('multiframe', data)
+
+        with zipfile.ZipFile(archive) as zipfp:
+            self.assertEqual(zipfp.read('multiframe'), data)
+
+        # Exercise a frame boundary between two reads from the archive.
+        with zipfile.ZipFile(archive) as zipfp:
+            with zipfp.open('multiframe') as fp:
+                fp.MIN_READ_SIZE = 1
+                self.assertEqual(b''.join(iter(lambda: fp.read(1), b'')),
+                                 data)
+
 class AbstractTestZip64InSmallFiles:
     # These tests test the ZIP64 functionality without using large files,
     # see test_zipfile64 for proper tests.

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -1186,6 +1186,13 @@ class ZipExtFile(io.BufferedIOBase):
             data = self._decompressor.unconsumed_tail
             if n > len(data):
                 data += self._read2(n - len(data))
+        elif (self._compress_type == ZIP_ZSTANDARD and
+              self._decompressor.eof):
+            # Continue with the next Zstandard frame.
+            data = self._decompressor.unused_data
+            self._decompressor = _get_decompressor(self._compress_type)
+            if not data:
+                data = self._read2(n)
         else:
             data = self._read2(n)
 
@@ -1199,6 +1206,10 @@ class ZipExtFile(io.BufferedIOBase):
                          not self._decompressor.unconsumed_tail)
             if self._eof:
                 data += self._decompressor.flush()
+        elif self._compress_type == ZIP_ZSTANDARD:
+            data = self._decompressor.decompress(data)
+            self._eof = (self._compress_left <= 0 and
+                         not self._decompressor.unused_data)
         else:
             data = self._decompressor.decompress(data)
             self._eof = self._decompressor.eof or self._compress_left <= 0

--- a/Misc/NEWS.d/next/Library/2026-07-23-19-51-05.gh-issue-154481.6cFDFx.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-23-19-51-05.gh-issue-154481.6cFDFx.rst
@@ -1,0 +1,2 @@
+Fix :mod:`zipfile` to correctly read Zstandard-compressed archive members
+that could previously be truncated or incorrectly rejected.


### PR DESCRIPTION
## Summary

Fix `zipfile` reading of Zstandard-compressed archive members containing multiple concatenated frames.

`ZstdDecompressor` intentionally stops after one frame and stores any remaining compressed input in `unused_data`. `ZipExtFile` previously treated the decompressor's `eof` state as the end of the entire ZIP member. As a result, later frames were ignored, which could truncate the returned data or cause an incorrect CRC-32 error.

## Fix

When a Zstandard frame ends, `ZipExtFile` now:

1. Retrieves any remaining compressed input from `unused_data`.
2. Creates a new `ZstdDecompressor` for the next frame.
3. Continues with `unused_data`, or reads more compressed data when the frame boundary falls between archive reads.
4. Marks the ZIP member as finished only after all compressed input and buffered unused data have been consumed.

This keeps the single-frame semantics of `ZstdDecompressor` unchanged and handles concatenated frames at the `zipfile` streaming layer.

## Tests

The regression test creates a valid Zstandard-compressed ZIP member containing two frames and covers:

- Both frames being available in the same archive read.
- A frame boundary occurring between two archive reads.


<!-- gh-issue-number: gh-154481 -->
* Issue: gh-154481
<!-- /gh-issue-number -->
