### PR TITLE
gh-84532: Reopen the socket in SocketHandler.send() when sending fails

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -657,15 +657,20 @@ class SocketHandler(logging.Handler):
         This function allows for partial sends which can happen when the
         network is busy.
         """
-        if self.sock is None:
-            self.createSocket()
-        #self.sock can be None either because we haven't reached the retry
-        #time yet, or because we have reached the retry time and retried,
-        #but are still unable to connect.
-        if self.sock:
+        # Reopen the socket once if sending fails, e.g. the connection was
+        # closed after a timeout, so the record is not lost (gh-84532).
+        for attempt in range(2):
+            if self.sock is None:
+                self.createSocket()
+                # self.sock can be None either because we haven't reached the
+                # retry time yet, or because we have reached the retry time
+                # and retried, but are still unable to connect.
+                if self.sock is None:
+                    return
             try:
                 self.sock.sendall(s)
-            except OSError: #pragma: no cover
+                return
+            except OSError:
                 self.sock.close()
                 self.sock = None  # so we can call createSocket next time
 

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -1953,6 +1953,7 @@ class SocketHandlerTest(BaseTest):
 
         def recv_message():
             conn, _ = server.accept()
+            self.addCleanup(conn.close)
             chunk = conn.recv(4)
             slen = struct.unpack(">L", chunk)[0]
             chunk = b''

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -38,6 +38,7 @@ import os
 import queue
 import random
 import re
+import select
 import shutil
 import socket
 import struct
@@ -1939,6 +1940,43 @@ class SocketHandlerTest(BaseTest):
         self.assertGreater(self.sock_hdlr.retryTime, now)
         time.sleep(self.sock_hdlr.retryTime - now + 0.001)
         self.root_logger.error('Nor this')
+
+    def test_reconnect(self):
+        # If the server closes the connection, the record whose send fails is
+        # not dropped, but resent on a reopened socket (gh-84532).
+        server = socket.create_server(('localhost', 0))
+        self.addCleanup(server.close)
+        server.settimeout(support.LONG_TIMEOUT)
+        port = server.getsockname()[1]
+        hdlr = logging.handlers.SocketHandler('localhost', port)
+        self.addCleanup(hdlr.close)
+
+        def recv_message():
+            conn, _ = server.accept()
+            chunk = conn.recv(4)
+            slen = struct.unpack(">L", chunk)[0]
+            chunk = b''
+            while len(chunk) < slen:
+                chunk += conn.recv(slen - len(chunk))
+            return conn, logging.makeLogRecord(pickle.loads(chunk)).msg
+
+        # Connect and receive the first record.
+        hdlr.handle(logging.makeLogRecord({'msg': 'spam'}))
+        conn, msg = recv_message()
+        self.assertEqual(msg, 'spam')
+
+        # Close the connection on the server side.  After a peer close the
+        # first send still succeeds (the data is lost when the reset arrives),
+        # so a throwaway send is used up here to make the next send fail.
+        conn.close()
+        # Wait until the close is received, so the sends below are ordered.
+        select.select([hdlr.sock], [], [], support.LONG_TIMEOUT)
+        hdlr.sock.sendall(b'\x00\x00\x00\x00')
+
+        # The next send fails and the record is resent on a new connection.
+        hdlr.handle(logging.makeLogRecord({'msg': 'eggs'}))
+        conn, msg = recv_message()
+        self.assertEqual(msg, 'eggs')
 
 
 @unittest.skipUnless(hasattr(socket, "AF_UNIX"), "Unix sockets required")

--- a/Misc/NEWS.d/next/Library/2026-07-23-08-46-07.gh-issue-84532.NSN7fJ.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-23-08-46-07.gh-issue-84532.NSN7fJ.rst
@@ -1,0 +1,2 @@
+:class:`logging.handlers.SocketHandler` now loses fewer log records when the
+connection to the server is closed, for example after an idle timeout.


### PR DESCRIPTION
`SocketHandler.send()` dropped the record whose sending failed and reconnected only on the next record, so after the connection was closed (for example after an idle timeout) it lost more records than necessary.

It now reopens the socket and sends the record again, like `SysLogHandler.emit()` has done for the Unix socket since 2.5.

This does not make `SocketHandler` lossless over TCP: the first record sent after the connection is closed still succeeds locally and is lost when the reset arrives, which cannot be detected. But it stops dropping the following record, whose send actually fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-84532 -->
* Issue: gh-84532
<!-- /gh-issue-number -->
