### PR TITLE
gh-135683: Honor raiseExceptions when opening the file fails in FileHandler

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1263,7 +1263,12 @@ class FileHandler(StreamHandler):
         """
         if self.stream is None:
             if self.mode != 'w' or not self._closed:
-                self.stream = self._open()
+                # Report an error while opening the file, like emit errors.
+                try:
+                    self.stream = self._open()
+                except Exception:
+                    self.handleError(record)
+                    return
         if self.stream:
             StreamHandler.emit(self, record)
 

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -563,8 +563,13 @@ class WatchedFileHandler(logging.FileHandler):
         If underlying file has changed, reopen the file before emitting the
         record to it.
         """
-        self.reopenIfNeeded()
-        logging.FileHandler.emit(self, record)
+        # Report an error while reopening the file, like emit errors.
+        try:
+            self.reopenIfNeeded()
+        except Exception:
+            self.handleError(record)
+        else:
+            logging.FileHandler.emit(self, record)
 
 
 class SocketHandler(logging.Handler):

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -6416,6 +6416,38 @@ class FileHandlerTest(BaseFileTest):
         with open(self.fn) as fp:
             self.assertEqual(fp.read().strip(), '1')
 
+    def test_emit_open_error(self):
+        # gh-135683: an error while opening the file in emit() respects
+        # raiseExceptions, like an error during the actual write.
+        d = tempfile.mkdtemp()
+        self.addCleanup(os_helper.rmtree, d)
+        r = logging.makeLogRecord({})
+        old_raise = logging.raiseExceptions
+        self.addCleanup(setattr, logging, 'raiseExceptions', old_raise)
+
+        # FileHandler with delay: the failing open happens in emit().
+        fh = logging.FileHandler(os.path.join(d, 'missing', 'a.log'),
+                                 encoding='utf-8', delay=True)
+        self.addCleanup(fh.close)
+        # WatchedFileHandler: reopenIfNeeded() fails after the dir is removed.
+        subdir = os.path.join(d, 'sub')
+        os.mkdir(subdir)
+        wfh = logging.handlers.WatchedFileHandler(
+            os.path.join(subdir, 'b.log'), encoding='utf-8')
+        self.addCleanup(wfh.close)
+        os_helper.rmtree(subdir)
+
+        for h in (fh, wfh):
+            logging.raiseExceptions = True
+            with support.captured_stderr() as stderr:
+                h.handle(r)
+                self.assertIn('\nFileNotFoundError:', stderr.getvalue())
+
+            logging.raiseExceptions = False
+            with support.captured_stderr() as stderr:
+                h.handle(r)
+                self.assertEqual('', stderr.getvalue())
+
 class RotatingFileHandlerTest(BaseFileTest):
     def test_should_not_rollover(self):
         # If file is empty rollover never occurs

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -6416,37 +6416,45 @@ class FileHandlerTest(BaseFileTest):
         with open(self.fn) as fp:
             self.assertEqual(fp.read().strip(), '1')
 
-    def test_emit_open_error(self):
+    def _check_open_error(self, h):
         # gh-135683: an error while opening the file in emit() respects
         # raiseExceptions, like an error during the actual write.
-        d = tempfile.mkdtemp()
-        self.addCleanup(os_helper.rmtree, d)
         r = logging.makeLogRecord({})
         old_raise = logging.raiseExceptions
         self.addCleanup(setattr, logging, 'raiseExceptions', old_raise)
 
+        logging.raiseExceptions = True
+        with support.captured_stderr() as stderr:
+            h.handle(r)
+        self.assertIn('\nFileNotFoundError:', stderr.getvalue())
+
+        logging.raiseExceptions = False
+        with support.captured_stderr() as stderr:
+            h.handle(r)
+        self.assertEqual('', stderr.getvalue())
+
+    def test_emit_open_error(self):
         # FileHandler with delay: the failing open happens in emit().
-        fh = logging.FileHandler(os.path.join(d, 'missing', 'a.log'),
-                                 encoding='utf-8', delay=True)
-        self.addCleanup(fh.close)
+        d = tempfile.mkdtemp()
+        self.addCleanup(os_helper.rmtree, d)
+        h = logging.FileHandler(os.path.join(d, 'missing', 'a.log'),
+                                encoding='utf-8', delay=True)
+        self.addCleanup(h.close)
+        self._check_open_error(h)
+
+    @unittest.skipIf(os.name == 'nt',
+                     'WatchedFileHandler not appropriate for Windows.')
+    def test_emit_reopen_error(self):
         # WatchedFileHandler: reopenIfNeeded() fails after the dir is removed.
+        d = tempfile.mkdtemp()
+        self.addCleanup(os_helper.rmtree, d)
         subdir = os.path.join(d, 'sub')
         os.mkdir(subdir)
-        wfh = logging.handlers.WatchedFileHandler(
+        h = logging.handlers.WatchedFileHandler(
             os.path.join(subdir, 'b.log'), encoding='utf-8')
-        self.addCleanup(wfh.close)
+        self.addCleanup(h.close)
         os_helper.rmtree(subdir)
-
-        for h in (fh, wfh):
-            logging.raiseExceptions = True
-            with support.captured_stderr() as stderr:
-                h.handle(r)
-                self.assertIn('\nFileNotFoundError:', stderr.getvalue())
-
-            logging.raiseExceptions = False
-            with support.captured_stderr() as stderr:
-                h.handle(r)
-                self.assertEqual('', stderr.getvalue())
+        self._check_open_error(h)
 
 class RotatingFileHandlerTest(BaseFileTest):
     def test_should_not_rollover(self):

--- a/Misc/NEWS.d/next/Library/2026-07-23-14-13-39.gh-issue-135683.droBu7.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-23-14-13-39.gh-issue-135683.droBu7.rst
@@ -1,0 +1,3 @@
+:class:`logging.FileHandler` and :class:`logging.handlers.WatchedFileHandler`
+now honor :data:`logging.raiseExceptions` for errors that occur while opening
+the file, like for other errors during logging.


### PR DESCRIPTION
`FileHandler` and `WatchedFileHandler` opened the file outside the `try` block that reports errors via `handleError()`, so an error while opening the file was raised instead of being handled, ignoring `raiseExceptions`. The rotating handlers were not affected, as `BaseRotatingHandler.emit()` wraps the whole body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- gh-issue-number: gh-135683 -->
* Issue: gh-135683
<!-- /gh-issue-number -->
