### PR TITLE
gh-154525: Skip ncurses find_pair()/alloc_pair() reuse checks before 6.3

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -1997,12 +1997,15 @@ class TestCurses(unittest.TestCase):
         pair = curses.alloc_pair(fg, bg)
         self.assertGreater(pair, 0)
         self.assertEqual(curses.pair_content(pair), (fg, bg))
-        # The same combination of colors reuses the same pair.
-        self.assertEqual(curses.alloc_pair(fg, bg), pair)
-        self.assertEqual(curses.find_pair(fg, bg), pair)
-        # Once freed, the pair is no longer found.
-        self.assertIsNone(curses.free_pair(pair))
-        self.assertEqual(curses.find_pair(fg, bg), -1)
+        if getattr(curses, 'ncurses_version', (6, 3)) >= (6, 3):
+            # The same combination of colors reuses the same pair.
+            self.assertEqual(curses.alloc_pair(fg, bg), pair)
+            self.assertEqual(curses.find_pair(fg, bg), pair)
+            # Once freed, the pair is no longer found.
+            self.assertIsNone(curses.free_pair(pair))
+            self.assertEqual(curses.find_pair(fg, bg), -1)
+        else:
+            self.assertIsNone(curses.free_pair(pair))
 
         # Error paths.
         for color in self.bad_colors2():


### PR DESCRIPTION
`find_pair()` and pair reuse in `alloc_pair()` were fixed in ncurses 6.3 (patch 20200411). On earlier versions `find_pair()` returns -1 and `alloc_pair()` allocates a fresh pair instead of reusing an equal one, so `test_dynamic_color_pairs` failed on ncurses 6.1 and 6.2.

Gate the reuse and find assertions on `ncurses_version >= (6, 3)`; older versions still exercise `free_pair()`.

Verified on ncursesw 6.1 (previously failing) and 6.6.

Follow-up of #154526.

<!-- gh-issue-number: gh-154525 -->
* Issue: gh-154525
<!-- /gh-issue-number -->
