### PR TITLE
gh-154546: Validate cookie key before applying in BaseCookie.load()

### DIFF
--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -618,6 +618,8 @@ class BaseCookie(dict):
                 else:
                     parsed_items.append((TYPE_ATTRIBUTE, key, _unquote(value)))
             elif value is not None:
+                if not _is_legal_key(key):
+                    raise CookieError('Illegal key %r' % (key,))
                 parsed_items.append((TYPE_KEYVALUE, key, self.value_decode(value)))
                 morsel_seen = True
             else:

--- a/Lib/test/test_http_cookies.py
+++ b/Lib/test/test_http_cookies.py
@@ -320,6 +320,12 @@ class CookieTests(unittest.TestCase):
         with self.assertRaises(cookies.CookieError):
             C.load(rawdata)
 
+    def test_illegal_key_no_partial_state(self):
+        C = cookies.SimpleCookie()
+        with self.assertRaises(cookies.CookieError):
+            C.load("a=1; b,c=2; d=3")
+        self.assertEqual(len(C), 0)
+
     def test_comment_quoting(self):
         c = cookies.SimpleCookie()
         c['foo'] = '\N{COPYRIGHT SIGN}'

--- a/Misc/NEWS.d/next/Library/2026-07-18-12-00-00.gh-issue-154546.CkPrt5.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-18-12-00-00.gh-issue-154546.CkPrt5.rst
@@ -1,0 +1,4 @@
+Validate cookie key characters during parsing in
+:meth:`http.cookies.BaseCookie.load` so that an illegal key raises
+:exc:`~http.cookies.CookieError` before any cookies are applied.  Patch by
+tonghuaroot.


### PR DESCRIPTION
Move the `_is_legal_key()` check from the apply phase (`Morsel.set()`) into the parse phase of `__parse_string`, so an illegal key raises `CookieError` before any cookies are written to the jar.

Related to gh-84183 (raise-vs-silent inconsistency) but orthogonal: this fixes partial state when an error IS raised.
