### PR TITLE
gh-154551: Fix ctypes.util.find_library() in non-UTF-8 locales

### DIFF
--- a/Lib/ctypes/util.py
+++ b/Lib/ctypes/util.py
@@ -429,8 +429,7 @@ elif os.name == "posix":
             result = None
             try:
                 p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                     stderr=subprocess.PIPE,
-                                     universal_newlines=True)
+                                     stderr=subprocess.PIPE)
                 out, _ = p.communicate()
                 res = re.findall(expr, os.fsdecode(out))
                 for file in res:

--- a/Misc/NEWS.d/next/Library/2026-07-23-19-45-00.gh-issue-154551.Ct7pL9.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-23-19-45-00.gh-issue-154551.Ct7pL9.rst
@@ -1,0 +1,1 @@
+Fix :func:`ctypes.util.find_library` returning ``None`` in non-UTF-8 locales.


### PR DESCRIPTION
`_findLib_ld()` ran `ld` with `universal_newlines=True`, so `communicate()` decoded its output in the locale encoding and failed on a localized diagnostic on stderr. The exception was swallowed, so `find_library()` returned `None`. The stderr is discarded and the stdout is already decoded with `os.fsdecode()`, so the output is now read as bytes.

<!-- gh-issue-number -->
* Issue: gh-154551
<!-- /gh-issue-number -->
