### PR TITLE
gh-154570: Fix itertools.accumulate() silently corrupting its total on reentrancy

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -158,9 +158,6 @@ class TestBasicOps(unittest.TestCase):
             list(accumulate([10, 20], 100))
 
     def test_accumulate_reenter(self):
-        # A source iterable (or binop) that calls back into next() on the
-        # same accumulate object must not be allowed to silently corrupt
-        # the running total.
         class I:
             count = 0
             def __iter__(self):
@@ -172,6 +169,15 @@ class TestBasicOps(unittest.TestCase):
                 return self.count
 
         it = accumulate(I())
+        self.assertEqual(next(it), 1)
+        with self.assertRaisesRegex(RuntimeError, "accumulate"):
+            next(it)
+
+    def test_accumulate_reenter_func(self):
+        def reenter(a, b):
+            return next(it)
+
+        it = accumulate([1, 2, 3], reenter)
         self.assertEqual(next(it), 1)
         with self.assertRaisesRegex(RuntimeError, "accumulate"):
             next(it)

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -157,6 +157,25 @@ class TestBasicOps(unittest.TestCase):
         with self.assertRaises(TypeError):
             list(accumulate([10, 20], 100))
 
+    def test_accumulate_reenter(self):
+        # A source iterable (or binop) that calls back into next() on the
+        # same accumulate object must not be allowed to silently corrupt
+        # the running total.
+        class I:
+            count = 0
+            def __iter__(self):
+                return self
+            def __next__(self):
+                self.count += 1
+                if self.count == 2:
+                    return next(it)
+                return self.count
+
+        it = accumulate(I())
+        self.assertEqual(next(it), 1)
+        with self.assertRaisesRegex(RuntimeError, "accumulate"):
+            next(it)
+
     def test_batched(self):
         self.assertEqual(list(batched('ABCDEFG', 3)),
                              [('A', 'B', 'C'), ('D', 'E', 'F'), ('G',)])

--- a/Misc/NEWS.d/next/Library/2026-07-23-22-00-00.gh-issue-154570.accumulate-reentrancy.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-23-22-00-00.gh-issue-154570.accumulate-reentrancy.rst
@@ -1,6 +1,2 @@
 Fix :func:`itertools.accumulate` silently corrupting its running total
-when the source iterable (or the ``func`` callable) re-enters the same
-:func:`!accumulate` iterator via a nested call to :func:`!next`. It now
-raises :exc:`RuntimeError` on re-entry instead of producing wrong,
-silently-dropped values, matching the existing behavior of
-:func:`itertools.tee`.
+on reentrancy; it now raises :exc:`RuntimeError` instead.

--- a/Misc/NEWS.d/next/Library/2026-07-23-22-00-00.gh-issue-154570.accumulate-reentrancy.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-23-22-00-00.gh-issue-154570.accumulate-reentrancy.rst
@@ -1,0 +1,6 @@
+Fix :func:`itertools.accumulate` silently corrupting its running total
+when the source iterable (or the ``func`` callable) re-enters the same
+:func:`!accumulate` iterator via a nested call to :func:`!next`. It now
+raises :exc:`RuntimeError` on re-entry instead of producing wrong,
+silently-dropped values, matching the existing behavior of
+:func:`itertools.tee`.

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3079,7 +3079,7 @@ typedef struct {
     PyObject *binop;
     PyObject *initial;
     itertools_state *state;
-    int running;
+    uint8_t running;
 } accumulateobject;
 
 #define accumulateobject_CAST(op)   ((accumulateobject *)(op))

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3079,6 +3079,7 @@ typedef struct {
     PyObject *binop;
     PyObject *initial;
     itertools_state *state;
+    int running;
 } accumulateobject;
 
 #define accumulateobject_CAST(op)   ((accumulateobject *)(op))
@@ -3120,6 +3121,7 @@ itertools_accumulate_impl(PyTypeObject *type, PyObject *iterable,
     lz->it = it;
     lz->initial = Py_XNewRef(initial);
     lz->state = find_state_by_type(type);
+    lz->running = 0;
     return (PyObject *)lz;
 }
 
@@ -3160,12 +3162,21 @@ accumulate_next_lock_held(PyObject *op)
         lz->initial = Py_NewRef(Py_None);
         return Py_NewRef(lz->total);
     }
-    val = (*Py_TYPE(lz->it)->tp_iternext)(lz->it);
-    if (val == NULL)
+    if (lz->running) {
+        PyErr_SetString(PyExc_RuntimeError,
+                         "cannot re-enter the accumulate iterator");
         return NULL;
+    }
+    lz->running = 1;
+    val = (*Py_TYPE(lz->it)->tp_iternext)(lz->it);
+    if (val == NULL) {
+        lz->running = 0;
+        return NULL;
+    }
 
     if (lz->total == NULL) {
         lz->total = Py_NewRef(val);
+        lz->running = 0;
         return lz->total;
     }
 
@@ -3174,6 +3185,7 @@ accumulate_next_lock_held(PyObject *op)
     else
         newtotal = PyObject_CallFunctionObjArgs(lz->binop, lz->total, val, NULL);
     Py_DECREF(val);
+    lz->running = 0;
     if (newtotal == NULL)
         return NULL;
 


### PR DESCRIPTION
A source iterable or `func=` callable that calls back into `next()` on
the same `accumulate` object mid-step silently corrupted the running
total instead of erroring. Fixes gh-154570.

Adds a `running` guard field to `accumulateobject`, mirroring the
existing pattern already used by `teedataobject` for the identical
class of bug (see `teedataobject_getitem_lock_held`). `accumulate`
now raises `RuntimeError("cannot re-enter the accumulate iterator")`
on reentrant access instead of silently corrupting state, matching
`tee`'s existing behavior for the same defect class.

Adds a regression test (`test_accumulate_reenter`) in the same style
as the existing `test_tee_reenter`.