### PR TITLE
gh-154756: Fix data race in list.sort()

### DIFF
--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -1653,25 +1653,25 @@ typedef struct {
 Py_LOCAL_INLINE(void)
 sortslice_copy(sortslice *s1, Py_ssize_t i, sortslice *s2, Py_ssize_t j)
 {
-    FT_ATOMIC_STORE_PTR_RELEASE(s1->keys[i], s2->keys[j]);
+    s1->keys[i] = s2->keys[j];
     if (s1->values != NULL)
-        FT_ATOMIC_STORE_PTR_RELEASE(s1->values[i], s2->values[j]);
+        s1->values[i] = s2->values[j];
 }
 
 Py_LOCAL_INLINE(void)
 sortslice_copy_incr(sortslice *dst, sortslice *src)
 {
-    FT_ATOMIC_STORE_PTR_RELEASE(*dst->keys++, *src->keys++);
+    *dst->keys++ = *src->keys++;
     if (dst->values != NULL)
-        FT_ATOMIC_STORE_PTR_RELEASE(*dst->values++, *src->values++);
+        *dst->values++ = *src->values++;
 }
 
 Py_LOCAL_INLINE(void)
 sortslice_copy_decr(sortslice *dst, sortslice *src)
 {
-    FT_ATOMIC_STORE_PTR_RELEASE(*dst->keys--, *src->keys--);
+    *dst->keys-- = *src->keys--;
     if (dst->values != NULL)
-        FT_ATOMIC_STORE_PTR_RELEASE(*dst->values--, *src->values--);
+        *dst->values-- = *src->values--;
 }
 
 
@@ -1855,22 +1855,22 @@ binarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok)
         for (M = ok - 1; M >= 0; --M) {
             k = ISLT(pivot, a[M]);
             if (k < 0) {
-                FT_ATOMIC_STORE_PTR_RELEASE(a[M + 1], pivot);
+                a[M + 1] = pivot;
                 if (has_values)
-                    FT_ATOMIC_STORE_PTR_RELEASE(v[M + 1], vpivot);
+                    v[M + 1] = vpivot;
                 goto fail;
             }
             else if (k) {
-                FT_ATOMIC_STORE_PTR_RELEASE(a[M + 1], a[M]);
+                a[M + 1] = a[M];
                 if (has_values)
-                    FT_ATOMIC_STORE_PTR_RELEASE(v[M + 1], v[M]);
+                    v[M + 1] = v[M];
             }
             else
                 break;
         }
-        FT_ATOMIC_STORE_PTR_RELEASE(a[M + 1], pivot);
+        a[M + 1] = pivot;
         if (has_values)
-            FT_ATOMIC_STORE_PTR_RELEASE(v[M + 1], vpivot);
+            v[M + 1] = vpivot;
     }
 #else // binary insertion sort
     Py_ssize_t L, R;
@@ -1915,13 +1915,13 @@ binarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok)
            usually moving many slots. Years later: under Visual Studio 2022,
            memmove seems just slightly slower than doing it "by hand". */
         for (M = ok; M > L; --M)
-            FT_ATOMIC_STORE_PTR_RELEASE(a[M], a[M - 1]);
-        FT_ATOMIC_STORE_PTR_RELEASE(a[L], pivot);
+            a[M] = a[M - 1];
+        a[L] = pivot;
         if (has_values) {
             pivot = v[ok];
             for (M = ok; M > L; --M)
-                FT_ATOMIC_STORE_PTR_RELEASE(v[M], v[M - 1]);
-            FT_ATOMIC_STORE_PTR_RELEASE(v[L], pivot);
+                v[M] = v[M - 1];
+            v[L] = pivot;
         }
     }
 #endif // pick binary or regular insertion sort

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2968,6 +2968,22 @@ list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse)
     saved_ob_size = Py_SIZE(self);
     saved_ob_item = self->ob_item;
     saved_allocated = self->allocated;
+#ifdef Py_GIL_DISABLED
+    // We can't use in-place sort for free-threaded, because list can be concurrently 
+    // read by other threads, leading to data race.
+    PyObject **orig_ob_item = saved_ob_item;
+    if (saved_ob_size >= 2 && _PyObject_GC_IS_SHARED(self)) {
+        // sort only take place when size >= 2, see `nremaining`
+        _PyListArray *sort_array = list_allocate_array((size_t)saved_allocated);
+        if (sort_array == NULL) {
+            PyErr_NoMemory();
+            return NULL;
+        }
+        memcpy(sort_array->ob_item, saved_ob_item,
+               (size_t)saved_ob_size * sizeof(PyObject *));
+        saved_ob_item = sort_array->ob_item;
+    }
+#endif
     Py_SET_SIZE(self, 0);
     FT_ATOMIC_STORE_PTR_RELEASE(self->ob_item, NULL);
     self->allocated = -1; /* any operation will reset it to >= 0 */
@@ -3202,6 +3218,13 @@ keyfunc_fail:
 #endif
         free_list_items(final_ob_item, use_qsbr);
     }
+#ifdef Py_GIL_DISABLED
+    if (saved_ob_item != orig_ob_item) {
+        // Only release memory, don't decref, because elements are owned by the published sorted array now.
+        ensure_shared_on_resize(self);
+        free_list_items(orig_ob_item, _PyObject_GC_IS_SHARED(self));
+    }
+#endif
     return Py_XNewRef(result);
 }
 #undef IFLT

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -1653,25 +1653,25 @@ typedef struct {
 Py_LOCAL_INLINE(void)
 sortslice_copy(sortslice *s1, Py_ssize_t i, sortslice *s2, Py_ssize_t j)
 {
-    s1->keys[i] = s2->keys[j];
+    FT_ATOMIC_STORE_PTR_RELEASE(s1->keys[i], s2->keys[j]);
     if (s1->values != NULL)
-        s1->values[i] = s2->values[j];
+        FT_ATOMIC_STORE_PTR_RELEASE(s1->values[i], s2->values[j]);
 }
 
 Py_LOCAL_INLINE(void)
 sortslice_copy_incr(sortslice *dst, sortslice *src)
 {
-    *dst->keys++ = *src->keys++;
+    FT_ATOMIC_STORE_PTR_RELEASE(*dst->keys++, *src->keys++);
     if (dst->values != NULL)
-        *dst->values++ = *src->values++;
+        FT_ATOMIC_STORE_PTR_RELEASE(*dst->values++, *src->values++);
 }
 
 Py_LOCAL_INLINE(void)
 sortslice_copy_decr(sortslice *dst, sortslice *src)
 {
-    *dst->keys-- = *src->keys--;
+    FT_ATOMIC_STORE_PTR_RELEASE(*dst->keys--, *src->keys--);
     if (dst->values != NULL)
-        *dst->values-- = *src->values--;
+        FT_ATOMIC_STORE_PTR_RELEASE(*dst->values--, *src->values--);
 }
 
 
@@ -1855,22 +1855,22 @@ binarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok)
         for (M = ok - 1; M >= 0; --M) {
             k = ISLT(pivot, a[M]);
             if (k < 0) {
-                a[M + 1] = pivot;
+                FT_ATOMIC_STORE_PTR_RELEASE(a[M + 1], pivot);
                 if (has_values)
-                    v[M + 1] = vpivot;
+                    FT_ATOMIC_STORE_PTR_RELEASE(v[M + 1], vpivot);
                 goto fail;
             }
             else if (k) {
-                a[M + 1] = a[M];
+                FT_ATOMIC_STORE_PTR_RELEASE(a[M + 1], a[M]);
                 if (has_values)
-                    v[M + 1] = v[M];
+                    FT_ATOMIC_STORE_PTR_RELEASE(v[M + 1], v[M]);
             }
             else
                 break;
         }
-        a[M + 1] = pivot;
+        FT_ATOMIC_STORE_PTR_RELEASE(a[M + 1], pivot);
         if (has_values)
-            v[M + 1] = vpivot;
+            FT_ATOMIC_STORE_PTR_RELEASE(v[M + 1], vpivot);
     }
 #else // binary insertion sort
     Py_ssize_t L, R;
@@ -1915,13 +1915,13 @@ binarysort(MergeState *ms, const sortslice *ss, Py_ssize_t n, Py_ssize_t ok)
            usually moving many slots. Years later: under Visual Studio 2022,
            memmove seems just slightly slower than doing it "by hand". */
         for (M = ok; M > L; --M)
-            a[M] = a[M - 1];
-        a[L] = pivot;
+            FT_ATOMIC_STORE_PTR_RELEASE(a[M], a[M - 1]);
+        FT_ATOMIC_STORE_PTR_RELEASE(a[L], pivot);
         if (has_values) {
             pivot = v[ok];
             for (M = ok; M > L; --M)
-                v[M] = v[M - 1];
-            v[L] = pivot;
+                FT_ATOMIC_STORE_PTR_RELEASE(v[M], v[M - 1]);
+            FT_ATOMIC_STORE_PTR_RELEASE(v[L], pivot);
         }
     }
 #endif // pick binary or regular insertion sort


### PR DESCRIPTION
This PR try to fix #154756, it uses RCU (read-copy-update) method:
1. copy `ob_item` to a newly allocated memory address
2. do the in place sort normally
3. swap the sorted array back into `ob_item` at the end.

Testing
- The reproducer now runs clean.
- PASS ./python -m test test_sort test_list
- Benchmark `sortperf.py` shows no perf regression


<!-- gh-issue-number: gh-154756-->
* Issue: gh-154756
<!-- /gh-issue-number -->
