### PR TITLE
[3.13] gh-80678: Document the preferred delimiters of csv.Sniffer (GH-154336)

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -314,6 +314,11 @@ The :mod:`csv` module defines the following classes:
       is given, it is interpreted as a string containing possible valid
       delimiter characters.
 
+      If several combinations fit the sample equally well ---
+      for example if both ``','`` and ``';'`` split every row consistently ---
+      the delimiters ``','``, ``'\t'``, ``';'``, ``' '`` and ``':'``
+      are preferred, in this order,
+      no matter how many times each of them occurs.
 
    .. method:: has_header(sample)
 

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -314,7 +314,7 @@ The :mod:`csv` module defines the following classes:
       is given, it is interpreted as a string containing possible valid
       delimiter characters.
 
-      If several combinations fit the sample equally well ---
+      If several delimiters fit the sample equally well ---
       for example if both ``','`` and ``';'`` split every row consistently ---
       the delimiters ``','``, ``'\t'``, ``';'``, ``' '`` and ``':'``
       are preferred, in this order,

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -245,7 +245,7 @@ class Sniffer:
         """
         Returns a dialect (or None) corresponding to the sample
 
-        If several combinations fit the sample equally well, the
+        If several delimiters fit the sample equally well, the
         delimiters listed in the preferred attribute are preferred, in
         that order, no matter how many times each of them occurs.
         """

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -244,6 +244,10 @@ class Sniffer:
     def sniff(self, sample, delimiters=None):
         """
         Returns a dialect (or None) corresponding to the sample
+
+        If several combinations fit the sample equally well, the
+        delimiters listed in the preferred attribute are preferred, in
+        that order, no matter how many times each of them occurs.
         """
 
         quotechar, doublequote, delimiter, skipinitialspace = \


### PR DESCRIPTION


The delimiters which win when several combinations fit the sample equally well were not documented.
(cherry picked from commit 79cdcee308c6612edd6d1ca972342e2a088b6b4e)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-80678 -->
* Issue: gh-80678
<!-- /gh-issue-number -->
