### PR TITLE
gh-154592: Fix test_peg_generator in non-UTF-8 locales with a non-ASCII work dir

### DIFF
--- a/Lib/test/test_peg_generator/test_c_parser.py
+++ b/Lib/test/test_peg_generator/test_c_parser.py
@@ -100,14 +100,17 @@ class TestCParser(unittest.TestCase):
 
         with contextlib.ExitStack() as stack:
             python_exe = stack.enter_context(support.setup_venv_with_pip_setuptools("venv"))
-            platlib_path = subprocess.check_output(
-                [python_exe, "-c", "import sysconfig; print(sysconfig.get_path('platlib'))"],
-                text=True,
-            ).strip()
-            purelib_path = subprocess.check_output(
-                [python_exe, "-c", "import sysconfig; print(sysconfig.get_path('purelib'))"],
-                text=True,
-            ).strip()
+
+            def get_sysconfig_path(name):
+                # Force UTF-8 to emit the non-ASCII venv path in any locale.
+                return subprocess.check_output(
+                    [python_exe, "-X", "utf8", "-c",
+                     f"import sysconfig; print(sysconfig.get_path({name!r}))"],
+                    encoding="utf-8",
+                ).strip()
+
+            platlib_path = get_sysconfig_path("platlib")
+            purelib_path = get_sysconfig_path("purelib")
             stack.enter_context(import_helper.DirsOnSysPath(platlib_path, purelib_path))
             cls.addClassCleanup(stack.pop_all().close)
 


### PR DESCRIPTION
`setUpClass` creates a venv in the regrtest working directory — whose name has a non-ASCII suffix (`os_helper.FS_NONASCII`, `æ` on Windows) — then runs a child printing `sysconfig.get_path()`.  In a non-UTF-8 locale whose encoding cannot encode that character (e.g. cp932 or cp1251 on Windows), the child fails to encode the path.  Force UTF-8 for the child.

<!-- gh-issue-number -->
* Issue: gh-154592
<!-- /gh-issue-number -->
