### PR TITLE
gh-154596: Fix configparser write() losing unnamed-section items to DEFAULT

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -971,11 +971,11 @@ class RawConfigParser(MutableMapping):
             d = " {} ".format(self._delimiters[0])
         else:
             d = self._delimiters[0]
+        if UNNAMED_SECTION in self._sections and self._sections[UNNAMED_SECTION]:
+            self._write_section(fp, UNNAMED_SECTION, self._sections[UNNAMED_SECTION].items(), d, unnamed=True)
         if self._defaults:
             self._write_section(fp, self.default_section,
                                     self._defaults.items(), d)
-        if UNNAMED_SECTION in self._sections and self._sections[UNNAMED_SECTION]:
-            self._write_section(fp, UNNAMED_SECTION, self._sections[UNNAMED_SECTION].items(), d, unnamed=True)
 
         for section in self._sections:
             if section is UNNAMED_SECTION:

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -2250,6 +2250,17 @@ class SectionlessTestCase(unittest.TestCase):
         cfg.write(output)
         self.assertEqual(output.getvalue(), 'a = 1\n\n')
 
+    def test_write_roundtrip_with_default(self):
+        US = configparser.UNNAMED_SECTION
+        cfg = configparser.ConfigParser(allow_unnamed_section=True)
+        cfg.read_string('key1 = val1\n[DEFAULT]\ndkey = dval\n[sect1]\nkey2 = val2\n')
+        out = io.StringIO()
+        cfg.write(out)
+        cfg2 = configparser.ConfigParser(allow_unnamed_section=True)
+        cfg2.read_string(out.getvalue())
+        self.assertIn('key1', cfg2[US])
+        self.assertNotIn('key1', cfg2.defaults())
+
     def test_disabled_error(self):
         with self.assertRaises(configparser.MissingSectionHeaderError):
             configparser.ConfigParser().read_string("a = 1")

--- a/Misc/NEWS.d/next/Library/2026-07-24-20-00-00.gh-issue-154596.CfgWrt.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-24-20-00-00.gh-issue-154596.CfgWrt.rst
@@ -1,0 +1,3 @@
+Fix :meth:`configparser.ConfigParser.write` outputting unnamed-section
+items after the ``[DEFAULT]`` header, causing them to be absorbed into
+DEFAULT on re-read.  Patch by tonghuaroot.


### PR DESCRIPTION
`write()` outputs `UNNAMED_SECTION` items after the `[DEFAULT]` header. Since unnamed items have no section header, they get absorbed into DEFAULT on re-read. Fix: write unnamed items before `[DEFAULT]`.


<!-- gh-issue-number: gh-154596 -->
* Issue: gh-154596
<!-- /gh-issue-number -->
