### PR TITLE
gh-130821: Improve error messages for magic methods returning wrong type

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7950,16 +7950,16 @@ _PyObject_GetNewArguments(PyObject *obj, PyObject **args, PyObject **kwargs)
             return -1;
         }
         if (!PyTuple_Check(newargs)) {
-            PyErr_Format(PyExc_TypeError,
-                         "__getnewargs_ex__ should return a tuple, "
-                         "not '%.200s'", Py_TYPE(newargs)->tp_name);
+           PyErr_Format(PyExc_TypeError,
+             "%T.__getnewargs_ex__() must return a tuple, "
+             "not %T", obj, newargs);
             Py_DECREF(newargs);
             return -1;
         }
         if (PyTuple_GET_SIZE(newargs) != 2) {
             PyErr_Format(PyExc_ValueError,
-                         "__getnewargs_ex__ should return a tuple of "
-                         "length 2, not %zd", PyTuple_GET_SIZE(newargs));
+             "%T.__getnewargs_ex__() must return a tuple of "
+             "length 2, not %zd", obj, PyTuple_GET_SIZE(newargs));
             Py_DECREF(newargs);
             return -1;
         }
@@ -8002,8 +8002,8 @@ _PyObject_GetNewArguments(PyObject *obj, PyObject **args, PyObject **kwargs)
         }
         if (!PyTuple_Check(*args)) {
             PyErr_Format(PyExc_TypeError,
-                         "__getnewargs__ should return a tuple, "
-                         "not '%.200s'", Py_TYPE(*args)->tp_name);
+             "%T.__getnewargs__() must return a tuple, "
+             "not %T", obj, *args);
             Py_CLEAR(*args);
             return -1;
         }
@@ -10759,9 +10759,10 @@ slot_tp_hash(PyObject *self)
         return PyObject_HashNotImplemented(self);
     }
     if (!PyLong_Check(res)) {
+        PyErr_Format(PyExc_TypeError,
+             "%T.__hash__() must return an integer, not %T",
+             self, res);
         Py_DECREF(res);
-        PyErr_SetString(PyExc_TypeError,
-                        "__hash__ method should return an integer");
         return -1;
     }
     /* Transform the PyLong `res` to a Py_hash_t `h`.  For an existing
@@ -11030,8 +11031,8 @@ slot_tp_init(PyObject *self, PyObject *args, PyObject *kwds)
         return -1;
     if (res != Py_None) {
         PyErr_Format(PyExc_TypeError,
-                     "__init__() should return None, not '%.200s'",
-                     Py_TYPE(res)->tp_name);
+             "%T.__init__() must return None, not %T",
+             self, res);
         Py_DECREF(res);
         return -1;
     }

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -4819,8 +4819,8 @@ dummy_func(
         inst(EXIT_INIT_CHECK, (should_be_none -- )) {
             if (!PyStackRef_IsNone(should_be_none)) {
                 PyErr_Format(PyExc_TypeError,
-                    "__init__() should return None, not '%.200s'",
-                    Py_TYPE(PyStackRef_AsPyObjectBorrow(should_be_none))->tp_name);
+             "__init__() must return None, not %T",
+             PyStackRef_AsPyObjectBorrow(should_be_none));
                 ERROR_NO_POP();
             }
             DEAD(should_be_none);


### PR DESCRIPTION
Fixes remaining inconsistent error messages for magic methods that 
return the wrong type, as part of issue #130821.

Changes made to use the consistent `%T.__method__() must return ..., not %T` 
format established in previous PRs (#130835, #144737):

- `Objects/typeobject.c`: Fixed `__hash__`, `__init__`, `__getnewargs_ex__`, 
  and `__getnewargs__` error messages
- `Python/bytecodes.c`: Fixed `__init__` error message in EXIT_INIT_CHECK

This follows the pattern established by the merged PRs for this issue.


<!-- gh-issue-number: gh-130821 -->
* Issue: gh-130821
<!-- /gh-issue-number -->
