### PR TITLE
gh-154559: Link the annotations future statement to the language reference

### DIFF
--- a/Doc/library/__future__.rst
+++ b/Doc/library/__future__.rst
@@ -82,7 +82,8 @@ language using this mechanism:
      * 3.7.0b1
      * Never [1]_
      * :pep:`563`: *Postponed evaluation of annotations*,
-       :pep:`649`: *Deferred evaluation of annotations using descriptors*
+       :pep:`649`: *Deferred evaluation of annotations using descriptors*;
+       see :ref:`annotations`
 
 .. XXX Adding a new entry?  Remember to update simple_stmts.rst, too.
 


### PR DESCRIPTION
Closes #154559

The `annotations` entry in the future-statements table in the `__future__` documentation lists PEP 563 and PEP 649, but does not link to the language reference section that documents how annotations actually behave in current Python (https://docs.python.org/3/reference/compound_stmts.html#annotations).

This adds a `:ref:`annotations`` cross-reference to that table row, as suggested by @picnixz in the issue discussion.

Documentation-only change, so no NEWS entry is included (the `skip news` label applies). Verified with a full docs build (`make -C Doc html`, which runs Sphinx with `--fail-on-warning`): build completes with zero warnings and the rendered page links to `reference/compound_stmts.html#annotations`. 

`make patchcheck` is clean.

<!-- gh-issue-number: gh-154559 -->
* Issue: gh-154559
<!-- /gh-issue-number -->
