### PR TITLE
gh-154587: Fix Windows buffer declaration in _cursesmodule

### DIFF
--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -1956,7 +1956,7 @@ PyCursesWindow_New(cursesmodule_state *state,
 {
     if (encoding == NULL) {
 #if defined(MS_WINDOWS)
-        char *buffer[100];
+        char buffer[100];
         UINT cp;
         cp = GetConsoleOutputCP();
         if (cp != 0) {


### PR DESCRIPTION
## Summary

Fix a Windows-only buffer declaration in `Modules/_cursesmodule.c`.

The code incorrectly declared:

```c
char *buffer[100];
```

which creates an array of 100 `char *` pointers. However, the buffer is passed to `PyOS_snprintf()`, which expects a writable `char *` character buffer. This change replaces it with:

```c
char buffer[100];
```

which matches the intended usage and resolves the `clang-cl` incompatible pointer type compilation error reported in gh-154587.

Closes gh-154587.