### PR TITLE
Ignore the free-threaded Windows build output directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,10 +124,14 @@ PCbuild/*-pgo
 PCbuild/*.VC.db
 PCbuild/*.VC.opendb
 PCbuild/amd64/
+PCbuild/amd64t/
 PCbuild/arm32/
+PCbuild/arm32t/
 PCbuild/arm64/
+PCbuild/arm64t/
 PCbuild/obj/
 PCbuild/win32/
+PCbuild/win32t/
 Tools/unicode/data/
 /autom4te.cache
 /build/


### PR DESCRIPTION
Split out of #154586 at @zooba's suggestion.

`PCbuild/python.props` gives free-threaded builds their own output directories, one per platform:

https://github.com/python/cpython/blob/eef23498751fff48f15c70975b415161491621a3/PCbuild/python.props#L55-L62

`.gitignore` lists the four GIL-enabled directories (`win32/`, `amd64/`, `arm32/`, `arm64/`) but none of the `t` counterparts, so `PCbuild\build.bat --disable-gil` leaves its entire output — `.pdb`, `.lib`, `.exp`, `pybuilddir.txt`, the copied `LICENSE.txt`, and so on — showing up as untracked files. That is easy to sweep into a commit by accident, which is exactly what happened in #154586.

This adds the four missing entries, keeping the list alphabetical.

Verified against a real `-p x64 -c Release --disable-gil` build tree:

```
$ git check-ignore -v --no-index PCbuild/amd64t/python.exe PCbuild/win32t/_freeze_module.pdb
.gitignore:127:PCbuild/amd64t/	PCbuild/amd64t/python.exe
.gitignore:134:PCbuild/win32t/	PCbuild/win32t/_freeze_module.pdb
```

`git status` is clean afterwards, where it previously listed 140 build artifacts. `arm32t/` and `arm64t/` are included for symmetry with the props file; I have no ARM machine to build on, so those two are matched by inspection rather than by test.

No behaviour change, so this needs the `skip news` label.
