### PR TITLE
gh-152433: Windows: do not use _syscmd_ver() on UWP build

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -422,16 +422,21 @@ def _win32_ver(version, csd, ptype):
     # Fall back to a combination of sys.getwindowsversion and "ver"
     try:
         from sys import getwindowsversion
+        from _winapi import IsWindowsDesktop
     except ImportError:
         return version, csd, ptype, True
 
     winver = getwindowsversion()
     is_client = (getattr(winver, 'product_type', 1) == 1)
-    try:
-        version = _syscmd_ver()[2]
-        major, minor, build = map(int, version.split('.'))
-    except ValueError:
-        major, minor, build = winver.platform_version or winver[:3]
+    if IsWindowsDesktop():
+        try:
+            version = _syscmd_ver()[2]
+            major, minor, build = map(int, version.split('.'))
+        except ValueError:
+            major, minor, build = winver.platform_version or winver[:3]
+            version = '{0}.{1}.{2}'.format(major, minor, build)
+    else:
+        major, minor, build = winver[:3]
         version = '{0}.{1}.{2}'.format(major, minor, build)
 
     # getwindowsversion() reflect the compatibility mode Python is

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -3175,6 +3175,23 @@ _winapi_GetTickCount64_impl(PyObject *module)
     return PyLong_FromUnsignedLongLong(ticks);
 }
 
+/*[clinic input]
+_winapi.IsWindowsDesktop
+
+Return TRUE for Windows desktop build or FALSE for UWP build.
+[clinic start generated code]*/
+
+static PyObject *
+_winapi_IsWindowsDesktop_impl(PyObject *module)
+/*[clinic end generated code: output=6c1a044078bba5fd input=cf5bd7f013ba4bff]*/
+{
+#ifdef MS_WINDOWS_DESKTOP
+    return PyBool_FromLong(TRUE);
+#else
+    return PyBool_FromLong(FALSE);
+#endif
+}
+
 
 static PyMethodDef winapi_functions[] = {
     _WINAPI_CLOSEHANDLE_METHODDEF
@@ -3228,6 +3245,7 @@ static PyMethodDef winapi_functions[] = {
     _WINAPI_COPYFILE2_METHODDEF
     _WINAPI_GETPROCESSMEMORYINFO_METHODDEF
     _WINAPI_GETTICKCOUNT64_METHODDEF
+    _WINAPI_ISWINDOWSDESKTOP_METHODDEF
     {NULL, NULL}
 };
 

--- a/Modules/clinic/_winapi.c.h
+++ b/Modules/clinic/_winapi.c.h
@@ -2376,7 +2376,25 @@ _winapi_GetTickCount64(PyObject *module, PyObject *Py_UNUSED(ignored))
     return _winapi_GetTickCount64_impl(module);
 }
 
+PyDoc_STRVAR(_winapi_IsWindowsDesktop__doc__,
+"IsWindowsDesktop($module, /)\n"
+"--\n"
+"\n"
+"Return TRUE for Windows desktop build or FALSE for UWP build.");
+
+#define _WINAPI_ISWINDOWSDESKTOP_METHODDEF    \
+    {"IsWindowsDesktop", (PyCFunction)_winapi_IsWindowsDesktop, METH_NOARGS, _winapi_IsWindowsDesktop__doc__},
+
+static PyObject *
+_winapi_IsWindowsDesktop_impl(PyObject *module);
+
+static PyObject *
+_winapi_IsWindowsDesktop(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return _winapi_IsWindowsDesktop_impl(module);
+}
+
 #ifndef _WINAPI_GETSHORTPATHNAME_METHODDEF
     #define _WINAPI_GETSHORTPATHNAME_METHODDEF
 #endif /* !defined(_WINAPI_GETSHORTPATHNAME_METHODDEF) */
-/*[clinic end generated code: output=713a8ce97185b017 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=166fed414568108f input=a9049054013a1b77]*/


### PR DESCRIPTION
UWP cannot run `subprocess` and `platform` triggers runtime errors.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152433 -->
* Issue: gh-152433
<!-- /gh-issue-number -->
