### PR TITLE
gh-154643: Only use __STDC_VERSION__ when defined

### DIFF
--- a/Include/cpython/pyatomic.h
+++ b/Include/cpython/pyatomic.h
@@ -582,7 +582,7 @@ static inline void _Py_atomic_fence_release(void);
 #  define Py_ATOMIC_GCC_H
 #  include "pyatomic_gcc.h"
 #  undef Py_ATOMIC_GCC_H
-#elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)
 #  define Py_ATOMIC_STD_H
 #  include "pyatomic_std.h"
 #  undef Py_ATOMIC_STD_H

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -491,7 +491,7 @@ extern "C" {
 #ifdef WITH_THREAD
 #  ifdef thread_local
 #    define _Py_thread_local thread_local
-#  elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
+#  elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
 #    define _Py_thread_local _Thread_local
 #  elif defined(_MSC_VER)  /* AKA NT_THREADS */
 #    define _Py_thread_local __declspec(thread)

--- a/Lib/test/test_cppext/__init__.py
+++ b/Lib/test/test_cppext/__init__.py
@@ -134,6 +134,11 @@ class TestPublicCAPI(BaseTests, unittest.TestCase):
     def test_build_intel_asm(self):
         self.check_build('_testcppext_asm', extra_cflags='-masm=intel')
 
+    # gh-154643: Test that headers don't use undefined macros in #if
+    @unittest.skipIf(support.MS_WINDOWS, "MSVC doesn't support -Werror=undef")
+    def test_build_werror_undef(self):
+        self.check_build('_testcppext_undef', extra_cflags='-Werror=undef')
+
 
 class TestInteralCAPI(BaseTests, unittest.TestCase):
     TEST_INTERNAL_C_API = True

--- a/Misc/NEWS.d/next/C_API/2026-07-24-22-30-40.gh-issue-154643.z-ZutK.rst
+++ b/Misc/NEWS.d/next/C_API/2026-07-24-22-30-40.gh-issue-154643.z-ZutK.rst
@@ -1,0 +1,2 @@
+In ``pyport.h`` and ``pyatomic.h`` don't use ``__STDC_VERSION__`` when it is
+not defined, fixing build errors for C++ code built with ``-Werror=undef``.


### PR DESCRIPTION
This fixes:

    $ g++ -I/usr/include/python3.15 -c -Werror=undef test.cpp
    In file included from /usr/include/python3.15/Python.h:68,
                     from test.cpp:1:
    /usr/include/python3.15/pyport.h:494:9: error: ‘__STDC_VERSION__’ is not defined, evaluates to ‘0’ [-Werror=undef]
      494 | #  elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
          |         ^~~~~~~~~~~~~~~~
    cc1plus: some warnings being treated as errors

For any test.cpp that has #include <Python.h>.

For locating the place for the added test, I used LLM.

The main issue I could reproduce was in Include/pyport.h. Include/cpython/pyatomic.h was updated for completeness. Include/internal/mimalloc/mimalloc/atomic.h also has this but was left untouched as it is code from a bundled project and is likely not exposed publicly.

Assisted-By: Claude Opus 4.6

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-154643 -->
* Issue: gh-154643
<!-- /gh-issue-number -->
