### PR TITLE
gh-110721: Remove undefined `_Py_Offer_Suggestions` in `pycore_pyerrors.h`

### DIFF
--- a/Include/internal/pycore_pyerrors.h
+++ b/Include/internal/pycore_pyerrors.h
@@ -186,7 +186,6 @@ extern int _PyErr_CheckSignalsTstate(PyThreadState *tstate);
 extern void _Py_DumpExtensionModules(int fd, PyInterpreterState *interp);
 // Exported for external JIT support
 PyAPI_FUNC(PyObject *) _Py_CalculateSuggestions(PyObject *dir, PyObject *name);
-extern PyObject* _Py_Offer_Suggestions(PyObject* exception);
 
 // Export for '_testinternalcapi' shared extension
 PyAPI_FUNC(Py_ssize_t) _Py_UTF8_Edit_Cost(PyObject *str_a, PyObject *str_b,


### PR DESCRIPTION
After https://github.com/python/cpython/pull/113712, `_Py_Offer_Suggestions` was removed but its declaration was left in the header.

cc @pablogsal 

<!-- gh-issue-number: gh-110721 -->
* Issue: gh-110721
<!-- /gh-issue-number -->
