### PR TITLE
gh-154670: Fix use-after-free in itertools.count via re-entrant step

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -625,9 +625,13 @@ class TestBasicOps(unittest.TestCase):
         self.test_count_threading(step=5)
 
     def test_count_reentrant_step(self):
+        entered = False
         class Step(int):
             def __radd__(self, other):
-                next(c)
+                nonlocal entered
+                if not entered:
+                    entered = True
+                    next(c)
                 return other + 1
         c = count(1 << 100, Step())
         next(c)

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -624,6 +624,15 @@ class TestBasicOps(unittest.TestCase):
     def test_count_with_step_threading(self):
         self.test_count_threading(step=5)
 
+    def test_count_reentrant_step(self):
+        c = count(1 << 100, Step())
+        class Step:
+            def __radd__(self, other):
+                next(c)
+                return other + 1
+        c = count(1 << 100, Step())
+        next(c)
+
     def test_cycle(self):
         self.assertEqual(take(10, cycle('abc')), list('abcabcabca'))
         self.assertEqual(list(cycle('')), [])

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -625,7 +625,7 @@ class TestBasicOps(unittest.TestCase):
         self.test_count_threading(step=5)
 
     def test_count_reentrant_step(self):
-        class Step:
+        class Step(int):
             def __radd__(self, other):
                 next(c)
                 return other + 1

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -625,7 +625,6 @@ class TestBasicOps(unittest.TestCase):
         self.test_count_threading(step=5)
 
     def test_count_reentrant_step(self):
-        c = count(1 << 100, Step())
         class Step:
             def __radd__(self, other):
                 next(c)

--- a/Misc/NEWS.d/next/Library/2026-07-25-12-00-00.gh-issue-154670.CtUAF1.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-25-12-00-00.gh-issue-154670.CtUAF1.rst
@@ -1,0 +1,2 @@
+Fix use-after-free in :func:`itertools.count` when the step object's
+``__radd__`` re-enters the iterator.  Patch by tonghuaroot.

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3628,15 +3628,14 @@ count_nextlong(countobject *lz)
     }
     assert(lz->cnt == PY_SSIZE_T_MAX && lz->long_cnt != NULL);
 
-    // We hold one reference to "result" (a.k.a. the old value of
-    // lz->long_cnt); we'll either return it or keep it in lz->long_cnt.
-    PyObject *result = lz->long_cnt;
+    PyObject *result = Py_NewRef(lz->long_cnt);
 
     PyObject *stepped_up = PyNumber_Add(result, lz->long_step);
     if (stepped_up == NULL) {
+        Py_DECREF(result);
         return NULL;
     }
-    lz->long_cnt = stepped_up;
+    Py_SETREF(lz->long_cnt, stepped_up);
 
     return result;
 }


### PR DESCRIPTION
`count_nextlong()` borrows `lz->long_cnt` without `Py_INCREF`, then calls `PyNumber_Add` which can re-enter via `step.__radd__`. The inner `next()` returns the same pointer; when the caller releases it, the outer call holds a dangling pointer.

Fix: `Py_NewRef` the borrowed value before the callback, `Py_SETREF` for the swap.


<!-- gh-issue-number: gh-154670 -->
* Issue: gh-154670
<!-- /gh-issue-number -->
