### PR TITLE
gh-154672: Fix use-after-free in itertools.zip_longest via re-entrant iterator

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -624,15 +624,6 @@ class TestBasicOps(unittest.TestCase):
     def test_count_with_step_threading(self):
         self.test_count_threading(step=5)
 
-    def test_count_reentrant_step(self):
-        c = count(1 << 100, Step())
-        class Step:
-            def __radd__(self, other):
-                next(c)
-                return other + 1
-        c = count(1 << 100, Step())
-        next(c)
-
     def test_cycle(self):
         self.assertEqual(take(10, cycle('abc')), list('abcabcabca'))
         self.assertEqual(list(cycle('')), [])
@@ -1513,6 +1504,22 @@ class TestBasicOps(unittest.TestCase):
         it = zip_longest([[]])
         gc.collect()
         self.assertTrue(gc.is_tracked(next(it)))
+
+    def test_zip_longest_reentrant_iterator(self):
+        # A re-entrant iterator exhaust must not cause use-after-free.
+        zl = None
+        class ReentrantFilter:
+            def __init__(self, it):
+                self.it = it
+            def __iter__(self):
+                return self
+            def __next__(self):
+                if zl is not None:
+                    for _ in zl:
+                        pass
+                return next(self.it)
+        zl = zip_longest(ReentrantFilter(iter([1])), iter([2, 3]))
+        list(zl)
 
     @support.cpython_only
     def test_pairwise_result_gc(self):

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1507,18 +1507,20 @@ class TestBasicOps(unittest.TestCase):
 
     def test_zip_longest_reentrant_iterator(self):
         # A re-entrant iterator exhaust must not cause use-after-free.
-        zl = None
-        class ReentrantFilter:
+        entered = False
+        class ReentrantIter:
             def __init__(self, it):
                 self.it = it
             def __iter__(self):
                 return self
             def __next__(self):
-                if zl is not None:
+                nonlocal entered
+                if not entered:
+                    entered = True
                     for _ in zl:
                         pass
                 return next(self.it)
-        zl = zip_longest(ReentrantFilter(iter([1])), iter([2, 3]))
+        zl = zip_longest(ReentrantIter(iter([1])), iter([2, 3]))
         list(zl)
 
     @support.cpython_only

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1507,20 +1507,22 @@ class TestBasicOps(unittest.TestCase):
 
     def test_zip_longest_reentrant_iterator(self):
         # A re-entrant iterator exhaust must not cause use-after-free.
-        entered = False
-        class ReentrantIter:
-            def __init__(self, it):
+        class ExhaustingIter:
+            def __init__(self, it, sibling):
                 self.it = it
+                self.sibling = sibling
+                self.first = True
             def __iter__(self):
                 return self
             def __next__(self):
-                nonlocal entered
-                if not entered:
-                    entered = True
-                    for _ in zl:
+                val = next(self.it)
+                if self.first:
+                    self.first = False
+                    for _ in self.sibling:
                         pass
-                return next(self.it)
-        zl = zip_longest(ReentrantIter(iter([1])), iter([2, 3]))
+                return val
+        sib = iter([2, 3])
+        zl = zip_longest(ExhaustingIter(iter([1, 4]), sib), sib)
         list(zl)
 
     @support.cpython_only

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -624,6 +624,15 @@ class TestBasicOps(unittest.TestCase):
     def test_count_with_step_threading(self):
         self.test_count_threading(step=5)
 
+    def test_count_reentrant_step(self):
+        c = count(1 << 100, Step())
+        class Step:
+            def __radd__(self, other):
+                next(c)
+                return other + 1
+        c = count(1 << 100, Step())
+        next(c)
+
     def test_cycle(self):
         self.assertEqual(take(10, cycle('abc')), list('abcabcabca'))
         self.assertEqual(list(cycle('')), [])

--- a/Misc/NEWS.d/next/Library/2026-07-25-12-00-00.gh-issue-000000.CtUAF1.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-25-12-00-00.gh-issue-000000.CtUAF1.rst
@@ -1,0 +1,2 @@
+Fix use-after-free in :func:`itertools.count` when the step object's
+``__radd__`` re-enters the iterator.  Patch by tonghuaroot.

--- a/Misc/NEWS.d/next/Library/2026-07-25-12-00-00.gh-issue-000000.CtUAF1.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-25-12-00-00.gh-issue-000000.CtUAF1.rst
@@ -1,2 +1,0 @@
-Fix use-after-free in :func:`itertools.count` when the step object's
-``__radd__`` re-enters the iterator.  Patch by tonghuaroot.

--- a/Misc/NEWS.d/next/Library/2026-07-25-12-30-00.gh-issue-154672.ZlUAF2.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-25-12-30-00.gh-issue-154672.ZlUAF2.rst
@@ -1,0 +1,2 @@
+Fix use-after-free in :func:`itertools.zip_longest` when a re-entrant
+iterator callback exhausts a sibling iterator.  Patch by tonghuaroot.

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3628,15 +3628,14 @@ count_nextlong(countobject *lz)
     }
     assert(lz->cnt == PY_SSIZE_T_MAX && lz->long_cnt != NULL);
 
-    // We hold one reference to "result" (a.k.a. the old value of
-    // lz->long_cnt); we'll either return it or keep it in lz->long_cnt.
-    PyObject *result = lz->long_cnt;
+    PyObject *result = Py_NewRef(lz->long_cnt);
 
     PyObject *stepped_up = PyNumber_Add(result, lz->long_step);
     if (stepped_up == NULL) {
+        Py_DECREF(result);
         return NULL;
     }
-    lz->long_cnt = stepped_up;
+    Py_SETREF(lz->long_cnt, stepped_up);
 
     return result;
 }

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3628,14 +3628,15 @@ count_nextlong(countobject *lz)
     }
     assert(lz->cnt == PY_SSIZE_T_MAX && lz->long_cnt != NULL);
 
-    PyObject *result = Py_NewRef(lz->long_cnt);
+    // We hold one reference to "result" (a.k.a. the old value of
+    // lz->long_cnt); we'll either return it or keep it in lz->long_cnt.
+    PyObject *result = lz->long_cnt;
 
     PyObject *stepped_up = PyNumber_Add(result, lz->long_step);
     if (stepped_up == NULL) {
-        Py_DECREF(result);
         return NULL;
     }
-    Py_SETREF(lz->long_cnt, stepped_up);
+    lz->long_cnt = stepped_up;
 
     return result;
 }
@@ -3976,19 +3977,24 @@ zip_longest_next_lock_held(PyObject *op)
             if (it == NULL) {
                 item = Py_NewRef(lz->fillvalue);
             } else {
+                Py_INCREF(it);
                 item = PyIter_Next(it);
                 if (item == NULL) {
                     lz->numactive -= 1;
                     if (lz->numactive == 0 || PyErr_Occurred()) {
                         lz->numactive = 0;
+                        Py_DECREF(it);
                         Py_DECREF(result);
                         return NULL;
                     } else {
                         item = Py_NewRef(lz->fillvalue);
-                        PyTuple_SET_ITEM(lz->ittuple, i, NULL);
-                        Py_DECREF(it);
+                        if (PyTuple_GET_ITEM(lz->ittuple, i) != NULL) {
+                            PyTuple_SET_ITEM(lz->ittuple, i, NULL);
+                            Py_DECREF(it);
+                        }
                     }
                 }
+                Py_DECREF(it);
             }
             olditem = PyTuple_GET_ITEM(result, i);
             PyTuple_SET_ITEM(result, i, item);
@@ -4006,19 +4012,24 @@ zip_longest_next_lock_held(PyObject *op)
             if (it == NULL) {
                 item = Py_NewRef(lz->fillvalue);
             } else {
+                Py_INCREF(it);
                 item = PyIter_Next(it);
                 if (item == NULL) {
                     lz->numactive -= 1;
                     if (lz->numactive == 0 || PyErr_Occurred()) {
                         lz->numactive = 0;
+                        Py_DECREF(it);
                         Py_DECREF(result);
                         return NULL;
                     } else {
                         item = Py_NewRef(lz->fillvalue);
-                        PyTuple_SET_ITEM(lz->ittuple, i, NULL);
-                        Py_DECREF(it);
+                        if (PyTuple_GET_ITEM(lz->ittuple, i) != NULL) {
+                            PyTuple_SET_ITEM(lz->ittuple, i, NULL);
+                            Py_DECREF(it);
+                        }
                     }
                 }
+                Py_DECREF(it);
             }
             PyTuple_SET_ITEM(result, i, item);
         }


### PR DESCRIPTION
`zip_longest_next_lock_held()` borrows iterators from `lz->ittuple` via `PyTuple_GET_ITEM` without `Py_INCREF`, then calls `PyIter_Next(it)`. A re-entrant callback can exhaust and free the iterator while the outer call is still using it.

Fix: `Py_INCREF(it)` before `PyIter_Next`, `Py_DECREF` after. Guard the exhaust handler against double-free when a re-entrant call already removed the iterator.


<!-- gh-issue-number: gh-154672 -->
* Issue: gh-154672
<!-- /gh-issue-number -->
