### PR TITLE
Fix a stale link for the math.integer.isqrt correctness proof

### DIFF
--- a/Modules/mathintegermodule.c
+++ b/Modules/mathintegermodule.c
@@ -182,8 +182,7 @@ iteration to the next. A sketch of the proof of this is given below.
 In addition to the proof sketch, a formal, computer-verified proof
 of correctness (using Lean) of the algorithm can be found here:
 
-    https://github.com/mdickinson/snippets/tree/main/proofs/isqrt
-
+    https://github.com/mdickinson/snippets/tree/41ce2d256fef06fb32f24fe7014cfa95173ac5e0/proofs/isqrt
 
 Here's Python code equivalent to the C implementation below:
 

--- a/Modules/mathintegermodule.c
+++ b/Modules/mathintegermodule.c
@@ -180,10 +180,9 @@ that the bound `(a - 1)**2 < (n >> s) < (a + 1)**2` is maintained from one
 iteration to the next. A sketch of the proof of this is given below.
 
 In addition to the proof sketch, a formal, computer-verified proof
-of correctness (using Lean) of an equivalent recursive algorithm can be found
-here:
+of correctness (using Lean) of the algorithm can be found here:
 
-    https://github.com/mdickinson/snippets/blob/master/proofs/isqrt/src/isqrt.lean
+    https://github.com/mdickinson/snippets/tree/main/proofs/isqrt
 
 
 Here's Python code equivalent to the C implementation below:

--- a/Modules/mathintegermodule.c
+++ b/Modules/mathintegermodule.c
@@ -184,6 +184,7 @@ of correctness (using Lean) of the algorithm can be found here:
 
     https://github.com/mdickinson/snippets/tree/41ce2d256fef06fb32f24fe7014cfa95173ac5e0/proofs/isqrt
 
+
 Here's Python code equivalent to the C implementation below:
 
     def isqrt(n):


### PR DESCRIPTION
The `math.integer` C source contains a link to an old proof of correctness for the `math.integer.isqrt` algorithm. That old proof, written in the obsolete language Lean 3, no longer exists at the given URL. This PR:

- updates the URL to point to the [current proof](https://github.com/mdickinson/snippets/tree/main/proofs/isqrt), written in Lean 4
- removes the "an equivalent recursive algorithm" hedge, since the Lean 4 proof directly proves correctness of the iterative form of the algorithm

I didn't create an issue for this trivial comment-only change. Let me know if you think it needs one.