### PR TITLE
gh-47482: Reject non-bytes-like input in the idna codec decoder

### DIFF
--- a/Lib/encodings/idna.py
+++ b/Lib/encodings/idna.py
@@ -234,13 +234,15 @@ class Codec(codecs.Codec):
         if errors != 'strict':
             raise UnicodeError(f"Unsupported error handling: {errors}")
 
+        if not isinstance(input, bytes):
+            try:
+                input = bytes(memoryview(input))
+            except TypeError:
+                raise TypeError("a bytes-like object is required, not "
+                                f"'{type(input).__name__}'") from None
+
         if not input:
             return "", 0
-
-        # IDNA allows decoding to operate on Unicode strings, too.
-        if not isinstance(input, bytes):
-            # XXX obviously wrong, see #3232
-            input = bytes(input)
 
         if ace_prefix not in input.lower():
             # Fast path

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1688,6 +1688,26 @@ class IDNACodecTest(unittest.TestCase):
                 self.assertEqual(exc.start, expected.start, msg=f'reason: {exc.reason}')
                 self.assertEqual(exc.end, expected.end)
 
+    def test_decode_bytes_like(self):
+        # Bytes-like objects other than bytes are still accepted.
+        for case in (bytearray(b"xn--pythn-mua.org"),
+                     memoryview(b"xn--pythn-mua.org")):
+            with self.subTest(case=case):
+                self.assertEqual(codecs.decode(case, "idna"), "pyth\xf6n.org")
+
+    def test_decode_invalid_type(self):
+        # The decoder used to call bytes(input) on any non-bytes input, which
+        # silently produced nonsense for objects bytes() happens to accept:
+        # decoding 5 returned '\x00\x00\x00\x00\x00' and [65, 66] returned 'AB'.
+        for case in ("python.org", "", 5, 0, [65, 66], (67,), None, 3.5, {}):
+            with self.subTest(case=case):
+                with self.assertRaises(TypeError) as cm:
+                    codecs.decode(case, "idna")
+                self.assertEqual(
+                    str(cm.exception),
+                    "a bytes-like object is required, "
+                    f"not '{type(case).__name__}'")
+
     def test_builtin_encode(self):
         self.assertEqual("python.org".encode("idna"), b"python.org")
         self.assertEqual("python.org.".encode("idna"), b"python.org.")

--- a/Misc/NEWS.d/next/Library/2026-07-25-15-12-33.gh-issue-47482.Kq7Vn2.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-25-15-12-33.gh-issue-47482.Kq7Vn2.rst
@@ -1,0 +1,5 @@
+The ``idna`` codec now raises :exc:`TypeError` when asked to decode an object
+that is not bytes-like, instead of silently coercing it with ``bytes()``.
+Previously ``codecs.decode(5, "idna")`` returned ``'\x00\x00\x00\x00\x00'``
+and ``codecs.decode([65, 66], "idna")`` returned ``'AB'``. Bytes-like objects
+such as :class:`bytearray` and :class:`memoryview` are still accepted.


### PR DESCRIPTION
`Codec.decode` in `Lib/encodings/idna.py` called `bytes(input)` on any input that
was not already `bytes`:

```python
# IDNA allows decoding to operate on Unicode strings, too.
if not isinstance(input, bytes):
    # XXX obviously wrong, see #3232
    input = bytes(input)
```

`bytes()` accepts more than buffers, so objects it happens to understand were
silently coerced instead of rejected:

```pycon
>>> codecs.decode(5, "idna")
'\x00\x00\x00\x00\x00'
>>> codecs.decode([65, 66], "idna")
'AB'
>>> codecs.decode(None, "idna")
''
>>> codecs.decode("python.org", "idna")
TypeError: string argument without an encoding
```

The first three return nonsense rather than raising, and the last leaks an
error message from `bytes()` that never mentions what was actually expected.
Every other bytes-to-text decoder raises `TypeError: a bytes-like object is
required, not 'str'`.

This PR raises `TypeError` with that same message, and keeps accepting
bytes-like objects, so `bytearray` and `memoryview` continue to work:

```pycon
>>> codecs.decode(bytearray(b"xn--pythn-mua.org"), "idna")
'pythön.org'
>>> codecs.decode(5, "idna")
TypeError: a bytes-like object is required, not 'int'
```

The type check now runs before the empty-input shortcut, so `codecs.decode("", "idna")`
raises instead of returning `''`, matching `codecs.decode("", "utf-8")`.

This is the narrow half of the issue that already has agreement in the
discussion: rejecting non-bytes input "deliberately and explicitly, rather than
as a result of a bogus forward-port". I have deliberately not touched the
separate proposal in that thread to add a new `decode_idna` function for
un-IDNA-ing `str` input, since that is a feature and still undecided.

The issue is marked "test needed" and noted that the behaviour was not covered
by the test suite, so `IDNACodecTest` gains two tests: one that bytes-like
input still decodes, and one that non-bytes-like input raises `TypeError` with
the expected message.

`test_codecs`, `test_socket`, `test_ssl`, `test_httplib`, `test_urllib`,
`test_urllib2`, `test_email` and `test_str` all pass.

One thing I noticed but left alone: `IncrementalDecoder._buffer_decode` has an
`isinstance(input, str)` branch that is unreachable, because
`codecs.BufferedIncrementalDecoder` concatenates its bytes buffer to the input
before `_buffer_decode` is called. Happy to address that separately if wanted.


<!-- gh-issue-number: gh-47482 -->
* Issue: gh-47482
<!-- /gh-issue-number -->
