### PR TITLE
gh-152433: Windows: fix ``ctypes`` error in UWP build

### DIFF
--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -562,7 +562,7 @@ if _os.name == "nt":
     windll = LibraryLoader(WinDLL)
     oledll = LibraryLoader(OleDLL)
 
-    GetLastError = windll.kernel32.GetLastError
+    from _winapi import GetLastError
     from _ctypes import get_last_error, set_last_error
 
     def WinError(code=None, descr=None):

--- a/Modules/_ctypes/malloc_closure.c
+++ b/Modules/_ctypes/malloc_closure.c
@@ -68,10 +68,17 @@ static void more_core(void)
 
     /* allocate a memory block */
 #ifdef MS_WIN32
+#ifdef MS_WINDOWS_DESKTOP
     item = (ITEM *)VirtualAlloc(NULL,
                                            count * sizeof(ITEM),
                                            MEM_COMMIT,
                                            PAGE_EXECUTE_READWRITE);
+#else
+    item = (ITEM*)VirtualAllocFromApp(NULL,
+                                      count * sizeof(ITEM),
+                                      MEM_COMMIT | MEM_RESERVE,
+                                      PAGE_READWRITE);
+#endif
     if (item == NULL)
         return;
 #else


### PR DESCRIPTION
Fix ``ctypes`` error in UWP build:

In UWP is possible call `GetLastError()` Win32 API but not like import from ctypes with `LibraryLoader`:

```Python
GetLastError = windll.kernel32.GetLastError
```

The error produced is like this (in this case using Cryptodome):

```
EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
 - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
Error Type: <class 'AttributeError'>
Error Contents: kernel32
Traceback (most recent call last):
  File "V:\kodi-build-UWP\Debug\AppX\system\python\Lib\site-packages\Cryptodome\Util\_raw_api.py", line 83, in <module>
    raise ImportError("CFFI is not compatible with Python 3.12 on Windows")
ImportError: CFFI is not compatible with Python 3.12 on Windows

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "V:\kodi-build-UWP\Debug\AppX\system\python\Lib\ctypes\__init__.py", line 461, in __getattr__
    dll = self._dlltype(name)
  File "V:\kodi-build-UWP\Debug\AppX\system\python\Lib\ctypes\__init__.py", line 390, in __init__
    self._handle = _dlopen(self._name, mode)
                   ~~~~~~~^^^^^^^^^^^^^^^^^^
FileNotFoundError: Could not find module 'kernel32' (or one of its dependencies). Try using the full path with constructor syntax.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\Joel\AppData\Local\Packages\XBMCFoundation.Kodi_4n2hpmxwrvr6p\LocalState\addons\script.kodi.loguploader\default.py", line 1, in <module>
    from Cryptodome.Cipher import AES
  File "V:\kodi-build-UWP\Debug\AppX\system\python\Lib\site-packages\Cryptodome\Cipher\AES.py", line 26, in <module>
    from Cryptodome.Util._raw_api import (load_pycryptodome_raw_lib,
                                      VoidPointer, SmartPointer,
                                      c_size_t, c_uint8_ptr)
  File "V:\kodi-build-UWP\Debug\AppX\system\python\Lib\site-packages\Cryptodome\Util\_raw_api.py", line 170, in <module>
    import ctypes
  File "V:\kodi-build-UWP\Debug\AppX\system\python\Lib\ctypes\__init__.py", line 492, in <module>
    GetLastError = windll.kernel32.GetLastError
                   ^^^^^^^^^^^^^^^
  File "V:\kodi-build-UWP\Debug\AppX\system\python\Lib\ctypes\__init__.py", line 463, in __getattr__
    raise AttributeError(name)
AttributeError: kernel32
-->End of Python script error report<--
```

~Since GetLastError is available from `_winapi`, the workaround is import from _winapi and call directly.~


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152433 -->
* Issue: gh-152433
<!-- /gh-issue-number -->
