### PR TITLE
gh-91826: Document that smtplib/poplib/ftplib TLS defaults do not verify certs

### DIFF
--- a/Doc/library/ftplib.rst
+++ b/Doc/library/ftplib.rst
@@ -480,6 +480,13 @@ FTP_TLS objects
       Please read :ref:`ssl-security` for best practices.
    :type context: :class:`ssl.SSLContext`
 
+   .. note::
+
+      With the default *context*, the connection is encrypted but the
+      server certificate and hostname are not verified.
+      To verify them, pass a context created by
+      :func:`ssl.create_default_context`.
+
    :param timeout:
       A timeout in seconds for blocking operations like :meth:`~FTP.connect`
       (default: the global default timeout setting).

--- a/Doc/library/poplib.rst
+++ b/Doc/library/poplib.rst
@@ -60,6 +60,13 @@ The :mod:`!poplib` module provides two classes:
    single (potentially long-lived) structure.  Please read :ref:`ssl-security`
    for best practices.
 
+   .. note::
+
+      With the default *context*, the connection is encrypted but the
+      server certificate and hostname are not verified.
+      To verify them, pass a context created by
+      :func:`ssl.create_default_context`.
+
    .. audit-event:: poplib.connect self,host,port poplib.POP3_SSL
 
    .. audit-event:: poplib.putline self,line poplib.POP3_SSL
@@ -234,6 +241,13 @@ A :class:`POP3` instance has the following methods:
    bundling SSL configuration options, certificates and private keys into
    a single (potentially long-lived) structure.  Please read :ref:`ssl-security`
    for best practices.
+
+   .. note::
+
+      With the default *context*, the connection is encrypted but the
+      server certificate and hostname are not verified.
+      To verify them, pass a context created by
+      :func:`ssl.create_default_context`.
 
    This method supports hostname checking via
    :attr:`ssl.SSLContext.check_hostname` and *Server Name Indication* (see

--- a/Doc/library/security_warnings.rst
+++ b/Doc/library/security_warnings.rst
@@ -9,20 +9,28 @@ The following modules have specific security considerations:
 
 * :mod:`base64`: :ref:`base64 security considerations <base64-security>` in
   :rfc:`4648`
+* :mod:`ftplib`: default TLS context does not verify server certificates;
+  pass a context from :func:`ssl.create_default_context` to verify them
 * :mod:`hashlib`: :ref:`all constructors take a "usedforsecurity" keyword-only
   argument disabling known insecure and blocked algorithms
   <hashlib-usedforsecurity>`
 * :mod:`http.server` is not suitable for production use, only implementing
   basic security checks. See the :ref:`security considerations <http.server-security>`.
+* :mod:`imaplib`: default TLS context does not verify server certificates;
+  pass a context from :func:`ssl.create_default_context` to verify them
 * :mod:`logging`: :ref:`Logging configuration uses eval()
   <logging-eval-security>`
 * :mod:`multiprocessing`: :ref:`Connection.recv() uses pickle
   <multiprocessing-recv-pickle-security>`
 * :mod:`pickle`: :ref:`Restricting globals in pickle <pickle-restrict>`
+* :mod:`poplib`: default TLS context does not verify server certificates;
+  pass a context from :func:`ssl.create_default_context` to verify them
 * :mod:`random` shouldn't be used for security purposes, use :mod:`secrets`
   instead
 * :mod:`shelve`: :ref:`shelve is based on pickle and thus unsuitable for
   dealing with untrusted sources <shelve-security>`
+* :mod:`smtplib`: default TLS context does not verify server certificates;
+  pass a context from :func:`ssl.create_default_context` to verify them
 * :mod:`ssl`: :ref:`SSL/TLS security considerations <ssl-security>`
 * :mod:`subprocess`: :ref:`Subprocess security considerations
   <subprocess-security>`

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -98,6 +98,13 @@ Protocol) and :rfc:`1869` (SMTP Service Extensions).
    aspects of the secure connection.  Please read :ref:`ssl-security` for
    best practices.
 
+   .. note::
+
+      With the default *context*, the connection is encrypted but the
+      server certificate and hostname are not verified.
+      To verify them, pass a context created by
+      :func:`ssl.create_default_context`.
+
    .. attribute:: SMTP_SSL.default_port
 
       The default port used for SMTP-over-SSL connections (465).
@@ -421,6 +428,13 @@ An :class:`SMTP` instance has the following methods:
    Optional *context* parameter is an :class:`ssl.SSLContext` object; This is
    an alternative to using a keyfile and a certfile and if specified both
    *keyfile* and *certfile* should be ``None``.
+
+   .. note::
+
+      With the default *context*, the connection is encrypted but the
+      server certificate and hostname are not verified.
+      To verify them, pass a context created by
+      :func:`ssl.create_default_context`.
 
    If there has been no previous ``EHLO`` or ``HELO`` command this session,
    this method tries ESMTP ``EHLO`` first.


### PR DESCRIPTION
## Summary

Documentation-only follow-up to the long-standing issue that the stdlib mail/FTP TLS clients encrypt by default **without** verifying the peer certificate or hostname. This does **not** flip any runtime defaults (that remains PEP-gated on gh-91826). It closes the "users had no idea" half of the problem the same way gh-72507 / PR #152778 already did for `imaplib`.

Fixes part of gh-91826 (docs slice only).

---

## What the issue is

`smtplib`, `poplib`, `ftplib` (and historically `imaplib`) obtain their default `SSLContext` from `ssl._create_stdlib_context`, which is an alias of `ssl._create_unverified_context` (`cert_reqs=CERT_NONE`, `check_hostname=False`). The connection is encrypted, but:

- a MITM can present any certificate,
- hostname mismatches are ignored,
- and **nothing in the module docs said so** for SMTP/POP/FTP.

`imaplib` already documents this (merged PR #152778). Users who only read `smtplib` / `poplib` / `ftplib` still had no in-tree warning, and `Doc/library/security_warnings.rst` did not list these modules either. That is a documentation gap on a security-sensitive default, independent of whether/when the default is flipped.

---

## Why I solved it that way

1. **Docs-only, no behavior change.** Flipping verification on by default is blocked on a PEP / core-dev sponsor (two PEP attempts already died). Shipping docs does not require that process and is immediately backportable.
2. **Copy the already-accepted wording.** PR #152778 established the note text and placement for `IMAP4_SSL` / `IMAP4.starttls`. Reusing it avoids inventing a second house style and makes the four modules consistent.
3. **Parameter name adapted per API.** imaplib uses `*ssl_context*`; the others use `*context*`. The note text uses the local parameter name so it matches the signature the reader is looking at.
4. **`security_warnings.rst` bullets.** That page is the stdlib index of "look here before you ship." Listing all four modules (including imaplib for completeness) matches how `ssl` / `http.server` / etc. are already called out.

I deliberately did **not**:

- change `ssl._create_stdlib_context`,
- add `DeprecationWarning`s,
- touch `logging.handlers.SMTPHandler`,
- or reopen the PEP track in this PR.

Those belong in separate workstreams so this PR stays reviewable in minutes.

---

## How I did it

| File | Change |
|------|--------|
| `Doc/library/smtplib.rst` | Note on `SMTP_SSL` and `SMTP.starttls` |
| `Doc/library/poplib.rst` | Note on `POP3_SSL` and `POP3.stls` |
| `Doc/library/ftplib.rst` | Note on `FTP_TLS` (near `context`) |
| `Doc/library/security_warnings.rst` | Bullets for `ftplib`, `imaplib`, `poplib`, `smtplib` |

Each note is:

```rst
.. note::

   With the default *context*, the connection is encrypted but the
   server certificate and hostname are not verified.
   To verify them, pass a context created by
   :func:`ssl.create_default_context`.
```

---

## Impact

- **Users:** discover the insecure default in the first place they look (class/method docs and the security-warnings index).
- **Runtime:** zero. No bytecode, no ABI, no test expectation changes.
- **Backports:** safe for 3.15 / 3.14 / 3.13 (docs-only). Not needed on security-only branches unless an RM wants it.
- **Does not close gh-91826 fully** — only the documentation half. The default-flip remains open.

---

## Testing plan

- [x] Sphinx-lint / pre-commit on the touched `.rst` files (passed locally via pre-commit hook).
- [ ] Docs build (`make -C Doc html` or CI docs job) to confirm no broken refs to `ssl.create_default_context`.
- [ ] Visual check that notes render under the correct signatures on the HTML docs.

No unit tests: pure documentation.

---

## Everything else

- **Precedent:** gh-72507 / #152778 (imaplib).
- **Related but out of scope:** gh-143497 (`FTP_TLS` PROT P default), stale PR #91875 (full flip), draft PEP 738.
- **Suggested reviewers:** docs + ssl/stdlib TLS SMEs (see review request).
- **Backport labels:** please add `needs backport to 3.15`, `3.14`, `3.13` if desired after merge.

<!-- gh-issue-91826 -->
