### PR TITLE
gh-151673: Fix crash in warnings setup_context when filename alloc fails

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-26-12-00-02.gh-issue-151673.g7h8i9.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-26-12-00-02.gh-issue-151673.g7h8i9.rst
@@ -1,0 +1,1 @@
+Fix a crash in the warnings module when allocating a synthetic filename fails under memory pressure.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1035,6 +1035,9 @@ setup_context(Py_ssize_t stack_level,
         globals = interp->sysdict;
         *filename = PyUnicode_FromString("<sys>");
         *lineno = 0;
+        if (*filename == NULL) {
+            return 0;  /* nothing else allocated yet on this path */
+        }
     }
     else {
         globals = f->f_frame->f_globals;


### PR DESCRIPTION
## Summary

Fix OOM-0001 (gh-151673 / umbrella gh-151763): crash in the warnings module when allocating the synthetic `"<sys>"` filename fails under memory pressure.

---

## What the issue is

In `setup_context` (`Python/_warnings.c`), when no frame is available:

```c
*filename = PyUnicode_FromString("<sys>");
*lineno = 0;
// NO NULL CHECK
```

If that allocation returns `NULL`, setup still proceeds / returns success-ish paths that later `Py_DECREF(*filename)` in `do_warn` or `handle_error` on a NULL/invalid pointer. The sibling `"<string>"` module path already checks for `NULL`; `"<sys>"` did not.

---

## Why I solved it that way

1. **Fail at the source** — check immediately after `PyUnicode_FromString`.
2. **`return 0` rather than `goto handle_error`** on this path, because at that moment nothing else has been allocated (`*registry` / `*module` not set yet), and `handle_error` historically did `Py_DECREF(*filename)` which is unsafe when `*filename` is NULL.
3. **Leave the `"<string>"` path alone** — it already has the correct check.
4. **Minimal, mechanical** — matches the shape of other Family-C OOM fixes under gh-151763.

---

## How I did it

```c
*filename = PyUnicode_FromString("<sys>");
*lineno = 0;
if (*filename == NULL) {
    return 0;  /* nothing else allocated yet on this path */
}
```

NEWS entry under Core and Builtins for gh-151673.

---

## Impact

- Stops a crash when issuing warnings under extreme memory pressure with no Python frame (e.g. very early / finalization-adjacent paths using sys dict as globals).
- No behavioral change when allocations succeed.

---

## Testing plan

- [x] Rebuild debug interpreter.
- [x] `./python -m test test_warnings` — PASS.
- [x] Smoke: `warnings.warn("x")` — OK.
- [ ] Optional nomemory-targeted test (not included; can add on request).
- [ ] CI matrix.

---

## Everything else

- Umbrella gh-151763; per-finding issue gh-151673.
- One-PR-per-finding as requested by the umbrella maintainer.
- Reviewers: interpreter-core / warnings owners / OOM umbrella.

<!-- gh-issue-151673 -->

---

## Requested reviewers (subject-matter experts)

Could the following SMEs take a look when convenient (I cannot formally request reviews from this fork account):

- **devdanzin** — OOM umbrella (gh-151763)
- warnings / interpreter-core reviewers

Thank you!
