### PR TITLE
gh-153852: Assert thread list non-empty only after stopping the world (TSAN-0034)

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-26-12-00-00.gh-issue-153852.a1b2c3.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-26-12-00-00.gh-issue-153852.a1b2c3.rst
@@ -1,0 +1,1 @@
+Fix a free-threading race in finalization by asserting the thread list is non-empty only after stopping the world.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -3827,8 +3827,8 @@ handle_thread_shutdown_exception(PyThreadState *tstate)
     assert(tstate != NULL);
     assert(_PyErr_Occurred(tstate));
     PyInterpreterState *interp = tstate->interp;
-    assert(interp->threads.head != NULL);
     _PyEval_StopTheWorld(interp);
+    assert(interp->threads.head != NULL);   /* safe: world is stopped */
 
     // We don't have to worry about locking this because the
     // world is stopped.


### PR DESCRIPTION
## Summary

Fix TSAN-0034 from the free-threading data-race umbrella gh-153852: a debug-only race on `interp->threads.head` during finalization.

---

## What the issue is

In `handle_thread_shutdown_exception` (`Python/pylifecycle.c`):

```c
assert(interp->threads.head != NULL);  // plain read
_PyEval_StopTheWorld(interp);          // only THEN is the list stable
```

The comment below correctly says the world-stopped loop does not need locking — but the **assert runs before STW**. A racing exiting thread in `tstate_delete_common` can mutate the list under `HEAD_LOCK`, and TSan reports a data race on the assert's load. Severity is low (debug assert only; `NDEBUG` strips it), but it is a real race on a free-threaded `--with-pydebug` build and pollutes TSan signal.

---

## Why I solved it that way

1. **Move the assert after `_PyEval_StopTheWorld`**, do not delete it. The invariant ("finalizing thread is still registered") remains checked; the read becomes race-free by construction.
2. **Do not take `HEAD_LOCK` for the assert** — that would introduce a lock ordered before STW on the finalization path for no benefit and a plausible lock-ordering hazard.
3. **Do not add a regression test that requires TSan** — the race is only visible under TSan + pydebug; CI TSan does not always `halt_on_error`. The fix is a pure ordering change with no release-build codegen impact (`assert` vanishes under `NDEBUG`; STW is unconditional in both modes).

---

## How I did it

```c
PyInterpreterState *interp = tstate->interp;
_PyEval_StopTheWorld(interp);
assert(interp->threads.head != NULL);   /* safe: world is stopped */
```

NEWS under Core and Builtins referencing gh-153852 (TSAN-0034).

---

## Impact

- Removes a TSan race on free-threaded debug finalization.
- **Zero release-build behavior or performance change.**
- Unblocks cleaner TSan runs for later FT work.

---

## Testing plan

- [x] Rebuild debug interpreter (GIL configuration available here).
- [x] `./python -m test test_sys test_threading` smoke — OK.
- [ ] Ideal: `--disable-gil --with-thread-sanitizer --with-pydebug` rebuild + the fusil/TSan repro from the TSAN-0034 gist — not run in this environment (no FT+TSan build). Requesting FT SMEs to confirm on their TSan setup.
- [ ] CI: free-threading / sanitizer jobs.

---

## Everything else

- Umbrella: gh-153852, finding **TSAN-0034**.
- Please mark the umbrella table row once merged.
- Lowest-risk item in the umbrella; good first merge for this cluster.

<!-- gh-issue-153852 -->

---

## Requested reviewers (subject-matter experts)

Could the following SMEs take a look when convenient (I cannot formally request reviews from this fork account):

- **colesbury** — free-threading owner
- **devdanzin** — TSan umbrella reporter (gh-153852)
- **kumaraditya303** — FT reviewer

Thank you!
