### PR TITLE
gh-151763: Restore exception if parser recovery path leaves none set (OOM-0021)

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-26-07-01-33.gh-issue-151763.RacVgg.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-26-07-01-33.gh-issue-151763.RacVgg.rst
@@ -1,0 +1,2 @@
+Fix a crash in the parser recovery path when an allocation failure leaves no
+exception set.

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -1026,7 +1026,12 @@ _PyPegen_run_parser(Parser *p)
         if (PyErr_ExceptionMatches(PyExc_SyntaxError)) {
             _PyPegen_set_syntax_error_metadata(p);
         }
-       return NULL;
+        if (!PyErr_Occurred()) {
+            /* Under OOM the recovery pass can clear the exception and fail
+               silently; restore the result/error contract. */
+            PyErr_NoMemory();
+        }
+        return NULL;
     }
 
     if (p->start_rule == Py_single_input && bad_single_statement(p)) {


### PR DESCRIPTION
## Summary

Fix OOM-0021 under umbrella gh-151763: the parser recovery / diagnostic second pass can return `NULL` with **no exception set**, which later trips `Py_FatalError("a function returned NULL without setting an exception")` in `_Py_CheckFunctionResult`.

---

## What the issue is

`_PyPegen_run_parser` already guards `res != NULL && PyErr_Occurred()` (OOM-0013). On `res == NULL` it still runs a heavier second parse pass and `_PyPegen_set_syntax_error_metadata`, which can `PyErr_Clear()` internally. Under sustained OOM the recovery path can finish with `tstate->current_exception == NULL` and `return NULL`, violating the C-API result/error contract. Callers such as the symtable path then fatal in `Objects/call.c`.

---

## Why I solved it that way

1. **Restore the contract at the return site** with:

   ```c
   if (!PyErr_Occurred()) {
       PyErr_NoMemory();
   }
   ```

   This matches the idiom already used nearby after OOM-0013 (`Parser/pegen.c` other arms). `PyErr_NoMemory()` is safe under OOM (preallocated singleton).

2. **Do not remove `_Py_CheckFunctionResult`'s fatal** — that enforces the contract for the whole C API; weakening it would hide extension bugs.

3. **Do not yet rewrite `_PyPegen_set_syntax_error_metadata` to save/restore** around its `PyErr_Clear` calls — that is a nicer long-term fix but larger and riskier; the belt at the return site closes the crash now.

4. **Separate PR from other OOM findings** per umbrella policy (one PR per bug).

---

## How I did it

At the end of the `res == NULL` block in `_PyPegen_run_parser`, after syntax-error metadata setup and before `return NULL`:

```c
if (!PyErr_Occurred()) {
    /* Under OOM the recovery pass can clear the exception and fail
       silently; restore the result/error contract. */
    PyErr_NoMemory();
}
return NULL;
```

NEWS under Core and Builtins for gh-151763 (OOM-0021).

---

## Impact

- Converts a hard fatal / abort under parser OOM into a normal `MemoryError`.
- Success-path parsing unchanged.
- Complements OOM-0013 rather than duplicating it (that fix covered the `res != NULL` contradiction).

---

## Testing plan

- [x] Rebuild debug interpreter.
- [x] Parser-related tests via normal suite smoke; full `test_peg_generator` needs extra resources (skipped in default run).
- [ ] Optional: fusil/OOM-0021 gist repro with `set_nomemory` sweep — not automated here.
- [ ] CI: full parser / test_grammar / test_syntax jobs.

---

## Everything else

- Umbrella gh-151763, finding **OOM-0021**.
- Related merged fix: OOM-0013 (#151968).
- Reviewers: parser / pegen owners + OOM umbrella.

<!-- gh-issue-151763 -->

---

## Requested reviewers (subject-matter experts)

Could the following SMEs take a look when convenient (I cannot formally request reviews from this fork account):

- **lysnikolaou** / **pablogsal** — parser / pegen
- **devdanzin** — OOM umbrella

Thank you!
