### PR TITLE
gh-153711: Guard dup3/pipe2 with __builtin_available on Apple platforms

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1448,7 +1448,8 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    Return a pair of file descriptors ``(r, w)`` usable for reading and writing,
    respectively.
 
-   .. availability:: Unix, not WASI, not macOS, not iOS.
+   .. availability:: Unix, not WASI.  Availability on macOS requires macOS 27.0
+      or later; availability on iOS requires iOS 27.0 or later.
 
    .. versionadded:: 3.3
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1448,8 +1448,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    Return a pair of file descriptors ``(r, w)`` usable for reading and writing,
    respectively.
 
-   .. availability:: Unix, not WASI.  Availability on macOS requires macOS 27.0
-      or later; availability on iOS requires iOS 27.0 or later.
+   .. availability:: Unix, not WASI, macOS >= 27.0, iOS >= 27.0.
 
    .. versionadded:: 3.3
 

--- a/Lib/test/test_os/test_posix.py
+++ b/Lib/test/test_os/test_posix.py
@@ -2388,6 +2388,22 @@ class TestPosixWeaklinking(unittest.TestCase):
             self.assertNotHasAttr(os, "pwritev")
             self.assertNotHasAttr(os, "preadv")
 
+    def test_pipe2(self):
+        self._verify_available("HAVE_PIPE2")
+        if self.mac_ver >= (27, 0):
+            self.assertHasAttr(os, "pipe2")
+        else:
+            self.assertNotHasAttr(os, "pipe2")
+
+    def test_dup3(self):
+        self._verify_available("HAVE_DUP3")
+        r, w = os.pipe()
+        self.addCleanup(os.close, r)
+        self.addCleanup(os.close, w)
+        # Must not crash even when dup3 unavailable at runtime.
+        # os.dup2 returns fd2 (here w); do not double-close.
+        os.dup2(r, w, inheritable=False)
+
     def test_stat(self):
         self._verify_available("HAVE_FSTATAT")
         if self.mac_ver >= (10, 10):

--- a/Misc/NEWS.d/next/macOS/2026-07-26-07-01-41.gh-issue-153711.ad8g_Q.rst
+++ b/Misc/NEWS.d/next/macOS/2026-07-26-07-01-41.gh-issue-153711.ad8g_Q.rst
@@ -1,0 +1,3 @@
+Guard ``os.dup2`` and ``os.pipe``/``os.pipe2`` against calling ``dup3``/``pipe2``
+when the symbols are weak-imported but unavailable at runtime (Xcode 27 SDKs on
+older macOS).

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -504,6 +504,8 @@ static const unsigned int _Py_STATX_KNOWN = (STATX_BASIC_STATS | STATX_BTIME
 #  define HAVE_MKFIFOAT_RUNTIME __builtin_available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 #  define HAVE_MKNODAT_RUNTIME __builtin_available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 #  define HAVE_PTSNAME_R_RUNTIME __builtin_available(macOS 10.13.4, iOS 11.3, tvOS 11.3, watchOS 4.3, *)
+#  define HAVE_DUP3_RUNTIME __builtin_available(macOS 27.0, iOS 27.0, tvOS 27.0, watchOS 27.0, *)
+#  define HAVE_PIPE2_RUNTIME __builtin_available(macOS 27.0, iOS 27.0, tvOS 27.0, watchOS 27.0, *)
 
 #  define HAVE_POSIX_SPAWN_SETSID_RUNTIME __builtin_available(macOS 10.15, *)
 
@@ -589,6 +591,14 @@ static const unsigned int _Py_STATX_KNOWN = (STATX_BASIC_STATS | STATX_BTIME
 #    define HAVE_PTSNAME_R_RUNTIME (ptsname_r != NULL)
 #  endif
 
+#  ifdef HAVE_DUP3
+#    define HAVE_DUP3_RUNTIME (dup3 != NULL)
+#  endif
+
+#  ifdef HAVE_PIPE2
+#    define HAVE_PIPE2_RUNTIME (pipe2 != NULL)
+#  endif
+
 #endif
 
 #ifdef HAVE_FUTIMESAT
@@ -619,6 +629,8 @@ static const unsigned int _Py_STATX_KNOWN = (STATX_BASIC_STATS | STATX_BTIME
 #  define HAVE_MKFIFOAT_RUNTIME 1
 #  define HAVE_MKNODAT_RUNTIME 1
 #  define HAVE_PTSNAME_R_RUNTIME 1
+#  define HAVE_DUP3_RUNTIME 1
+#  define HAVE_PIPE2_RUNTIME 1
 #endif
 
 
@@ -11910,16 +11922,21 @@ os_dup2_impl(PyObject *module, int fd, int fd2, int inheritable)
 
 #ifdef HAVE_DUP3
     if (!inheritable && dup3_works != 0) {
-        Py_BEGIN_ALLOW_THREADS
-        res = dup3(fd, fd2, O_CLOEXEC);
-        Py_END_ALLOW_THREADS
-        if (res < 0) {
-            if (dup3_works == -1)
-                dup3_works = (errno != ENOSYS);
-            if (dup3_works) {
-                posix_error();
-                return -1;
+        if (HAVE_DUP3_RUNTIME) {
+            Py_BEGIN_ALLOW_THREADS
+            res = dup3(fd, fd2, O_CLOEXEC);
+            Py_END_ALLOW_THREADS
+            if (res < 0) {
+                if (dup3_works == -1)
+                    dup3_works = (errno != ENOSYS);
+                if (dup3_works) {
+                    posix_error();
+                    return -1;
+                }
             }
+        }
+        else {
+            dup3_works = 0;
         }
     }
 
@@ -12779,9 +12796,13 @@ os_pipe_impl(PyObject *module)
 #else
 
 #ifdef HAVE_PIPE2
-    Py_BEGIN_ALLOW_THREADS
-    res = pipe2(fds, O_CLOEXEC);
-    Py_END_ALLOW_THREADS
+    res = -1;
+    errno = ENOSYS;
+    if (HAVE_PIPE2_RUNTIME) {
+        Py_BEGIN_ALLOW_THREADS
+        res = pipe2(fds, O_CLOEXEC);
+        Py_END_ALLOW_THREADS
+    }
 
     if (res != 0 && errno == ENOSYS)
     {
@@ -18806,6 +18827,18 @@ posixmodule_exec(PyObject *m)
             return -1;
         }
         if (PyDict_PopString(dct, "preadv", NULL) < 0) {
+            return -1;
+        }
+    }
+#endif
+
+#if defined(HAVE_PIPE2)
+    if (HAVE_PIPE2_RUNTIME) {} else {
+        PyObject *dct = PyModule_GetDict(m);
+        if (dct == NULL) {
+            return -1;
+        }
+        if (PyDict_PopString(dct, "pipe2", NULL) < 0) {
             return -1;
         }
     }


### PR DESCRIPTION
## Summary

Fix gh-153711 (deferred-blocker): when CPython is built with an Xcode 27 SDK, `dup3` / `pipe2` are detected at configure time but only exist at runtime on macOS / iOS 27+. On older OSes they bind as `weak_import` NULL and the first `os.pipe()` / non-inheritable `os.dup2()` jumps to address 0.

---

## What the issue is

1. Xcode 27 SDKs annotate `dup3`/`pipe2` with `__API_AVAILABLE(macos(27.0), iOS(27.0), …)`.
2. `AC_CHECK_FUNCS` synthesizes its own `char dup3();` prototype, **ignores** availability, links against `libSystem.tbd`, and defines `HAVE_DUP3` / `HAVE_PIPE2`.
3. `Modules/posixmodule.c` then calls them unconditionally inside `os_dup2_impl` / `os_pipe_impl` / `os_pipe2_impl`.
4. With `MACOSX_DEPLOYMENT_TARGET < 27`, the symbols are weak; on macOS 26 they are NULL → `EXC_BAD_ACCESS`.
5. `os.pipe()` is on the hot path of `subprocess`, `multiprocessing`, and `asyncio` — effectively a total-loss crash for python.org-style builds.

iOS was already excluded from the configure check (gh-150443 / #150444). **macOS was not.** The issue body already points at the gh-97897 (`mkfifoat`/`mknodat`) weak-linking pattern.

---

## Why I solved it that way

1. **Runtime `__builtin_available` guards**, not configure hacks — configure cannot see availability attributes, and we still want the symbols on macOS 27+.
2. **Reuse the existing three-arm `HAVE_*_RUNTIME` machinery** in `posixmodule.c` (modern / Xcode≤8 / non-Apple) documented in `Mac/README.rst`. Omitting any arm breaks the build.
3. **Sole-expression `if (HAVE_X_RUNTIME)`** — Apple's compiler rejects `if (!HAVE_X_RUNTIME)`.
4. **Latch `dup3_works = 0`** when unavailable so the existing `dup2`+`FD_CLOEXEC` fallback runs this call and every later call without re-probing.
5. **Seed `res = -1; errno = ENOSYS` before the pipe2 probe** so the existing ENOSYS → `pipe()` fallback still runs when the symbol is missing (uninitialized `res`/`errno` would be a footgun).
6. **Pop `os.pipe2` from the module dict** when unavailable (same idiom as `pwritev`/`preadv`) because `os_pipe2_impl` has no fallback and would crash on direct call. Existing tests already `hasattr(os, "pipe2")`.
7. **Omit visionOS** from `__builtin_available` — no other macro in the block names it; pre-Xcode-15 clang rejects the spelling.
8. **Honest verification limit:** this environment is Linux. Code mirrors gh-97897; an OS-mac core dev with Xcode 27 should confirm on macOS 26.

---

## How I did it

| Area | Change |
|------|--------|
| `Modules/posixmodule.c` | `HAVE_DUP3_RUNTIME` / `HAVE_PIPE2_RUNTIME` in all 3 arms; guard `dup3`/`pipe2` call sites; pop `pipe2` at exec |
| `Lib/test/test_os/test_posix.py` | `TestPosixWeaklinking.test_pipe2` / `test_dup3` |
| `Doc/library/os.rst` | `os.pipe2` availability notes macOS/iOS ≥ 27 |
| `Misc/NEWS.d/next/macOS/` | blurb for gh-153711 |

---

## Impact

- Unblocks building with Xcode 27 SDKs while deploying to macOS < 27.
- On Linux/non-Apple, macros are `1` — **zero codegen change** (constant-folded).
- On macOS ≥ 27, behavior unchanged (fast path still used).
- Deferred-blocker across 3.13–3.16 — backports appropriate after OS-mac review.

---

## Testing plan

- [x] Linux debug build + `./python -m test test_os.test_posix` — PASS (weaklinking class skipped on non-macOS, as designed).
- [x] Smoke: `os.pipe()` / `os.dup2(..., inheritable=False)` on Linux — OK.
- [ ] **Needed from reviewer / buildbot:** macOS 26 host, Xcode 27 SDK, deployment target < 27:
  - Before: crash on `os.pipe()` / `os.pipe2` / non-inheritable `dup2`.
  - After: `os.pipe()` works via fallback; `hasattr(os, "pipe2")` is False; `TestPosixWeaklinking` assertions hold.
- [ ] macOS 27+ : `pipe2` present, weaklinking tests assert attrs exist.
- [ ] CI: macOS jobs (will not fully exercise the Xcode 27 × older OS matrix).

---

## Everything else

- **Does not undo** iOS configure exclusion from #150444.
- **Pattern credit:** Ned Deily's gh-97897 / commit for mkfifoat/mknodat.
- **Backports:** 3.15, 3.14, 3.13 after merge.
- **Reviewers:** OS-mac / Apple platform SMEs.

<!-- gh-issue-153711 -->

---

## Requested reviewers (subject-matter experts)

Could the following SMEs take a look when convenient (I cannot formally request reviews from this fork account):

- **ned-deily** — OS-mac / weak-linking (gh-97897 pattern)
- **ronaldoussoren** — macOS
- **freakboy3742** — Apple/iOS (adjacent gh-150443)

Thank you!
