### PR TITLE
gh-154709: Fix out-of-bounds access in dict reverse iterator

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1411,12 +1411,18 @@ class DictTest(unittest.TestCase):
         for i in range(1, 1000):
             del d[f"k{i}"]
 
-        it = reversed(d)
+        iterators = (
+            reversed(d),
+            reversed(d.keys()),
+            reversed(d.values()),
+            reversed(d.items()),
+        )
 
         d.clear()
         d["k0"] = 0
 
-        self.assertEqual(list(it), [])
+        for it in iterators:
+            self.assertEqual(list(it), [])
 
     def test_dict_copy_order(self):
         # bpo-34320

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1403,6 +1403,21 @@ class DictTest(unittest.TestCase):
         self.assertEqual(list(reversed(A(1, 0).__dict__)), ['x'])
         self.assertEqual(list(reversed(A(0, 1).__dict__)), ['y'])
 
+    def test_reversed_dict_after_clear_and_restore(self):
+        d = {}
+        for i in range(1000):
+            d[f"k{i}"] = i
+
+        for i in range(1, 1000):
+            del d[f"k{i}"]
+
+        it = reversed(d)
+
+        d.clear()
+        d["k0"] = 0
+
+        self.assertEqual(list(it), [])
+
     def test_dict_copy_order(self):
         # bpo-34320
         od = collections.OrderedDict([('a', 1), ('b', 2)])

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-26-09-07-41.gh-issue-154709.M2uZ76.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-26-09-07-41.gh-issue-154709.M2uZ76.rst
@@ -1,0 +1,2 @@
+Fix an out-of-bounds access in reverse dictionary iterators when the
+underlying dictionary is cleared and modified after the iterator is created.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -6274,14 +6274,10 @@ dictreviter_iter_lock_held(PyDictObject *d, PyObject *self)
     }
 
     if (_PyDict_HasSplitTable(d)) {
-        if (i >= d->ma_used) {
-            goto fail;
-        }
-
         int index = get_index_from_order(d, i);
         key = LOAD_SHARED_KEY(DK_UNICODE_ENTRIES(k)[index].me_key);
         value = d->ma_values->values[index];
-        assert (value != NULL);
+        assert(value != NULL);
     }
     else {
         if (i >= k->dk_nentries) {

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -6272,7 +6272,6 @@ dictreviter_iter_lock_held(PyDictObject *d, PyObject *self)
     if (i < 0) {
         goto fail;
     }
-
     if (_PyDict_HasSplitTable(d)) {
         int index = get_index_from_order(d, i);
         key = LOAD_SHARED_KEY(DK_UNICODE_ENTRIES(k)[index].me_key);

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -6272,13 +6272,23 @@ dictreviter_iter_lock_held(PyDictObject *d, PyObject *self)
     if (i < 0) {
         goto fail;
     }
+
     if (_PyDict_HasSplitTable(d)) {
+        if (i >= d->ma_used) {
+            goto fail;
+        }
+
         int index = get_index_from_order(d, i);
         key = LOAD_SHARED_KEY(DK_UNICODE_ENTRIES(k)[index].me_key);
         value = d->ma_values->values[index];
         assert (value != NULL);
     }
     else {
+        Py_ssize_t n = k->dk_nentries;
+        if (i >= n) {
+            goto fail;
+        }
+
         if (DK_IS_UNICODE(k)) {
             PyDictUnicodeEntry *entry_ptr = &DK_UNICODE_ENTRIES(k)[i];
             while (entry_ptr->me_value == NULL) {

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -6284,11 +6284,9 @@ dictreviter_iter_lock_held(PyDictObject *d, PyObject *self)
         assert (value != NULL);
     }
     else {
-        Py_ssize_t n = k->dk_nentries;
-        if (i >= n) {
+        if (i >= k->dk_nentries) {
             goto fail;
         }
-
         if (DK_IS_UNICODE(k)) {
             PyDictUnicodeEntry *entry_ptr = &DK_UNICODE_ENTRIES(k)[i];
             while (entry_ptr->me_value == NULL) {


### PR DESCRIPTION
## Summary

Fix an out-of-bounds access in `dictreviter_iter_lock_held()` when a reverse dictionary iterator is used after the underlying dictionary is cleared and modified.

The fix adds bounds checks before indexing into the dictionary's storage for both split-table and combined-table dictionaries. If the iterator's position is no longer valid, it now exits cleanly instead of accessing invalid memory.

A regression test has also been added to verify that this scenario no longer results in a crash.

## Testing

- Reproduced the original crash using the provided reproducer before the fix.
- Verified that the reproducer no longer crashes after the fix.
- Ran:
  - `./python -m test test_dict`
  - `./python -m test test_gc`
  - `./python -m test test_builtin`
  - `./python -m test test_dict test_gc test_builtin`

<!-- gh-issue-number: gh-154709 -->
* Issue: gh-154709
<!-- /gh-issue-number -->
