### PR TITLE
gh-154682: Fix corruption of locale-encoded text on FreeBSD, NetBSD, DragonFly BSD and macOS

### DIFF
--- a/Include/internal/pycore_fileutils.h
+++ b/Include/internal/pycore_fileutils.h
@@ -243,6 +243,7 @@ extern void _Py_ResetForceASCII(void);
 // Convert between Unicode code points and the native wchar_t form for
 // C library functions which use the latter (such as the curses library).
 // Export for '_curses'.
+PyAPI_FUNC(int) _Py_LocaleNeedsWcharConversion(void);
 PyAPI_FUNC(int) _Py_UnicodeToLocaleWchar_InPlace(wchar_t *str, Py_ssize_t size);
 PyAPI_FUNC(void) _Py_LocaleWcharToUnicode_InPlace(wchar_t *str, Py_ssize_t size);
 #endif

--- a/Include/internal/pycore_fileutils.h
+++ b/Include/internal/pycore_fileutils.h
@@ -225,6 +225,28 @@ extern int _Py_GetForceASCII(void);
    encoding. */
 extern void _Py_ResetForceASCII(void);
 
+#ifdef HAVE_LANGINFO_H
+#  include <langinfo.h>           // CODESET
+#endif
+
+/* On FreeBSD, NetBSD, DragonFly BSD and macOS, wchar_t values are not
+   Unicode code points in non-UTF-8 locales.  Locale-encoded text is converted
+   with iconv() (see Python/fileutils.c), and the wide character
+   functions which use the locale (such as wcscoll()) cannot be used
+   with Unicode wchar_t. */
+#if (defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) \
+     || defined(__APPLE__)) \
+    && defined(HAVE_ICONV) \
+    && defined(HAVE_LANGINFO_H) && defined(CODESET) && SIZEOF_WCHAR_T == 4
+#  define _Py_NON_UNICODE_WCHAR_T
+
+// Convert between Unicode code points and the native wchar_t form for
+// C library functions which use the latter (such as the curses library).
+// Export for '_curses'.
+PyAPI_FUNC(int) _Py_UnicodeToLocaleWchar_InPlace(wchar_t *str, Py_ssize_t size);
+PyAPI_FUNC(void) _Py_LocaleWcharToUnicode_InPlace(wchar_t *str, Py_ssize_t size);
+#endif
+
 
 extern int _Py_GetLocaleconvNumeric(
     struct lconv *lc,

--- a/Include/internal/pycore_runtime_structs.h
+++ b/Include/internal/pycore_runtime_structs.h
@@ -52,6 +52,12 @@ struct pyhash_runtime_state {
 
 struct _fileutils_state {
     int force_ascii;
+    /* Memoized result of _Py_LocaleNeedsWcharConversion() with the locale
+       encoding it was computed for (see Python/fileutils.c). */
+    struct _Py_wchar_conversion_state {
+        char codeset[32];
+        int needed;
+    } wchar;
 };
 
 #include "pycore_interpframe_structs.h" // _PyInterpreterFrame

--- a/Lib/test/test_locale.py
+++ b/Lib/test/test_locale.py
@@ -350,6 +350,53 @@ class TestCollation(unittest.TestCase):
         self.assertRaises(ValueError, locale.strxfrm, 'a\0')
 
 
+class TestCollationAcrossEncodings(unittest.TestCase):
+    # gh-154682: collation must give the same results in locales which
+    # only differ in the encoding.
+
+    @support.thread_unsafe('setlocale is not thread-safe')
+    @unittest.skipIf(sys.platform.startswith("netbsd"),
+                     "gh-124108: NetBSD doesn't support UTF-8 for LC_COLLATE")
+    @unittest.skipIf(sys.platform.startswith("dragonfly") or
+                     sys.platform == "darwin",
+                     "no collation data for non-UTF-8 locales")
+    def test_across_encodings(self):
+        def sign(x):
+            return (x > 0) - (x < 0)
+        cases = [
+            ('uk_UA.UTF-8', 'uk_UA.KOI8-U', 'гґдиіїя'),
+            ('uk_UA.UTF-8', 'uk_UA.CP1251', 'гґдиіїя'),
+            ('el_GR.UTF-8', 'el_GR.ISO8859-7', 'αβδω'),
+            ('de_DE.UTF-8', 'de_DE.ISO8859-1', 'aäbößz'),
+            ('tr_TR.UTF-8', 'tr_TR.ISO8859-9', 'cçdıisşz'),
+            ('ca_ES.UTF-8', 'ca_ES.ISO8859-1', 'cçde'),
+        ]
+        oldloc = locale.setlocale(locale.LC_ALL)
+        self.addCleanup(locale.setlocale, locale.LC_ALL, oldloc)
+        tested = False
+        for utf8_loc, legacy_loc, chars in cases:
+            try:
+                locale.setlocale(locale.LC_ALL, utf8_loc)
+            except locale.Error:
+                continue
+            expected_order = sorted(chars, key=locale.strxfrm)
+            expected_signs = [[sign(locale.strcoll(a, b)) for b in chars]
+                              for a in chars]
+            try:
+                locale.setlocale(locale.LC_ALL, legacy_loc)
+            except locale.Error:
+                continue
+            with self.subTest(locale=legacy_loc):
+                self.assertEqual(sorted(chars, key=locale.strxfrm),
+                                 expected_order)
+                signs = [[sign(locale.strcoll(a, b)) for b in chars]
+                         for a in chars]
+                self.assertEqual(signs, expected_signs)
+            tested = True
+        if not tested:
+            self.skipTest('no suitable locales')
+
+
 class TestEnUSCollation(BaseLocalizedTest, TestCollation):
     # Test string collation functions with a real English locale
 

--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -125,6 +125,10 @@ class TestHistoryManipulation (unittest.TestCase):
             readline.append_history_file(-2147483648, hfilename)
 
     def test_nonascii_history(self):
+        try:
+            "entrée".encode(locale.getencoding())
+        except UnicodeEncodeError as err:
+            self.skipTest("Locale cannot encode test data: " + format(err))
         readline.clear_history()
         try:
             readline.add_history("entrée 1")

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -3,6 +3,7 @@ from test.support import warnings_helper
 import decimal
 import enum
 import fractions
+import locale
 import math
 import platform
 import sys
@@ -231,6 +232,41 @@ class TimeTestCase(unittest.TestCase):
                 self.fail('conversion specifier: %r failed.' % format)
 
         self.assertRaises(TypeError, time.strftime, b'%S', tt)
+
+    @support.thread_unsafe('setlocale is not thread-safe')
+    def test_strftime_locale_encodings(self):
+        # gh-154682: the result must be the same in locales which only
+        # differ in the encoding.
+        pairs = [
+            ('uk_UA.UTF-8', 'uk_UA.KOI8-U'),
+            ('uk_UA.UTF-8', 'uk_UA.CP1251'),
+            ('el_GR.UTF-8', 'el_GR.ISO8859-7'),
+            ('ja_JP.UTF-8', 'ja_JP.eucJP'),
+            ('de_DE.UTF-8', 'de_DE.ISO8859-1'),
+            ('tr_TR.UTF-8', 'tr_TR.ISO8859-9'),
+            ('ca_ES.UTF-8', 'ca_ES.ISO8859-1'),
+        ]
+        oldloc = locale.setlocale(locale.LC_ALL)
+        self.addCleanup(locale.setlocale, locale.LC_ALL, oldloc)
+        # Wednesday, March: non-ASCII in all tested locales
+        # (including Turkish and German)
+        tt = (2026, 3, 4, 12, 34, 56, 2, 63, 0)
+        tested = False
+        for utf8_loc, legacy_loc in pairs:
+            try:
+                locale.setlocale(locale.LC_ALL, utf8_loc)
+            except locale.Error:
+                continue
+            expected = time.strftime('%A, %B', tt)
+            try:
+                locale.setlocale(locale.LC_ALL, legacy_loc)
+            except locale.Error:
+                continue
+            with self.subTest(locale=legacy_loc):
+                self.assertEqual(time.strftime('%A, %B', tt), expected)
+            tested = True
+        if not tested:
+            self.skipTest('no suitable locales')
 
     def test_strftime_invalid_format(self):
         tt = time.gmtime(self.t)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-25-13-50-00.gh-issue-154682.wChBSD.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-25-13-50-00.gh-issue-154682.wChBSD.rst
@@ -1,0 +1,10 @@
+Fix corruption of locale-encoded text on FreeBSD, NetBSD, DragonFly BSD
+and macOS
+in non-UTF-8 locales,
+e.g. in the results of :func:`time.strftime` and :func:`locale.nl_langinfo`,
+in localized error messages,
+and in decoding of the command line arguments,
+fix wrong collation in :func:`locale.strcoll` and :func:`locale.strxfrm`,
+and fix display and input of non-ASCII characters in :mod:`curses`.
+``wchar_t`` values are not Unicode code points on these platforms,
+so ``iconv()`` is now used instead of ``mbstowcs()`` and ``wcstombs()``.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -527,6 +527,11 @@ PyCurses_ConvertToWideCell(PyObject *obj, wchar_t *wch)
                      (int)CCHARW_MAX, PyUnicode_GET_LENGTH(obj));
         return -1;
     }
+#ifdef _Py_NON_UNICODE_WCHAR_T
+    if (_Py_UnicodeToLocaleWchar_InPlace(wch, nch) < 0) {
+        return -1;
+    }
+#endif
     /* A lone control character is allowed (like addch(ord('\n'))), but in a
        multi-character cell the base must be a printable spacing character and
        the rest zero-width combining characters.  Check explicitly: otherwise
@@ -622,6 +627,13 @@ PyCurses_ConvertToString(PyCursesWindowObject *win, PyObject *obj,
         *wstr = PyUnicode_AsWideCharString(obj, NULL);
         if (*wstr == NULL)
             return 0;
+#ifdef _Py_NON_UNICODE_WCHAR_T
+        if (_Py_UnicodeToLocaleWchar_InPlace(*wstr, wcslen(*wstr)) < 0) {
+            PyMem_Free(*wstr);
+            *wstr = NULL;
+            return 0;
+        }
+#endif
         return 2;
 #else
         assert (wstr == NULL);
@@ -880,6 +892,9 @@ curses_cell_text(cursesmodule_state *state, const curses_cell_t *cell)
         PyErr_SetString(state->error, "getcchar() returned ERR");
         return NULL;
     }
+#ifdef _Py_NON_UNICODE_WCHAR_T
+    _Py_LocaleWcharToUnicode_InPlace(wstr, wcslen(wstr));
+#endif
     return PyUnicode_FromWideChar(wstr, -1);
 #else
     char ch = (char)(*cell & A_CHARTEXT);
@@ -1296,6 +1311,12 @@ complexstr_from_string(cursesmodule_state *state, PyObject *str,
     if (wbuf == NULL) {
         return NULL;
     }
+#ifdef _Py_NON_UNICODE_WCHAR_T
+    if (_Py_UnicodeToLocaleWchar_InPlace(wbuf, n) < 0) {
+        PyMem_Free(wbuf);
+        return NULL;
+    }
+#endif
     curses_cell_t *cells = n > 0 ? PyMem_New(curses_cell_t, n) : NULL;
     if (n > 0 && cells == NULL) {
         PyMem_Free(wbuf);
@@ -1585,6 +1606,9 @@ complexstr_str(PyObject *self)
         }
         pos += wcslen(buf + pos);
     }
+#ifdef _Py_NON_UNICODE_WCHAR_T
+    _Py_LocaleWcharToUnicode_InPlace(buf, pos);
+#endif
     PyObject *res = PyUnicode_FromWideChar(buf, pos);
     PyMem_Free(buf);
     return res;
@@ -3276,6 +3300,13 @@ _curses_window_getkey_impl(PyCursesWindowObject *self, int group_right_1,
         }
 #endif
 #endif
+#ifdef _Py_NON_UNICODE_WCHAR_T
+        {
+            wchar_t wch = (wchar_t)rtn;
+            _Py_LocaleWcharToUnicode_InPlace(&wch, 1);
+            return PyUnicode_FromOrdinal(wch);
+        }
+#endif
         return PyUnicode_FromOrdinal(rtn);
     } else {
         const char *knp = keyname(rtn);
@@ -3325,8 +3356,16 @@ _curses_window_get_wch_impl(PyCursesWindowObject *self, int group_right_1,
     }
     if (ct == KEY_CODE_YES)
         return PyLong_FromLong(rtn);
+#ifdef _Py_NON_UNICODE_WCHAR_T
+    else {
+        wchar_t wch = (wchar_t)rtn;
+        _Py_LocaleWcharToUnicode_InPlace(&wch, 1);
+        return PyUnicode_FromOrdinal(wch);
+    }
+#else
     else
         return PyUnicode_FromOrdinal(rtn);
+#endif
 #else
     /* Without the wide library, read one key with wgetch(): a value above 255
        is a function key (returned as an int); a byte is decoded with the
@@ -3801,6 +3840,9 @@ PyCursesWindow_get_wstr(PyObject *op, PyObject *args)
     for (Py_ssize_t i = 0; i < len; i++) {
         wbuf[i] = (wchar_t)buf[i];
     }
+#ifdef _Py_NON_UNICODE_WCHAR_T
+    _Py_LocaleWcharToUnicode_InPlace(wbuf, len);
+#endif
     PyObject *res = PyUnicode_FromWideChar(wbuf, len);
     PyMem_Free(wbuf);
     PyMem_Free(buf);
@@ -3866,6 +3908,9 @@ PyCursesWindow_in_wstr(PyObject *op, PyObject *args)
         PyMem_Free(buf);
         return Py_GetConstant(Py_CONSTANT_EMPTY_STR);
     }
+#ifdef _Py_NON_UNICODE_WCHAR_T
+    _Py_LocaleWcharToUnicode_InPlace(buf, wcslen(buf));
+#endif
     PyObject *res = PyUnicode_FromWideChar(buf, -1);
     PyMem_Free(buf);
     return res;
@@ -5854,6 +5899,9 @@ _curses_erasewchar_impl(PyObject *module)
         curses_set_error(module, "erasewchar", NULL);
         return NULL;
     }
+#ifdef _Py_NON_UNICODE_WCHAR_T
+    _Py_LocaleWcharToUnicode_InPlace(&ch, 1);
+#endif
     return PyUnicode_FromWideChar(&ch, 1);
 #else
     /* Without the wide library, decode the single-byte erase character
@@ -7076,6 +7124,9 @@ _curses_killwchar_impl(PyObject *module)
         curses_set_error(module, "killwchar", NULL);
         return NULL;
     }
+#ifdef _Py_NON_UNICODE_WCHAR_T
+    _Py_LocaleWcharToUnicode_InPlace(&ch, 1);
+#endif
     return PyUnicode_FromWideChar(&ch, 1);
 #else
     /* Without the wide library, decode the single-byte kill character
@@ -8018,6 +8069,19 @@ _curses_wunctrl(PyObject *module, PyObject *ch)
         curses_set_null_error(module, "wunctrl", NULL);
         return NULL;
     }
+#ifdef _Py_NON_UNICODE_WCHAR_T
+    {
+        /* wunctrl() returns a pointer to a static buffer; make a copy
+           before converting in place. */
+        wchar_t wbuf[8];
+        size_t len = wcslen(res);
+        if (len < Py_ARRAY_LENGTH(wbuf)) {
+            wcscpy(wbuf, res);
+            _Py_LocaleWcharToUnicode_InPlace(wbuf, len);
+            return PyUnicode_FromWideChar(wbuf, len);
+        }
+    }
+#endif
     return PyUnicode_FromWideChar(res, -1);
 #else
     /* Without the wide library, fall back to the single-byte unctrl() and
@@ -8107,6 +8171,10 @@ _curses_ungetch(PyObject *module, PyObject *ch)
         wchar_t wch;
         if (!PyCurses_ConvertToWchar_t(ch, &wch))
             return NULL;
+#ifdef _Py_NON_UNICODE_WCHAR_T
+        if (_Py_UnicodeToLocaleWchar_InPlace(&wch, 1) < 0)
+            return NULL;
+#endif
         return curses_check_err(module, unget_wch(wch), "unget_wch", "ungetch");
     }
 #endif
@@ -8138,6 +8206,10 @@ _curses_unget_wch(PyObject *module, PyObject *ch)
     if (!PyCurses_ConvertToWchar_t(ch, &wch))
         return NULL;
 #ifdef HAVE_NCURSESW
+#ifdef _Py_NON_UNICODE_WCHAR_T
+    if (_Py_UnicodeToLocaleWchar_InPlace(&wch, 1) < 0)
+        return NULL;
+#endif
     return curses_check_err(module, unget_wch(wch), "unget_wch", NULL);
 #else
     /* Without the wide library there is no unget_wch(): encode the character as
@@ -8226,6 +8298,12 @@ _curses_slk_set_impl(PyObject *module, int labnum, PyObject *label,
     if (wstr == NULL) {
         return NULL;
     }
+#ifdef _Py_NON_UNICODE_WCHAR_T
+    if (_Py_UnicodeToLocaleWchar_InPlace(wstr, wcslen(wstr)) < 0) {
+        PyMem_Free(wstr);
+        return NULL;
+    }
+#endif
     rtn = slk_wset(labnum, wstr, justify);
     PyMem_Free(wstr);
 #else

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -3657,18 +3657,18 @@ dotsep_as_utf8(const char *s)
 {
     PyObject *utf8;
     PyObject *tmp;
-    wchar_t buf[2];
-    size_t n;
 
-    n = mbstowcs(buf, s, 2);
-    if (n != 1) { /* Issue #7442 */
+    /* Do not use mbstowcs(): wchar_t values are not Unicode code points
+       in non-UTF-8 locales on some platforms (e.g. the BSDs and macOS). */
+    tmp = PyUnicode_DecodeLocale(s, NULL);
+    if (tmp == NULL) {
+        return NULL;
+    }
+    if (PyUnicode_GET_LENGTH(tmp) != 1) { /* Issue #7442 */
+        Py_DECREF(tmp);
         PyErr_SetString(PyExc_ValueError,
             "invalid decimal point or unsupported "
             "combination of LC_CTYPE and LC_NUMERIC");
-        return NULL;
-    }
-    tmp = PyUnicode_FromWideChar(buf, n);
-    if (tmp == NULL) {
         return NULL;
     }
     utf8 = PyUnicode_AsUTF8String(tmp);

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -407,6 +407,7 @@ _locale_strcoll_impl(PyObject *module, PyObject *os1, PyObject *os2)
 /*[clinic end generated code: output=82ddc6d62c76d618 input=693cd02bcbf38dd8]*/
 {
 #ifdef _Py_NON_UNICODE_WCHAR_T
+  if (_Py_LocaleNeedsWcharConversion()) {
     /* wchar_t is not Unicode in non-UTF-8 locales and the collation
        tables are keyed by the raw locale values, so wcscoll() cannot
        be used with Unicode wchar_t.  Encode to the locale encoding
@@ -424,7 +425,9 @@ _locale_strcoll_impl(PyObject *module, PyObject *os1, PyObject *os2)
     }
     Py_DECREF(b1);
     return result;
-#else
+  }
+#endif
+    {
     PyObject *result = NULL;
     wchar_t *ws1 = NULL, *ws2 = NULL;
 
@@ -442,7 +445,7 @@ _locale_strcoll_impl(PyObject *module, PyObject *os1, PyObject *os2)
     if (ws1) PyMem_Free(ws1);
     if (ws2) PyMem_Free(ws2);
     return result;
-#endif
+    }
 }
 #endif
 
@@ -462,6 +465,7 @@ _locale_strxfrm_impl(PyObject *module, PyObject *str)
 /*[clinic end generated code: output=3081866ebffc01af input=1378bbe6a88b4780]*/
 {
 #ifdef _Py_NON_UNICODE_WCHAR_T
+  if (_Py_LocaleNeedsWcharConversion()) {
     /* wchar_t is not Unicode in non-UTF-8 locales and the collation
        tables are keyed by the raw locale values, so wcsxfrm() cannot
        be used with Unicode wchar_t.  Encode to the locale encoding
@@ -498,7 +502,9 @@ _locale_strxfrm_impl(PyObject *module, PyObject *str)
 error:
     Py_DECREF(bytes);
     return result;
-#else
+  }
+#endif
+    {
     Py_ssize_t n1;
     wchar_t *s = NULL, *buf = NULL;
     wchar_t dummy[1];
@@ -586,7 +592,7 @@ exit:
     PyMem_Free(buf);
     PyMem_Free(s);
     return result;
-#endif /* _Py_NON_UNICODE_WCHAR_T */
+    }
 }
 #endif
 

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -406,6 +406,25 @@ static PyObject *
 _locale_strcoll_impl(PyObject *module, PyObject *os1, PyObject *os2)
 /*[clinic end generated code: output=82ddc6d62c76d618 input=693cd02bcbf38dd8]*/
 {
+#ifdef _Py_NON_UNICODE_WCHAR_T
+    /* wchar_t is not Unicode in non-UTF-8 locales and the collation
+       tables are keyed by the raw locale values, so wcscoll() cannot
+       be used with Unicode wchar_t.  Encode to the locale encoding
+       and use strcoll(). */
+    PyObject *result = NULL;
+    PyObject *b1 = PyUnicode_EncodeLocale(os1, NULL);
+    if (b1 == NULL) {
+        return NULL;
+    }
+    PyObject *b2 = PyUnicode_EncodeLocale(os2, NULL);
+    if (b2 != NULL) {
+        result = PyLong_FromLong(strcoll(PyBytes_AS_STRING(b1),
+                                         PyBytes_AS_STRING(b2)));
+        Py_DECREF(b2);
+    }
+    Py_DECREF(b1);
+    return result;
+#else
     PyObject *result = NULL;
     wchar_t *ws1 = NULL, *ws2 = NULL;
 
@@ -423,6 +442,7 @@ _locale_strcoll_impl(PyObject *module, PyObject *os1, PyObject *os2)
     if (ws1) PyMem_Free(ws1);
     if (ws2) PyMem_Free(ws2);
     return result;
+#endif
 }
 #endif
 
@@ -441,6 +461,44 @@ static PyObject *
 _locale_strxfrm_impl(PyObject *module, PyObject *str)
 /*[clinic end generated code: output=3081866ebffc01af input=1378bbe6a88b4780]*/
 {
+#ifdef _Py_NON_UNICODE_WCHAR_T
+    /* wchar_t is not Unicode in non-UTF-8 locales and the collation
+       tables are keyed by the raw locale values, so wcsxfrm() cannot
+       be used with Unicode wchar_t.  Encode to the locale encoding
+       and use strxfrm().  The result is decoded as Latin-1: it maps
+       bytes to code points in the same order, so comparison of the
+       resulting strings compares the byte sequences. */
+    PyObject *bytes = PyUnicode_EncodeLocale(str, NULL);
+    if (bytes == NULL) {
+        return NULL;
+    }
+    const char *s = PyBytes_AS_STRING(bytes);
+    PyObject *result = NULL;
+    char dummy[1];
+    errno = 0;
+    size_t n = strxfrm(dummy, s, 1);
+    if (errno && errno != ERANGE) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        goto error;
+    }
+    char *buf = PyMem_Malloc(n + 1);
+    if (buf == NULL) {
+        PyErr_NoMemory();
+        goto error;
+    }
+    errno = 0;
+    n = strxfrm(buf, s, n + 1);
+    if (errno) {
+        PyErr_SetFromErrno(PyExc_OSError);
+    }
+    else {
+        result = PyUnicode_DecodeLatin1(buf, n, NULL);
+    }
+    PyMem_Free(buf);
+error:
+    Py_DECREF(bytes);
+    return result;
+#else
     Py_ssize_t n1;
     wchar_t *s = NULL, *buf = NULL;
     wchar_t dummy[1];
@@ -528,6 +586,7 @@ exit:
     PyMem_Free(buf);
     PyMem_Free(s);
     return result;
+#endif /* _Py_NON_UNICODE_WCHAR_T */
 }
 #endif
 

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -770,6 +770,15 @@ the C library strftime function.\n"
 #  undef HAVE_WCSFTIME
 #endif
 
+// On FreeBSD, NetBSD, DragonFly BSD and macOS, wchar_t values are not
+// Unicode code points in non-UTF-8 locales, so the result of wcsftime()
+// cannot be used directly.  Use strftime() and decode its result with
+// PyUnicode_DecodeLocaleAndSize() (which handles such platforms).
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) \
+    || defined(__APPLE__)
+#  undef HAVE_WCSFTIME
+#endif
+
 #ifdef HAVE_WCSFTIME
 #define time_char wchar_t
 #define format_time wcsftime

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -541,15 +541,12 @@ decode_locale_iconv(const char *arg, wchar_t **wstr, size_t *wlen,
                 return _Py_ICONV_FALLBACK;
             }
             if (!surrogateescape) {
+                /* Leave it to mbstowcs() to decide whether the input is
+                   valid: it can be more permissive than iconv(), and a
+                   broken locale should not make the conversion fail. */
                 PyMem_RawFree(res);
                 iconv_close(cd);
-                if (wlen != NULL) {
-                    *wlen = in - arg;
-                }
-                if (reason != NULL) {
-                    *reason = "decoding error";
-                }
-                return -2;
+                return _Py_ICONV_FALLBACK;
             }
             /* Escape the byte as UTF-8b, and start over in the initial
                shift state. */

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -454,6 +454,363 @@ decode_ascii(const char *arg, wchar_t **wstr, size_t *wlen,
 }
 #endif   /* !HAVE_MBRTOWC */
 
+#ifdef _Py_NON_UNICODE_WCHAR_T
+/* wchar_t is not Unicode in non-UTF-8 locales (see pycore_fileutils.h),
+   so mbstowcs() and wcstombs() cannot be used to convert locale-encoded
+   text.  Use iconv() instead. */
+#  include <iconv.h>
+#  include <limits.h>             // MB_LEN_MAX
+/* Native-endian UTF-32: a raw array of Unicode code points (unlike
+   "UCS-4", it also validates the converted values). */
+#  ifdef WORDS_BIGENDIAN
+#    define _Py_UTF32_NATIVE "UTF-32BE"
+#  else
+#    define _Py_UTF32_NATIVE "UTF-32LE"
+#  endif
+/* Fall back to mbstowcs()/wcstombs(). */
+#  define _Py_ICONV_FALLBACK (-9)
+
+static iconv_t
+locale_iconv_open(int decode)
+{
+    const char *codeset = nl_langinfo(CODESET);
+    if (!codeset || !*codeset
+        || strcmp(codeset, "UTF-8") == 0
+        || strcmp(codeset, "US-ASCII") == 0
+        || strcmp(codeset, "646") == 0)
+    {
+        /* mbstowcs() and wcstombs() are correct for these encodings */
+        return (iconv_t)-1;
+    }
+    return decode ? iconv_open(_Py_UTF32_NATIVE, codeset)
+                  : iconv_open(codeset, _Py_UTF32_NATIVE);
+}
+
+static int
+decode_locale_iconv(const char *arg, wchar_t **wstr, size_t *wlen,
+                    const char **reason, _Py_error_handler errors)
+{
+    int surrogateescape;
+    if (get_surrogateescape(errors, &surrogateescape) < 0) {
+        return -3;
+    }
+
+    size_t argsize = strlen(arg);
+    int ascii = 1;
+    for (size_t i = 0; i < argsize; i++) {
+        if ((unsigned char)arg[i] >= 0x80) {
+            ascii = 0;
+            break;
+        }
+    }
+    if (ascii) {
+        return _Py_ICONV_FALLBACK;
+    }
+
+    iconv_t cd = locale_iconv_open(1);
+    if (cd == (iconv_t)-1) {
+        return _Py_ICONV_FALLBACK;
+    }
+
+    if (argsize > PY_SSIZE_T_MAX / sizeof(wchar_t) - 1) {
+        iconv_close(cd);
+        return -1;
+    }
+    /* the output cannot be longer than the number of input bytes */
+    wchar_t *res = PyMem_RawMalloc((argsize + 1) * sizeof(wchar_t));
+    if (res == NULL) {
+        iconv_close(cd);
+        return -1;
+    }
+
+    char *in = (char *)arg;
+    size_t inleft = argsize;
+    wchar_t *wout = res;
+    while (inleft > 0) {
+        char *out = (char *)wout;
+        size_t outleft = (res + argsize - wout) * sizeof(wchar_t);
+        /* Cast through void*: iconv() declares its second argument as
+           "char **" on most systems, but "const char **" on some. */
+        size_t converted = iconv(cd, (void *)&in, &inleft, &out, &outleft);
+        wout = (wchar_t *)out;
+        if (converted == (size_t)-1) {
+            if (errno != EILSEQ && errno != EINVAL) {
+                /* unexpected error: fall back to mbstowcs() */
+                PyMem_RawFree(res);
+                iconv_close(cd);
+                return _Py_ICONV_FALLBACK;
+            }
+            if (!surrogateescape) {
+                PyMem_RawFree(res);
+                iconv_close(cd);
+                if (wlen != NULL) {
+                    *wlen = in - arg;
+                }
+                if (reason != NULL) {
+                    *reason = "decoding error";
+                }
+                return -2;
+            }
+            /* Escape the byte as UTF-8b, and start over in the initial
+               shift state. */
+            *wout++ = 0xdc00 + (unsigned char)*in++;
+            inleft--;
+            iconv(cd, NULL, NULL, NULL, NULL);
+        }
+    }
+    iconv_close(cd);
+    *wout = L'\0';
+    *wstr = res;
+    if (wlen != NULL) {
+        *wlen = wout - res;
+    }
+    return 0;
+}
+
+static int
+encode_locale_iconv(const wchar_t *text, char **str,
+                    size_t *error_pos, const char **reason,
+                    int raw_malloc, _Py_error_handler errors)
+{
+    int surrogateescape;
+    if (get_surrogateescape(errors, &surrogateescape) < 0) {
+        return -3;
+    }
+
+    size_t len = wcslen(text);
+    int ascii = 1;
+    for (size_t i = 0; i < len; i++) {
+        if ((unsigned long)text[i] >= 0x80) {
+            ascii = 0;
+            break;
+        }
+    }
+    if (ascii) {
+        return _Py_ICONV_FALLBACK;
+    }
+
+    iconv_t cd = locale_iconv_open(0);
+    if (cd == (iconv_t)-1) {
+        return _Py_ICONV_FALLBACK;
+    }
+
+    char *result = NULL;
+    int res = -1;
+    if (len > (PY_SSIZE_T_MAX - MB_LEN_MAX - 1) / MB_LEN_MAX) {
+        goto done;
+    }
+    /* reserve room for the final shift sequence and the null byte */
+    size_t size = len * MB_LEN_MAX + MB_LEN_MAX + 1;
+    result = raw_malloc ? PyMem_RawMalloc(size) : PyMem_Malloc(size);
+    if (result == NULL) {
+        goto done;
+    }
+
+    const wchar_t *win = text;
+    const wchar_t *wend = text + len;
+    char *out = result;
+    size_t outleft = size - 1;
+    while (win < wend) {
+        wchar_t c = *win;
+        if (c >= 0xdc80 && c <= 0xdcff) {
+            if (!surrogateescape) {
+                goto encode_error;
+            }
+            /* UTF-8b surrogate: write the raw byte, and start over in
+               the initial shift state */
+            *out++ = (char)(c - 0xdc00);
+            outleft--;
+            win++;
+            iconv(cd, NULL, NULL, NULL, NULL);
+            continue;
+        }
+        /* Note: iconv() can replace a character which cannot be encoded
+           with an approximation (e.g. "'e" for "é" or "?"), depending
+           on the implementation. */
+        char *in = (char *)win;
+        size_t inleft = (wend - win) * sizeof(wchar_t);
+        /* Cast through void*: iconv() declares its second argument as
+           "char **" on most systems, but "const char **" on some. */
+        size_t converted = iconv(cd, (void *)&in, &inleft, &out, &outleft);
+        win = (const wchar_t *)in;
+        if (converted == (size_t)-1) {
+            if (errno != EILSEQ && errno != EINVAL) {
+                /* unexpected error: fall back to wcstombs() */
+                goto fallback;
+            }
+            /* iconv() stopped at the first character which cannot be
+               encoded; an escaped surrogate is handled at the start of
+               the next iteration */
+            if (!(*win >= 0xdc80 && *win <= 0xdcff)) {
+                goto encode_error;
+            }
+        }
+    }
+    /* write the final shift sequence for stateful encodings */
+    if (iconv(cd, NULL, NULL, &out, &outleft) == (size_t)-1) {
+        goto fallback;
+    }
+    *out = '\0';
+    *str = result;
+    result = NULL;
+    res = 0;
+    goto done;
+
+fallback:
+    res = _Py_ICONV_FALLBACK;
+    goto done;
+
+encode_error:
+    res = -2;
+    if (error_pos != NULL) {
+        *error_pos = win - text;
+    }
+    if (reason != NULL) {
+        *reason = "encoding error";
+    }
+
+done:
+    if (result != NULL) {
+        if (raw_malloc) {
+            PyMem_RawFree(result);
+        }
+        else {
+            PyMem_Free(result);
+        }
+    }
+    iconv_close(cd);
+    return res;
+}
+
+/* Convert a wide character string in place from Unicode code points to
+   the native wchar_t form, for passing to C library functions which
+   expect the latter (such as the curses library).
+   Return 0 on success.  Return -1 with an exception set if a character
+   cannot be represented in the locale encoding. */
+int
+_Py_UnicodeToLocaleWchar_InPlace(wchar_t *str, Py_ssize_t size)
+{
+    iconv_t cd = (iconv_t)-1;
+    int res = 0;
+    for (Py_ssize_t i = 0; i < size; i++) {
+        wchar_t wc = str[i];
+        if ((unsigned long)wc < 0x80
+            || ((unsigned long)wc >= 0xdc80 && (unsigned long)wc <= 0xdcff))
+        {
+            continue;
+        }
+        if (cd == (iconv_t)-1) {
+            cd = locale_iconv_open(0);
+            if (cd == (iconv_t)-1) {
+                /* wchar_t is Unicode for this locale encoding, or no
+                   conversion is possible */
+                return 0;
+            }
+        }
+        else {
+            /* reset cd to the initial shift state */
+            iconv(cd, NULL, NULL, NULL, NULL);
+        }
+        Py_UCS4 ch = (Py_UCS4)wc;
+        char buf[MB_LEN_MAX];
+        char *in = (char *)&ch;
+        size_t inleft = sizeof(ch);
+        char *out = buf;
+        size_t outleft = sizeof(buf);
+        mbstate_t mbs;
+        wchar_t converted;
+        size_t blen;
+        /* A non-zero result means that the character was replaced
+           with a substitute. */
+        if (iconv(cd, (void *)&in, &inleft, &out, &outleft) != 0
+            || inleft != 0)
+        {
+            goto encode_error;
+        }
+        /* locale bytes -> native form: exactly one wchar_t */
+        blen = sizeof(buf) - outleft;
+        memset(&mbs, 0, sizeof(mbs));
+        if (mbrtowc(&converted, buf, blen, &mbs) != blen) {
+            goto encode_error;
+        }
+        str[i] = converted;
+        continue;
+
+encode_error:
+        {
+            PyObject *obj = PyUnicode_FromOrdinal((int)wc);
+            if (obj != NULL) {
+                PyObject *exc = PyObject_CallFunction(
+                        PyExc_UnicodeEncodeError, "sOnns",
+                        nl_langinfo(CODESET), obj,
+                        (Py_ssize_t)0, (Py_ssize_t)1,
+                        "character maps to <undefined>");
+                if (exc != NULL) {
+                    PyCodec_StrictErrors(exc);
+                    Py_DECREF(exc);
+                }
+                Py_DECREF(obj);
+            }
+        }
+        res = -1;
+        break;
+    }
+    if (cd != (iconv_t)-1) {
+        iconv_close(cd);
+    }
+    return res;
+}
+
+/* The reverse conversion: from the native wchar_t form to Unicode
+   code points.  Values which cannot be converted are left unchanged. */
+void
+_Py_LocaleWcharToUnicode_InPlace(wchar_t *str, Py_ssize_t size)
+{
+    iconv_t cd = (iconv_t)-1;
+    for (Py_ssize_t i = 0; i < size; i++) {
+        wchar_t wc = str[i];
+        if ((unsigned long)wc < 0x80
+            || ((unsigned long)wc >= 0xdc80 && (unsigned long)wc <= 0xdcff))
+        {
+            continue;
+        }
+        /* native form -> locale bytes */
+        char buf[MB_LEN_MAX];
+        mbstate_t mbs;
+        memset(&mbs, 0, sizeof(mbs));
+        size_t blen = wcrtomb(buf, wc, &mbs);
+        if (blen == (size_t)-1) {
+            continue;
+        }
+        /* locale bytes -> Unicode */
+        if (cd == (iconv_t)-1) {
+            cd = locale_iconv_open(1);
+            if (cd == (iconv_t)-1) {
+                return;
+            }
+        }
+        else {
+            /* reset cd to the initial shift state */
+            iconv(cd, NULL, NULL, NULL, NULL);
+        }
+        char *in = buf;
+        size_t inleft = blen;
+        Py_UCS4 ch;
+        char *out = (char *)&ch;
+        size_t outleft = sizeof(ch);
+        if (iconv(cd, (void *)&in, &inleft, &out, &outleft) == (size_t)-1
+            || inleft != 0 || outleft != 0)
+        {
+            continue;
+        }
+        str[i] = (wchar_t)ch;
+    }
+    if (cd != (iconv_t)-1) {
+        iconv_close(cd);
+    }
+}
+#endif /* _Py_NON_UNICODE_WCHAR_T */
+
 static int
 decode_current_locale(const char* arg, wchar_t **wstr, size_t *wlen,
                       const char **reason, _Py_error_handler errors)
@@ -465,6 +822,13 @@ decode_current_locale(const char* arg, wchar_t **wstr, size_t *wlen,
     unsigned char *in;
     wchar_t *out;
     mbstate_t mbs;
+#endif
+
+#ifdef _Py_NON_UNICODE_WCHAR_T
+    int iconv_res = decode_locale_iconv(arg, wstr, wlen, reason, errors);
+    if (iconv_res != _Py_ICONV_FALLBACK) {
+        return iconv_res;
+    }
 #endif
 
     int surrogateescape;
@@ -682,6 +1046,14 @@ encode_current_locale(const wchar_t *text, char **str,
     char *result = NULL, *bytes = NULL;
     size_t i, size, converted;
     wchar_t c, buf[2];
+
+#ifdef _Py_NON_UNICODE_WCHAR_T
+    int iconv_res = encode_locale_iconv(text, str, error_pos, reason,
+                                        raw_malloc, errors);
+    if (iconv_res != _Py_ICONV_FALLBACK) {
+        return iconv_res;
+    }
+#endif
 
     int surrogateescape;
     if (get_surrogateescape(errors, &surrogateescape) < 0) {

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -470,15 +470,37 @@ decode_ascii(const char *arg, wchar_t **wstr, size_t *wlen,
 /* Fall back to mbstowcs()/wcstombs(). */
 #  define _Py_ICONV_FALLBACK (-9)
 
+/* Return non-zero if wchar_t is not Unicode in the current locale, i.e. if
+   the locale encoding is neither UTF-8 nor ASCII.  The result is memoized:
+   this is called before every conversion, and in the common case (a UTF-8
+   locale) it is the only overhead. */
+int
+_Py_LocaleNeedsWcharConversion(void)
+{
+    const char *codeset = nl_langinfo(CODESET);
+    if (codeset == NULL) {
+        return 0;
+    }
+    struct _Py_wchar_conversion_state *state = &_PyRuntime.fileutils.wchar;
+    if (strcmp(codeset, state->codeset) == 0) {
+        return state->needed;
+    }
+    int needed = (*codeset != '\0'
+                  && strcmp(codeset, "UTF-8") != 0
+                  && strcmp(codeset, "US-ASCII") != 0
+                  && strcmp(codeset, "646") != 0);
+    if (strlen(codeset) < sizeof(state->codeset)) {
+        memcpy(state->codeset, codeset, strlen(codeset) + 1);
+        state->needed = needed;
+    }
+    return needed;
+}
+
 static iconv_t
 locale_iconv_open(int decode)
 {
     const char *codeset = nl_langinfo(CODESET);
-    if (!codeset || !*codeset
-        || strcmp(codeset, "UTF-8") == 0
-        || strcmp(codeset, "US-ASCII") == 0
-        || strcmp(codeset, "646") == 0)
-    {
+    if (!_Py_LocaleNeedsWcharConversion()) {
         /* mbstowcs() and wcstombs() are correct for these encodings */
         return (iconv_t)-1;
     }
@@ -490,6 +512,10 @@ static int
 decode_locale_iconv(const char *arg, wchar_t **wstr, size_t *wlen,
                     const char **reason, _Py_error_handler errors)
 {
+    if (!_Py_LocaleNeedsWcharConversion()) {
+        return _Py_ICONV_FALLBACK;
+    }
+
     int surrogateescape;
     if (get_surrogateescape(errors, &surrogateescape) < 0) {
         return -3;
@@ -569,6 +595,10 @@ encode_locale_iconv(const wchar_t *text, char **str,
                     size_t *error_pos, const char **reason,
                     int raw_malloc, _Py_error_handler errors)
 {
+    if (!_Py_LocaleNeedsWcharConversion()) {
+        return _Py_ICONV_FALLBACK;
+    }
+
     int surrogateescape;
     if (get_surrogateescape(errors, &surrogateescape) < 0) {
         return -3;
@@ -687,6 +717,10 @@ done:
 int
 _Py_UnicodeToLocaleWchar_InPlace(wchar_t *str, Py_ssize_t size)
 {
+    if (!_Py_LocaleNeedsWcharConversion()) {
+        return 0;
+    }
+
     iconv_t cd = (iconv_t)-1;
     int res = 0;
     for (Py_ssize_t i = 0; i < size; i++) {
@@ -763,6 +797,10 @@ encode_error:
 void
 _Py_LocaleWcharToUnicode_InPlace(wchar_t *str, Py_ssize_t size)
 {
+    if (!_Py_LocaleNeedsWcharConversion()) {
+        return;
+    }
+
     iconv_t cd = (iconv_t)-1;
     for (Py_ssize_t i = 0; i < size; i++) {
         wchar_t wc = str[i];


### PR DESCRIPTION
On FreeBSD, NetBSD and DragonFly BSD, `wchar_t` values are not Unicode code points in non-UTF-8 locales: `mbstowcs()` and `wcstombs()` keep the raw locale values (e.g. the KOI8-U byte 0xD0 becomes 0x00D0, and the EUC-JP byte pair 0xB7 0xEE becomes 0xB7EE), and the collation tables and the curses library work with such values. This corrupted every interface which passes locale-encoded text through `wchar_t`:

* `time.strftime()` (and therefore `datetime` and `time.strptime()`) and `locale.nl_langinfo()` returned mojibake (e.g. `'ÐÏÎÅÄ¦ÌÏË'` instead of `'понеділок'` in the uk_UA.KOI8-U locale);
* `locale.localeconv()` and `format(n, 'n')` returned mojibake monetary and numeric strings;
* localized OSError, `ctypes` and other error messages were mojibake;
* `sys.argv` and other startup data could not round-trip through `os.fsencode()`;
* `locale.strcoll()` and `locale.strxfrm()` produced wrong collation (the collation tables are keyed by the raw locale values, and characters missing from the table are compared by their numeric value);
* the wide-character curses API could not display or read non-ASCII characters at all (Cyrillic text in a Cyrillic locale was rendered as blanks).

The fix converts between the locale encoding and Unicode with `iconv()` in `_Py_DecodeLocaleEx()` and `_Py_EncodeLocaleEx()` -- unlike the codec machinery, `iconv()` is usable in early interpreter startup, and the C library's `iconv()` supports all encodings used by its own locales. `time.strftime()` uses `strftime()` instead of `wcsftime()` (whose output is non-Unicode `wchar_t`), the `locale` module uses `strcoll()` and `strxfrm()` on the locale-encoded strings, and the curses module converts between Unicode and the native `wchar_t` form on the library boundary. If `iconv()` is not functional for the locale encoding, the current behavior is kept.

An alternative -- converting globally in `PyUnicode_FromWideChar()` and `PyUnicode_AsWideChar()` like on Oracle Solaris (`HAVE_NON_UNICODE_WCHAR_T_REPRESENTATION`) -- was prototyped and rejected: `wchar_t` at that boundary is also used as a plain Unicode container (e.g. `os.path.normpath()` is implemented on `wchar_t`), and on these platforms the raw locale values overlap with Unicode code points, so no boundary policy can distinguish the two uses. It broke 46-126 test files, either with hard errors or with silent corruption (`os.path.normpath('café')` returned `'cafФ'` in the KOI8-U locale).

Verified on FreeBSD 15.1, NetBSD 10.1 and DragonFly BSD 6.4 with Ukrainian, Greek, German, Turkish, Catalan and Japanese locales in eight encodings: the full test suite has no regressions, previously failing tests (`test_cmd_line.test_invalid_utf8_arg`) now pass, and `test_curses` passes in non-UTF-8 locales with the ncursesw backend. The full suite in the uk_UA.KOI8-U locale on FreeBSD now passes with zero failures.

Note: `test_logging.test_listen_server_error` in non-UTF-8 locales additionally needs the gh-93251 fix (#154683).


<!-- gh-issue-number: gh-154682 -->
* Issue: gh-154682
<!-- /gh-issue-number -->
