### PR TITLE
gh-154726: Fix `shutil.copyfile()` for symlinks to special files with `follow_symlinks=False`

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -292,8 +292,11 @@ def copyfile(src, dst, *, follow_symlinks=True):
     if _samefile(src, dst):
         raise SameFileError("{!r} and {!r} are the same file".format(src, dst))
 
+    copy_symlink = not follow_symlinks and _islink(src)
     file_size = 0
     for i, fn in enumerate([src, dst]):
+        if copy_symlink and i == 0:
+            continue
         try:
             st = _stat(fn)
         except OSError:
@@ -315,7 +318,7 @@ def copyfile(src, dst, *, follow_symlinks=True):
             if _WINDOWS and i == 0:
                 file_size = st.st_size
 
-    if not follow_symlinks and _islink(src):
+    if copy_symlink:
         os.symlink(os.readlink(src), dst)
     else:
         with open(src, 'rb') as fsrc:

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1583,6 +1583,19 @@ class TestCopy(BaseTest, unittest.TestCase):
         self.assertRaisesRegex(shutil.SpecialFileError, 'is a character device',
                                shutil.copyfile, src_file, '/dev/null')
 
+    @os_helper.skip_unless_symlink
+    @unittest.skipUnless(os.path.exists('/dev/null'), 'requires /dev/null')
+    def test_copyfile_symlink_to_character_device(self):
+        tmp_dir = self.mkdtemp()
+        src = os.path.join(tmp_dir, 'src')
+        dst = os.path.join(tmp_dir, 'dst')
+        os.symlink('/dev/null', src)
+
+        shutil.copyfile(src, dst, follow_symlinks=False)
+
+        self.assertTrue(os.path.islink(dst))
+        self.assertEqual(os.readlink(dst), '/dev/null')
+
     def test_copyfile_block_device(self):
         block_dev = None
         for dev in ['/dev/loop0', '/dev/sda', '/dev/vda', '/dev/disk0']:

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1606,12 +1606,7 @@ class TestCopy(BaseTest, unittest.TestCase):
         try:
             socket_helper.bind_unix_socket(sock, sock_path)
         except OSError as e:
-            if str(e) == "AF_UNIX path too long":
-                self.skipTest(
-                    "Pathname {0!a} is too long to serve as an AF_UNIX path"
-                    .format(sock_path))
-            else:
-                raise
+            self.skipTest(f'cannot bind AF_UNIX socket: {e}')
         self.addCleanup(os_helper.unlink, sock_path)
         self._check_copyfile_symlink_to_special_file(sock_path)
 

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1574,6 +1574,47 @@ class TestCopy(BaseTest, unittest.TestCase):
         self.assertRaisesRegex(shutil.SpecialFileError, 'is a socket',
                                shutil.copyfile, __file__, sock_path)
 
+    def _check_copyfile_symlink_to_special_file(self, target):
+        tmp_dir = self.mkdtemp()
+        src = os.path.join(tmp_dir, 'src')
+        dst = os.path.join(tmp_dir, 'dst')
+        os.symlink(target, src)
+
+        shutil.copyfile(src, dst, follow_symlinks=False)
+
+        self.assertTrue(os.path.islink(dst))
+        self.assertEqual(os.readlink(dst), target)
+
+    @os_helper.skip_unless_symlink
+    @unittest.skipUnless(hasattr(os, "mkfifo"), 'requires os.mkfifo()')
+    @unittest.skipIf(sys.platform == "vxworks",
+                    "fifo requires special path on VxWorks")
+    def test_copyfile_symlink_to_named_pipe(self):
+        fifo_path = os.path.join(self.mkdtemp(), 'fifo')
+        try:
+            os.mkfifo(fifo_path)
+        except PermissionError as e:
+            self.skipTest('os.mkfifo(): %s' % e)
+        self._check_copyfile_symlink_to_special_file(fifo_path)
+
+    @os_helper.skip_unless_symlink
+    @socket_helper.skip_unless_bind_unix_socket
+    def test_copyfile_symlink_to_socket(self):
+        sock_path = os.path.join(self.mkdtemp(), 'sock')
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.addCleanup(sock.close)
+        try:
+            socket_helper.bind_unix_socket(sock, sock_path)
+        except OSError as e:
+            if str(e) == "AF_UNIX path too long":
+                self.skipTest(
+                    "Pathname {0!a} is too long to serve as an AF_UNIX path"
+                    .format(sock_path))
+            else:
+                raise
+        self.addCleanup(os_helper.unlink, sock_path)
+        self._check_copyfile_symlink_to_special_file(sock_path)
+
     @unittest.skipUnless(os.path.exists('/dev/null'), 'requires /dev/null')
     def test_copyfile_character_device(self):
         self.assertRaisesRegex(shutil.SpecialFileError, 'is a character device',
@@ -1586,15 +1627,7 @@ class TestCopy(BaseTest, unittest.TestCase):
     @os_helper.skip_unless_symlink
     @unittest.skipUnless(os.path.exists('/dev/null'), 'requires /dev/null')
     def test_copyfile_symlink_to_character_device(self):
-        tmp_dir = self.mkdtemp()
-        src = os.path.join(tmp_dir, 'src')
-        dst = os.path.join(tmp_dir, 'dst')
-        os.symlink('/dev/null', src)
-
-        shutil.copyfile(src, dst, follow_symlinks=False)
-
-        self.assertTrue(os.path.islink(dst))
-        self.assertEqual(os.readlink(dst), '/dev/null')
+        self._check_copyfile_symlink_to_special_file('/dev/null')
 
     def test_copyfile_block_device(self):
         block_dev = None

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1586,6 +1586,11 @@ class TestCopy(BaseTest, unittest.TestCase):
         self.assertEqual(os.readlink(dst), target)
 
     @os_helper.skip_unless_symlink
+    @unittest.skipUnless(os.path.exists('/dev/null'), 'requires /dev/null')
+    def test_copyfile_symlink_to_character_device(self):
+        self._check_copyfile_symlink_to_special_file('/dev/null')
+
+    @os_helper.skip_unless_symlink
     @unittest.skipUnless(hasattr(os, "mkfifo"), 'requires os.mkfifo()')
     @unittest.skipIf(sys.platform == "vxworks",
                     "fifo requires special path on VxWorks")
@@ -1618,11 +1623,6 @@ class TestCopy(BaseTest, unittest.TestCase):
         create_file(src_file, 'foo')
         self.assertRaisesRegex(shutil.SpecialFileError, 'is a character device',
                                shutil.copyfile, src_file, '/dev/null')
-
-    @os_helper.skip_unless_symlink
-    @unittest.skipUnless(os.path.exists('/dev/null'), 'requires /dev/null')
-    def test_copyfile_symlink_to_character_device(self):
-        self._check_copyfile_symlink_to_special_file('/dev/null')
 
     def test_copyfile_block_device(self):
         block_dev = None

--- a/Misc/NEWS.d/next/Library/2026-07-26-11-45-34.gh-issue-154726.hLJk5-.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-26-11-45-34.gh-issue-154726.hLJk5-.rst
@@ -1,0 +1,3 @@
+Fix :func:`shutil.copyfile` to copy a symbolic link to a special file when
+``follow_symlinks=False`` instead of raising
+:exc:`~shutil.SpecialFileError`.


### PR DESCRIPTION
Fixes #154726.

- Avoid checking a source symlink's target when `follow_symlinks=False`
- Add a regression test using a symlink to `/dev/null`.


<!-- gh-issue-number: gh-154726 -->
* Issue: gh-154726
<!-- /gh-issue-number -->
