### PR TITLE
gh-154734: Fix data race on Task.get_coro() with eager tasks in FT build

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-07-26-15-38-17.gh-issue-154734.8FDOiq.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-26-15-38-17.gh-issue-154734.8FDOiq.rst
@@ -1,0 +1,2 @@
+Fix a data race on :meth:`asyncio.Task.get_coro` with eager tasks in the
+:term:`free-threaded build`.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -3498,10 +3498,13 @@ task_eager_start(_PyThreadStateImpl *ts, asyncio_state *state, TaskObj *task)
         retval = -1;
     }
 
+    // gh-154734: Task.get_coro() reads task_coro under this lock
+    Py_BEGIN_CRITICAL_SECTION(task);
     if (task->task_state != STATE_PENDING) {
         // This seems to really help performance on pyperformance benchmarks
         clear_task_coro(task);
     }
+    Py_END_CRITICAL_SECTION();
 
     return retval;
 }


### PR DESCRIPTION
Fix data race on `Task.get_coro()` with eager tasks in FT build

For more details see gh-154734