### PR TITLE
gh-154719: Preserve trailing whitespace in t-string interpolation expressions

### DIFF
--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1862,7 +1862,7 @@ class TestTypeRepr(unittest.TestCase):
         self.assertEqual(type_repr(t'''{ 0
             & 1
             | 2
-        }'''), 't"""{ 0\n            & 1\n            | 2}"""')
+        }'''), 't"""{ 0\n            & 1\n            | 2\n        }"""')
         self.assertEqual(
             type_repr(Template("hi", Interpolation(42, "42"))), "t'hi{42}'"
         )

--- a/Lib/test/test_tstring.py
+++ b/Lib/test/test_tstring.py
@@ -162,6 +162,18 @@ class TestTString(unittest.TestCase, TStringBaseCase):
         )
         self.assertEqual(fstring(t), "Value: value = 42")
 
+    def test_debug_specifier_with_reconstructed_metadata(self):
+        regular = t'''{(
+            1,  # Force lexer metadata reconstruction.
+            "\"#")}'''
+        debug = t'''{(
+            1,  # Force lexer metadata reconstruction.
+            "\"#")=}'''
+        self.assertEqual(
+            debug.interpolations[0].expression,
+            regular.interpolations[0].expression,
+        )
+
     def test_raw_tstrings(self):
         path = r"C:\Users"
         t = rt"{path}\Documents"

--- a/Lib/test/test_tstring.py
+++ b/Lib/test/test_tstring.py
@@ -79,6 +79,28 @@ class TestTString(unittest.TestCase, TStringBaseCase):
         )
         self.assertEqual(fstring(t), "Name: Bob, Age: 30")
 
+    def test_interpolation_expression_whitespace(self):
+        x = 42
+        cases = [
+            (t"{x}", "x"),
+            (t"{x }", "x "),
+            (t"{ x}", " x"),
+            (t"{ x }", " x "),
+            (t"{  x  }", "  x  "),
+            (t"{x !r}", "x "),
+            (t"{x :}", "x "),
+            (t"{x = }", "x "),
+            (t"{x == 42 = }", "x == 42 "),
+            (t"""{
+  x
+}""", "\n  x\n"),
+        ]
+        for template, expected in cases:
+            with self.subTest(template=template):
+                self.assertEqual(
+                    template.interpolations[0].expression, expected
+                )
+
     def test_format_specifiers(self):
         # Test basic format specifiers
         value = 3.14159
@@ -136,7 +158,7 @@ class TestTString(unittest.TestCase, TStringBaseCase):
         # Test white space in debug specifier
         t = t"Value: {value = }"
         self.assertTStringEqual(
-            t, ("Value: value = ", ""), [(value, "value", "r")]
+            t, ("Value: value = ", ""), [(value, "value ", "r")]
         )
         self.assertEqual(fstring(t), "Value: value = 42")
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-26-17-20-49.gh-issue-154719.eI88Gs.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-26-17-20-49.gh-issue-154719.eI88Gs.rst
@@ -1,0 +1,3 @@
+Whitespace immediately before ``}``, ``!``, ``:``, or ``=`` is now included
+in :attr:`string.templatelib.Interpolation.expression` for interpolations
+created from t-string literals.

--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -1552,7 +1552,10 @@ _strip_interpolation_debug_expr(PyObject *exprstr)
         }
         len--;
     }
-    assert(len > 0 && PyUnicode_READ_CHAR(exprstr, len - 1) == '=');
+    /* The debug marker may be absent from reconstructed lexer metadata. */
+    if (len == 0 || PyUnicode_READ_CHAR(exprstr, len - 1) != '=') {
+        return Py_NewRef(exprstr);
+    }
 
     return PyUnicode_Substring(exprstr, 0, len - 1);
 }

--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -1540,21 +1540,21 @@ _get_interpolation_conversion(Parser *p, Token *debug, ResultTokenWithMetadata *
 }
 
 static PyObject *
-_strip_interpolation_expr(PyObject *exprstr)
+_strip_interpolation_debug_expr(PyObject *exprstr)
 {
     Py_ssize_t len = PyUnicode_GET_LENGTH(exprstr);
 
-    for (Py_ssize_t i = len - 1; i >= 0; i--) {
-        Py_UCS4 c = PyUnicode_READ_CHAR(exprstr, i);
-        if (_PyUnicode_IsWhitespace(c) || c == '=') {
-            len--;
-        }
-        else {
+    /* Discard whitespace after the debug "=" but preserve whitespace before it. */
+    while (len > 0) {
+        Py_UCS4 c = PyUnicode_READ_CHAR(exprstr, len - 1);
+        if (!_PyUnicode_IsWhitespace(c)) {
             break;
         }
+        len--;
     }
+    assert(len > 0 && PyUnicode_READ_CHAR(exprstr, len - 1) == '=');
 
-    return PyUnicode_Substring(exprstr, 0, len);
+    return PyUnicode_Substring(exprstr, 0, len - 1);
 }
 
 expr_ty _PyPegen_interpolation(Parser *p, expr_ty expression, Token *debug, ResultTokenWithMetadata *conversion,
@@ -1585,7 +1585,9 @@ expr_ty _PyPegen_interpolation(Parser *p, expr_ty expression, Token *debug, Resu
     }
 
     assert(exprstr != NULL);
-    PyObject *final_exprstr = _strip_interpolation_expr(exprstr);
+    PyObject *final_exprstr = debug
+        ? _strip_interpolation_debug_expr(exprstr)
+        : Py_NewRef(exprstr);
     if (!final_exprstr || _PyArena_AddPyObject(arena, final_exprstr) < 0) {
         Py_XDECREF(final_exprstr);
         return NULL;


### PR DESCRIPTION


## Issue

`Interpolation.expression` preserved whitespace after the opening `{`, but removed whitespace immediately before `}`, `!`, or `:`. This was inconsistent with the documented behavior of preserving the expression text inside the braces.

## Root cause

The lexer metadata already contained the trailing whitespace, but the parser unconditionally stripped trailing whitespace from every interpolation expression while handling debug expressions.

## Solution

Preserve the lexer metadata unchanged for regular interpolations. For self-documenting expressions, remove only the debug `=` and whitespace after it, while preserving whitespace before it. Add tests covering regular, converted, formatted, debug, comparison, and multiline expressions.



<!-- gh-issue-number: gh-154719 -->
* Issue: gh-154719
<!-- /gh-issue-number -->
