### PR TITLE
gh-154738: Propagate reparse-deferral setting to pyexpat subparsers

### DIFF
--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -1045,6 +1045,13 @@ class ParentParserLifetimeTest(unittest.TestCase):
         del parser
         del subparser
 
+    def test_subparser_inherits_reparse_deferral(self):
+        for enabled in (True, False):
+            parser = expat.ParserCreate()
+            parser.SetReparseDeferralEnabled(enabled)
+            subparser = parser.ExternalEntityParserCreate(None)
+            self.assertEqual(subparser.GetReparseDeferralEnabled(), enabled)
+
 
 class ExternalEntityParserCreateErrorTest(unittest.TestCase):
     """ExternalEntityParserCreate error paths should not crash or leak

--- a/Misc/NEWS.d/next/Library/2026-07-26-00-00-00.gh-issue-154738.Rd5Pxe.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-26-00-00-00.gh-issue-154738.Rd5Pxe.rst
@@ -1,0 +1,3 @@
+Fix :meth:`!ExternalEntityParserCreate` not propagating the reparse-deferral
+setting to the subparser, which left :meth:`!GetReparseDeferralEnabled`
+returning an uninitialized value.  Patch by tonghuaroot.

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1118,6 +1118,7 @@ pyexpat_xmlparser_ExternalEntityParserCreate_impl(xmlparseobject *self,
     new_parser->specified_attributes = self->specified_attributes;
     new_parser->in_callback = 0;
     new_parser->ns_prefixes = self->ns_prefixes;
+    new_parser->reparse_deferral_enabled = self->reparse_deferral_enabled;
     new_parser->itself = XML_ExternalEntityParserCreate(self->itself, context,
                                                         encoding);
     // The new subparser will make use of the parent XML_Parser inside of Expat.


### PR DESCRIPTION
`ExternalEntityParserCreate` copied every parent field onto the subparser except `reparse_deferral_enabled`. `PyObject_GC_New` does not zero the struct, so the field was read uninitialized and `GetReparseDeferralEnabled()` returned garbage. Copy it from the parent, matching `newxmlparseobject` and Expat's own inherited C-level state.


<!-- gh-issue-number: gh-154738 -->
* Issue: gh-154738
<!-- /gh-issue-number -->
