### PR TITLE
gh-100231: Clarify AF_PACKET protocol byte order

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -586,9 +586,10 @@ The AF_* and SOCK_* constants are now :class:`AddressFamily` and
 
 .. data:: ETH_P_ALL
 
-   :data:`!ETH_P_ALL` can be used in the :class:`~socket.socket`
-   constructor as *proto* for the :const:`AF_PACKET` family in order to
-   capture every packet, regardless of protocol.
+   To capture every packet, regardless of protocol, with an
+   :const:`AF_PACKET` socket, pass ``htons(ETH_P_ALL)`` as *proto* to the
+   :class:`~socket.socket` constructor.  The call to :func:`htons` converts
+   the protocol number to network byte order.
 
    For more information, see the :manpage:`packet(7)` manpage.
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Clarify that `AF_PACKET` protocol numbers passed to `socket.socket()` must
be converted to network byte order, and show `ETH_P_ALL` with
`socket.htons()`.

Fixes #100231.


<!-- gh-issue-number: gh-100231 -->
* Issue: gh-100231
<!-- /gh-issue-number -->
