### PR TITLE
gh-154561: Check module dict after trying to load submodule

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-26-18-34-45.gh-issue-154561.vuDLtN.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-26-18-34-45.gh-issue-154561.vuDLtN.rst
@@ -1,0 +1,3 @@
+Fix a race condition in the free-threaded build where concurrent access to
+the same lazy-imported submodule attribute could raise :exc:`AttributeError`.
+Patch by Bartosz Sławecki.

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -1398,6 +1398,16 @@ _Py_module_getattro_impl(PyModuleObject *m, PyObject *name, int suppress)
     if (PyErr_Occurred()) {
         return NULL;
     }
+    // Other threads could have raced to load the submodule.
+    // Re-check the module dict to avoid race condition.
+    attr = _PyObject_GenericGetAttrWithDict((PyObject *)m, name, NULL, 1);
+    if (attr != NULL) {
+        return attr;
+    }
+    if (PyErr_Occurred()) {
+        // pass up non-AttributeError exception
+        return NULL;
+    }
     if (PyDict_GetItemRef(m->md_dict, &_Py_ID(__getattr__), &getattr) < 0) {
         return NULL;
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Locally I bumped the test to use 100 threads for higher failure reproducibility:

```diff
diff --git a/Lib/test/test_lazy_import/__init__.py b/Lib/test/test_lazy_import/__init__.py
index 899ecec1ba2..3d44d2d04c9 100644
--- a/Lib/test/test_lazy_import/__init__.py
+++ b/Lib/test/test_lazy_import/__init__.py
@@ -1794,7 +1794,7 @@ def test_concurrent_lazy_import_reification(self):
         """Multiple threads racing to reify the same lazy import should succeed."""
         from test.test_lazy_import.data import basic_unused
 
-        num_threads = 10
+        num_threads = 100
         results = [None] * num_threads
         errors = []
         barrier = threading.Barrier(num_threads)
```

I cannot reproduce failures after the proposed change: after trying to load the submodule, we re-check the module dict in case a different thread beat us to it, in which case the attribute can be returned directly.

<!-- gh-issue-number: gh-154561 -->
* Issue: gh-154561
<!-- /gh-issue-number -->
