### PR TITLE
gh-154749: Reject a terminal-less screen in curses.set_term()

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -129,6 +129,8 @@ Initialization and termination
    and return the previously current screen.
    Returns ``None`` if the previous screen was the one created by
    :func:`initscr`.
+   Raises :exc:`error` if *screen* has no terminal,
+   as is the case for a screen returned by :func:`new_prescr`.
 
    .. versionadded:: next
 

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -3072,6 +3072,18 @@ class ScreenTests(NewtermTestBase):
         del screen
         gc_collect()
 
+    @unittest.skipUnless(hasattr(curses, 'new_prescr'),
+                         'requires curses.new_prescr()')
+    def test_set_term_prescr_screen(self):
+        # A new_prescr() screen has no terminal, so it cannot become the
+        # current one.  It used to be accepted, and the next refresh then
+        # crashed inside curses.
+        s = self.make_pty()
+        screen = curses.newterm('xterm', s, s)
+        self.assertRaises(curses.error, curses.set_term, curses.new_prescr())
+        # The current screen is unchanged, so refreshing it still works.
+        screen.stdscr.refresh()
+
     @cpython_only
     def test_disallow_instantiation(self):
         # The screen type cannot be instantiated directly (bpo-43916).

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -3072,8 +3072,7 @@ class ScreenTests(NewtermTestBase):
         del screen
         gc_collect()
 
-    @unittest.skipUnless(hasattr(curses, 'new_prescr'),
-                         'requires curses.new_prescr()')
+    @requires_curses_func('new_prescr')
     def test_set_term_prescr_screen(self):
         # A new_prescr() screen has no terminal, so it cannot become the
         # current one.  It used to be accepted, and the next refresh then

--- a/Misc/NEWS.d/next/Library/2026-07-26-20-22-45.gh-issue-154749.6ekT3T.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-26-20-22-45.gh-issue-154749.6ekT3T.rst
@@ -1,3 +1,0 @@
-:func:`curses.set_term` now raises :exc:`curses.error` when given a screen with
-no terminal, such as one returned by :func:`curses.new_prescr`.  Such a screen
-was accepted before, and the next window refresh crashed the interpreter.

--- a/Misc/NEWS.d/next/Library/2026-07-26-20-22-45.gh-issue-154749.6ekT3T.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-26-20-22-45.gh-issue-154749.6ekT3T.rst
@@ -1,0 +1,3 @@
+:func:`curses.set_term` now raises :exc:`curses.error` when given a screen with
+no terminal, such as one returned by :func:`curses.new_prescr`.  Such a screen
+was accepted before, and the next window refresh crashed the interpreter.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -6834,11 +6834,17 @@ _curses_set_term(PyObject *module, PyObject *screen)
     if (so == NULL) {
         return NULL;
     }
+    cursesmodule_state *state = get_cursesmodule_state(module);
+    if (so->stdscr_win == NULL) {
+        /* A screen from new_prescr() has no terminal, so it cannot become the
+           current one: a later refresh would dereference NULL in curses. */
+        PyErr_SetString(state->error, "the screen has no terminal");
+        return NULL;
+    }
     set_term(so->screen);
     if (!update_lines_cols(module)) {
         return NULL;
     }
-    cursesmodule_state *state = get_cursesmodule_state(module);
     PyObject *prev = state->topscreen;          /* steal the owned reference */
     state->topscreen = Py_NewRef(screen);
     return prev != NULL ? prev : Py_NewRef(Py_None);


### PR DESCRIPTION
`curses.set_term()` only checked that its argument is a screen that has not been
deleted, so it also accepted a screen from `curses.new_prescr()`. That screen has no
terminal attached, and once it was made current the next window refresh dereferenced
NULL inside curses and killed the interpreter:

```python
import curses, os
fd = os.openpty()[1]
scr = curses.newterm('xterm', fd, fd)
curses.set_term(curses.new_prescr())
scr.stdscr.refresh()          # Segmentation fault, rc=139
```

`set_term()` now raises `curses.error` when the screen has no standard window, which is
exactly what a `new_prescr()` screen is. The documentation already described the argument
as a screen returned by `newterm()`, so this makes the code match, and the docs now
mention the exception.

Both functions are new in 3.16 (gh-90092, GH-151748), so no released version is affected
and there is no NEWS entry.

The same reproducer after the change:

```
set_term(new_prescr()) -> error: the screen has no terminal
refresh after the rejected switch: ok
set_term(real screen) still works, prev is a screen: True
refresh on the new current screen: ok
```

Tests:

```
$ ./python -m test -u all -v test_curses -m 'test_set_term_prescr_screen'
test_set_term_prescr_screen (test.test_curses.ScreenTests.test_set_term_prescr_screen) ... ok
OK

$ ./python -m test -u all test_curses
Total tests: run=164 skipped=3
Result: SUCCESS
```


<!-- gh-issue-number: gh-154749 -->
* Issue: gh-154749
<!-- /gh-issue-number -->
