### PR TITLE
gh-154751: Keep the screen alive in curses.initscr() after newterm()

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -3073,16 +3073,18 @@ class ScreenTests(NewtermTestBase):
         gc_collect()
 
     def test_initscr_after_newterm_keeps_screen_alive(self):
-        # initscr() called while a newterm() screen is current returns a window
-        # for that screen, and the window must keep the screen alive.  It used
-        # to be created without a screen, and using the window after the
-        # screen was collected read freed memory.
+        # initscr() called while a newterm() screen is current returns that
+        # screen's own standard window, so the window keeps the screen alive.
+        # It used to be a second wrapper created without a screen: using it
+        # after the screen was collected read freed memory, and both wrappers
+        # could delwin() the same window.
         s1 = self.make_pty()
         s2 = self.make_pty()
         screen1 = curses.newterm('xterm', s1, s1)
         screen2 = curses.newterm('xterm', s2, s2)
         curses.set_term(screen1)
         win = curses.initscr()
+        self.assertIs(win, screen1.stdscr)
         curses.set_term(screen2)
         del screen1
         gc_collect()

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -3072,6 +3072,22 @@ class ScreenTests(NewtermTestBase):
         del screen
         gc_collect()
 
+    def test_initscr_after_newterm_keeps_screen_alive(self):
+        # initscr() called while a newterm() screen is current returns a window
+        # for that screen, and the window must keep the screen alive.  It used
+        # to be created without a screen, and using the window after the
+        # screen was collected read freed memory.
+        s1 = self.make_pty()
+        s2 = self.make_pty()
+        screen1 = curses.newterm('xterm', s1, s1)
+        screen2 = curses.newterm('xterm', s2, s2)
+        curses.set_term(screen1)
+        win = curses.initscr()
+        curses.set_term(screen2)
+        del screen1
+        gc_collect()
+        win.addstr(0, 0, 'x')
+
     @cpython_only
     def test_disallow_instantiation(self):
         # The screen type cannot be instantiated directly (bpo-43916).

--- a/Misc/NEWS.d/next/Library/2026-07-26-21-11-58.gh-issue-154751.q-YeEM.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-26-21-11-58.gh-issue-154751.q-YeEM.rst
@@ -1,3 +1,0 @@
-Fix a use-after-free in :mod:`curses`.  :func:`curses.initscr` called while a
-screen from :func:`curses.newterm` is current now returns a window that keeps
-that screen alive, like :func:`curses.newwin` and :func:`curses.newpad` do.

--- a/Misc/NEWS.d/next/Library/2026-07-26-21-11-58.gh-issue-154751.q-YeEM.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-26-21-11-58.gh-issue-154751.q-YeEM.rst
@@ -1,0 +1,3 @@
+Fix a use-after-free in :mod:`curses`.  :func:`curses.initscr` called while a
+screen from :func:`curses.newterm` is current now returns a window that keeps
+that screen alive, like :func:`curses.newwin` and :func:`curses.newpad` do.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -6573,7 +6573,11 @@ _curses_initscr_impl(PyObject *module)
             _curses_set_null_error(state, "wrefresh", "initscr");
             return NULL;
         }
-        PyObject *winobj = PyCursesWindow_New(state, stdscr, NULL, NULL, NULL);
+        /* Attach the current screen, like newwin(), newpad() and getwin() do,
+           so that the window keeps its screen alive.  It is NULL for the
+           screen created by initscr(), which has no screen object. */
+        PyObject *winobj = PyCursesWindow_New(state, stdscr, NULL, NULL,
+                                              state->topscreen);
         if (winobj == NULL) {
             return NULL;
         }

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -6573,6 +6573,18 @@ _curses_initscr_impl(PyObject *module)
             _curses_set_null_error(state, "wrefresh", "initscr");
             return NULL;
         }
+        if (state->topscreen != NULL) {
+            /* The current screen is one made by newterm(); return its own
+               standard window instead of a second wrapper over the same
+               WINDOW, which would delwin() it on its own. */
+            PyCursesScreenObject *so = (PyCursesScreenObject *)state->topscreen;
+            if (so->stdscr_win != NULL) {
+                if (curses_update_screen_encoding(so->stdscr_win) < 0) {
+                    return NULL;
+                }
+                return Py_NewRef(so->stdscr_win);
+            }
+        }
         /* Attach the current screen, like newwin(), newpad() and getwin() do,
            so that the window keeps its screen alive.  It is NULL for the
            screen created by initscr(), which has no screen object. */


### PR DESCRIPTION
`curses.initscr()` called while a screen from `curses.newterm()` was current returned a
window built with no screen. The window's `screen` field is the reference that keeps a
screen alive, so this window kept nothing alive. Dropping the screen freed its `WINDOW`,
and the next method call on the window read freed memory:

```python
import curses, gc, os
s1 = os.openpty()[1]; s2 = os.openpty()[1]
a = curses.newterm('xterm', s1, s1)
b = curses.newterm('xterm', s2, s2)
curses.set_term(a)
w = curses.initscr()
curses.set_term(b)
del a; gc.collect()
w.addstr(0, 0, 'boom')     # Segmentation fault, rc=139
```

When the current screen came from `newterm()`, `initscr()` now returns that screen's own
standard window, so there is only ever one wrapper over that `WINDOW` and it holds the
screen. Otherwise it passes `state->topscreen`, matching `newwin()`, `newpad()` and
`getwin()`; that value is NULL for the screen created by `initscr()`, which has no screen
object, so plain `initscr()` use is unchanged.

This restores what the screen objects documentation promises: "Each window keeps its screen
alive, so a screen remains valid as long as any of its windows does."

`newterm()` and `set_term()` are new in 3.16 (gh-90092, GH-151748), so no released version
is affected and there is no NEWS entry.

The reproducer above now prints `no crash` and exits 0, and
`curses.initscr() is screen.stdscr` is True where it was False. Tests:

```
$ ./python -m test -u all -v test_curses -m 'test_initscr_after_newterm_keeps_screen_alive'
test_initscr_after_newterm_keeps_screen_alive (test.test_curses.ScreenTests.test_initscr_after_newterm_keeps_screen_alive) ... ok
OK

$ ./python -m test -u all test_curses
Total tests: run=164 skipped=3
Result: SUCCESS
```


<!-- gh-issue-number: gh-154751 -->
* Issue: gh-154751
<!-- /gh-issue-number -->
