### PR TITLE
gh-154753: Fix doc references to moved Platforms/ paths and removed files

### DIFF
--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -1106,7 +1106,7 @@ Finally it should be mentioned that Capsules offer additional functionality,
 which is especially useful for memory allocation and deallocation of the pointer
 stored in a Capsule. The details are described in the Python/C API Reference
 Manual in the section :ref:`capsules` and in the implementation of Capsules (files
-:file:`Include/pycapsule.h` and :file:`Objects/pycapsule.c` in the Python source
+:file:`Include/pycapsule.h` and :file:`Objects/capsule.c` in the Python source
 code distribution).
 
 .. rubric:: Footnotes

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1941,8 +1941,8 @@ always available. Unless explicitly noted otherwise, all variables are read-only
       The interpreter is about to execute a new line of code or re-execute the
       condition of a loop.  The local trace function is called; *arg* is
       ``None``; the return value specifies the new local trace function.  See
-      :file:`Objects/lnotab_notes.txt` for a detailed explanation of how this
-      works.
+      :source:`InternalDocs/code_objects.md` for a detailed explanation of how
+      this works.
       Per-line events may be disabled for a frame by setting
       :attr:`~frame.f_trace_lines` to :const:`False` on that
       :ref:`frame <frame-objects>`.

--- a/Doc/using/android.rst
+++ b/Doc/using/android.rst
@@ -37,7 +37,7 @@ much easier experience:
 * `Termux <https://termux.dev/en/>`__
 
 If you're sure you want to do all of this manually, read on. You can use the
-:source:`testbed app <Android/testbed>` as a guide; each step below contains a
+:source:`testbed app <Platforms/Android/testbed>` as a guide; each step below contains a
 link to the relevant file.
 
 * First, acquire a build of Python for Android:
@@ -47,10 +47,10 @@ link to the relevant file.
     mentioned below is at the top level of the package.
 
   * Or if you want to build it yourself, follow the instructions in
-    :source:`Android/README.md`. The ``prefix`` directory will be created under
+    :source:`Platforms/Android/README.md`. The ``prefix`` directory will be created under
     :samp:`cross-build/{HOST}`.
 
-* Add code to your :source:`build.gradle <Android/testbed/app/build.gradle.kts>`
+* Add code to your :source:`build.gradle <Platforms/Android/testbed/app/build.gradle.kts>`
   file to copy the following items into your project. All except your own Python
   code can be copied from ``prefix/lib``:
 
@@ -65,10 +65,10 @@ link to the relevant file.
     * ``python*.*/site-packages`` (your own Python code)
 
 * Add code to your app to :source:`extract the assets to the filesystem
-  <Android/testbed/app/src/main/java/org/python/testbed/MainActivity.kt>`.
+  <Platforms/Android/testbed/app/src/main/java/org/python/testbed/MainActivity.kt>`.
 
 * Add code to your app to :source:`start Python in embedded mode
-  <Android/testbed/app/src/main/c/main_activity.c>`. This will need to be C code
+  <Platforms/Android/testbed/app/src/main/c/main_activity.c>`. This will need to be C code
   called via JNI.
 
 Building a Python package for Android

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -1275,7 +1275,7 @@ See :source:`Mac/README.rst`.
 iOS Options
 -----------
 
-See :source:`iOS/README.rst`.
+See :source:`Platforms/Apple/iOS/README.md`.
 
 .. option:: --enable-framework=INSTALLDIR
 

--- a/Doc/using/ios.rst
+++ b/Doc/using/ios.rst
@@ -170,7 +170,7 @@ helpful.
 To add Python to an iOS Xcode project:
 
 1. Build or obtain a Python ``XCFramework``. See the instructions in
-   :source:`Apple/iOS/README.md` (in the CPython source distribution) for details on
+   :source:`Platforms/Apple/iOS/README.md` (in the CPython source distribution) for details on
    how to build a Python ``XCFramework``. At a minimum, you will need a build
    that supports ``arm64-apple-ios``, plus one of either
    ``arm64-apple-ios-simulator`` or ``x86_64-apple-ios-simulator``.
@@ -266,13 +266,13 @@ modules in your app, some additional steps will be required:
 Testing a Python package
 ------------------------
 
-The CPython source tree contains :source:`a testbed project <Apple/iOS/testbed>` that
+The CPython source tree contains :source:`a testbed project <Platforms/Apple/testbed>` that
 is used to run the CPython test suite on the iOS simulator. This testbed can also
 be used as a testbed project for running your Python library's test suite on iOS.
 
-After building or obtaining an iOS XCFramework (see :source:`Apple/iOS/README.md`
+After building or obtaining an iOS XCFramework (see :source:`Platforms/Apple/iOS/README.md`
 for details), create a clone of the Python iOS testbed project. If you used the
-``Apple`` build script to build the XCframework, you can run:
+``Platforms/Apple`` build script to build the XCframework, you can run:
 
 .. code-block:: bash
 
@@ -282,7 +282,7 @@ Or, if you've sourced your own XCframework, by running:
 
 .. code-block:: bash
 
-    $ python Apple/testbed clone --platform iOS --framework <path/to/Python.xcframework> --app <path/to/module1> --app <path/to/module2> app-testbed
+    $ python Platforms/Apple/testbed clone --platform iOS --framework <path/to/Python.xcframework> --app <path/to/module1> --app <path/to/module2> app-testbed
 
 Any folders specified with the ``--app`` flag will be copied into the cloned
 testbed project. The resulting testbed will be created in the ``app-testbed``

--- a/InternalDocs/code_objects.md
+++ b/InternalDocs/code_objects.md
@@ -48,7 +48,7 @@ Note that traceback objects don't store all this information -- they store the s
 number, for backward compatibility, and the "last instruction" value.
 The rest can be computed from the last instruction (`tb_lasti`) with the help of the
 locations table. For Python code, there is a convenience method
-(`codeobject.co_positions`)[https://docs.python.org/dev/reference/datamodel.html#codeobject.co_positions]
+[`codeobject.co_positions`](https://docs.python.org/dev/reference/datamodel.html#codeobject.co_positions)
 which returns an iterator of `({line}, {endline}, {column}, {endcolumn})` tuples,
 one per instruction.
 There is also `co_lines()` which returns an iterator of `({start}, {end}, {line})` tuples,

--- a/InternalDocs/jit.md
+++ b/InternalDocs/jit.md
@@ -140,7 +140,7 @@ template file [`Tools/jit/template.c`](../Tools/jit/template.c).
 Each of the `.c` files is compiled by LLVM, to produce an object file
 that contains a function that executes the opcode. These compiled
 functions are used to generate the file
-[`jit_stencils.h`](../jit_stencils.h), which contains the functions
+`jit_stencils.h`, which contains the functions
 that the JIT can use to emit code for each of the bytecodes.
 
 For Python maintainers this means that changes to the bytecodes and


### PR DESCRIPTION
Fixes the stale file references collected in gh-154753, one commit per file:

- **`Doc/using/android.rst`** — five `:source:` links updated to `Platforms/Android/...` (moved in gh-146445; the old links 404 on docs.python.org today)
- **`Doc/using/ios.rst`** — `Platforms/Apple/iOS/README.md` (×2), the testbed reference updated to `Platforms/Apple/testbed` (the shared Apple testbed's actual location), the ``Apple`` build-script mention, and the `python Apple/testbed clone ...` shell example (matches the invocations in `Platforms/Apple/iOS/README.md`)
- **`Doc/using/configure.rst`** — ``:source:`iOS/README.rst` `` → ``:source:`Platforms/Apple/iOS/README.md` `` (moved twice; the file is Markdown)
- **`Doc/extending/extending.rst`** — `Objects/pycapsule.c` → `Objects/capsule.c` (no `pycapsule.c` exists; the `Include/pycapsule.h` half of the sentence is correct)
- **`Doc/library/sys.rst`** — `Objects/lnotab_notes.txt` (removed in gh-134690) → `InternalDocs/code_objects.md`, which documents the locations table that replaced lnotab
- **`InternalDocs/jit.md`** — drop the relative link to `jit_stencils.h`, a gitignored build artifact (404 on GitHub)
- **`InternalDocs/code_objects.md`** — fix inverted Markdown link syntax `(text)[url]` → `[text](url)`

Every corrected target was verified to exist in the current tree, and each old target verified missing.

**Backporting:** the `Platforms/` fixes (android.rst, ios.rst, configure.rst) must **not** be backported — 3.13/3.14 still have the pre-gh-146445 tree layout. The capsule.c and sys.rst fixes may be independently backport-eligible; happy to defer to the merger on labels.

Verified locally on macOS: `make -C Doc check` and `make -C Doc html` (which runs with `--fail-on-warning`) both pass; rendered HTML spot-checked for the new URLs.

*Prepared with AI assistance (Claude); every change was mechanically verified against the repository tree as described above.*

📚 Documentation preview 📚: https://cpython-previews--154754.org.readthedocs.build/