### PR TITLE
gh-154757: List the 3.16 C API deprecations on the Deprecations page

### DIFF
--- a/Doc/deprecations/index.rst
+++ b/Doc/deprecations/index.rst
@@ -18,6 +18,8 @@ Deprecations
 C API deprecations
 ------------------
 
+.. include:: c-api-pending-removal-in-3.16.rst
+
 .. include:: c-api-pending-removal-in-3.18.rst
 
 .. include:: c-api-pending-removal-in-3.19.rst


### PR DESCRIPTION
The C API section of the Deprecations page started at
`c-api-pending-removal-in-3.18.rst`, so the 26 APIs pending removal in 3.16 were not
listed. This adds the include back.

It does not close gh-154757: whether those APIs are removed in 3.16 or the deadline moves
is still open. Listing them is correct either way while they are pending.

Docs only, so no NEWS entry. Sphinx is not installed here, so I checked it by hand: the
included file uses the same `^^^^^^` section level as its four siblings, and the includes
stay in version order.
