### PR TITLE
gh-154775: Don't accept duplicate plus sign when matching complex number

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -568,7 +568,6 @@ real_number[expr_ty]:
 
 imaginary_number[expr_ty]:
     | imag=NUMBER { _PyPegen_ensure_imaginary(p, imag) }
-    | '+' imag=NUMBER { _PyPegen_ensure_imaginary(p, imag) }
 
 capture_pattern[pattern_ty]:
     | target=pattern_capture_target { _PyAST_MatchAs(NULL, target->v.Name.id, EXTRA) }

--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -2850,6 +2850,14 @@ class TestPatma(unittest.TestCase):
             case 0:
                 y = 1
         self.assertEqual(x, 0)
+    def test_patma_265(self):
+        x = 0
+        match x:
+            case +1e1000:
+                y = 0
+            case 0:
+                y = 1
+        self.assertEqual(x, 0)
         self.assertEqual(y, 1)
 
     def test_patma_frozendict_class_self(self):

--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -3329,6 +3329,34 @@ class TestSyntaxErrors(unittest.TestCase):
                 pass
         """)
 
+    def test_duplicate_sign_in_complex_1(self):
+        self.assert_syntax_error("""
+        match ...:
+            case 0 ++ 0j:
+                pass
+        """)
+
+    def test_duplicate_sign_in_complex_2(self):
+        self.assert_syntax_error("""
+        match ...:
+            case 0 -+ 0j:
+                pass
+        """)
+
+    def test_duplicate_sign_in_complex_3(self):
+        self.assert_syntax_error("""
+        match ...:
+            case 0 +- 0j:
+                pass
+        """)
+
+    def test_duplicate_sign_in_complex_4(self):
+        self.assert_syntax_error("""
+        match ...:
+            case 0 -- 0j:
+                pass
+        """)
+
 class TestTypeErrors(unittest.TestCase):
 
     def test_accepts_positional_subpatterns_0(self):

--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -2835,22 +2835,6 @@ class TestPatma(unittest.TestCase):
         self.assertEqual(y, 0)
 
     def test_patma_265(self):
-        x = 0.25 - 1.75j
-        match x:
-            case 0.25 - +1.75j:
-                y = 0
-        self.assertEqual(x, 0.25 - 1.75j)
-        self.assertEqual(y, 0)
-
-    def test_patma_266(self):
-        x = 0
-        match x:
-            case +1e1000:
-                y = 0
-            case 0:
-                y = 1
-        self.assertEqual(x, 0)
-    def test_patma_265(self):
         x = 0
         match x:
             case +1e1000:

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-27-16-29-10.gh-issue-154775._ISRIk.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-27-16-29-10.gh-issue-154775._ISRIk.rst
@@ -1,0 +1,2 @@
+When matching a complex literal in :keyword:`case` statements, an extraneous
+``+`` sign (for example, ``1++1j`` or ``1-+1j``) is no longer allowed.

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -9355,7 +9355,7 @@ real_number_rule(Parser *p)
     return _res;
 }
 
-// imaginary_number: NUMBER | '+' NUMBER
+// imaginary_number: NUMBER
 static expr_ty
 imaginary_number_rule(Parser *p)
 {
@@ -9391,33 +9391,6 @@ imaginary_number_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s imaginary_number[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "NUMBER"));
-    }
-    { // '+' NUMBER
-        if (p->error_indicator) {
-            p->level--;
-            return NULL;
-        }
-        D(fprintf(stderr, "%*c> imaginary_number[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'+' NUMBER"));
-        Token * _literal;
-        expr_ty imag;
-        if (
-            (_literal = _PyPegen_expect_token(p, 14))  // token='+'
-            &&
-            (imag = _PyPegen_number_token(p))  // NUMBER
-        )
-        {
-            D(fprintf(stderr, "%*c+ imaginary_number[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'+' NUMBER"));
-            _res = _PyPegen_ensure_imaginary ( p , imag );
-            if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                p->level--;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = _mark;
-        D(fprintf(stderr, "%*c%s imaginary_number[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'+' NUMBER"));
     }
     _res = NULL;
   done:


### PR DESCRIPTION
When matching a complex literal in :keyword:`case` statements, an extraneous
``+`` sign is no longer allowed (for example, in ``1++1j`` or ``1-+1j``).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-154775 -->
* Issue: gh-154775
<!-- /gh-issue-number -->
