### PR TITLE
gh-154781: Zero the in_wstr() buffer in curses

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -514,6 +514,12 @@ class TestCurses(unittest.TestCase):
                     self.assertEqual(stdscr.in_wstr(0, 0, len(s)), s)
                     self.assertIsInstance(stdscr.instr(0, 0, len(s)), bytes)
 
+        # Reading no characters gives an empty string, like instr() and
+        # in_wchstr() do.  curses does not terminate the buffer in this case.
+        stdscr.addstr(0, 0, 'abz')
+        self.assertEqual(stdscr.in_wstr(0, 0, 0), '')
+        self.assertEqual(stdscr.in_wstr(0), '')
+
     def test_complexchar(self):
         # A complexchar is a styled wide-character cell: str() is its text,
         # and the attr and pair attributes are its rendition.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -3850,7 +3850,9 @@ PyCursesWindow_in_wstr(PyObject *op, PyObject *args)
     }
 
     n = Py_MIN(n, max_buf_size - 1);
-    wchar_t *buf = PyMem_New(wchar_t, n + 1);
+    /* Zero the buffer: winnwstr() only writes the terminating null when it
+       stored at least one character, and the result is read up to it. */
+    wchar_t *buf = PyMem_Calloc(n + 1, sizeof(wchar_t));
     if (buf == NULL) {
         return PyErr_NoMemory();
     }

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -3850,7 +3850,7 @@ PyCursesWindow_in_wstr(PyObject *op, PyObject *args)
     }
 
     n = Py_MIN(n, max_buf_size - 1);
-    wchar_t *buf = PyMem_Calloc(n + 1, sizeof(wchar_t));
+    wchar_t *buf = PyMem_New(wchar_t, n + 1);
     if (buf == NULL) {
         return PyErr_NoMemory();
     }
@@ -3866,7 +3866,7 @@ PyCursesWindow_in_wstr(PyObject *op, PyObject *args)
         PyMem_Free(buf);
         return Py_GetConstant(Py_CONSTANT_EMPTY_STR);
     }
-    PyObject *res = PyUnicode_FromWideChar(buf, -1);
+    PyObject *res = PyUnicode_FromWideChar(buf, rtn);
     PyMem_Free(buf);
     return res;
 #else

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -3850,8 +3850,6 @@ PyCursesWindow_in_wstr(PyObject *op, PyObject *args)
     }
 
     n = Py_MIN(n, max_buf_size - 1);
-    /* Zero the buffer: winnwstr() only writes the terminating null when it
-       stored at least one character, and the result is read up to it. */
     wchar_t *buf = PyMem_Calloc(n + 1, sizeof(wchar_t));
     if (buf == NULL) {
         return PyErr_NoMemory();


### PR DESCRIPTION
`winnwstr()` only writes the terminating null when it stored at least one character, so
`in_wstr(y, x, 0)` read the result from uninitialized memory and usually raised
`ValueError: character U+xxxxxxxx is not in range`. Use `PyMem_Calloc`, like `in_wchstr()`
already does since gh-152503.

`in_wstr()` is new in 3.16, so there is no NEWS entry.


<!-- gh-issue-number: gh-154781 -->
* Issue: gh-154781
<!-- /gh-issue-number -->
