### PR TITLE
gh-154788: Make curses window.getparent() unconditional

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -278,6 +278,14 @@ class TestCurses(unittest.TestCase):
         del win2
         gc_collect()
 
+    def test_getparent(self):
+        # getparent() calls no curses function, so it works with any backend
+        # and is not gated like the is_*() getters below.
+        stdscr = self.stdscr
+        self.assertIsNone(stdscr.getparent())
+        sub = stdscr.subwin(3, 3, 0, 0)
+        self.assertIs(sub.getparent(), stdscr)
+
     def test_dupwin(self):
         win = curses.newwin(5, 10, 2, 3)
         win.addstr(0, 0, 'ABCDE')
@@ -1717,14 +1725,6 @@ class TestCurses(unittest.TestCase):
         stdscr.timeout(-1)
         stdscr.timeout(0)
         stdscr.timeout(5)
-
-    def test_getparent(self):
-        # getparent() calls no curses function, so it works with any backend
-        # and is not gated like the is_*() getters below.
-        stdscr = self.stdscr
-        self.assertIsNone(stdscr.getparent())
-        sub = stdscr.subwin(3, 3, 0, 0)
-        self.assertIs(sub.getparent(), stdscr)
 
     @requires_curses_window_meth('is_scrollok')
     def test_state_getters(self):

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -1718,6 +1718,14 @@ class TestCurses(unittest.TestCase):
         stdscr.timeout(0)
         stdscr.timeout(5)
 
+    def test_getparent(self):
+        # getparent() calls no curses function, so it works with any backend
+        # and is not gated like the is_*() getters below.
+        stdscr = self.stdscr
+        self.assertIsNone(stdscr.getparent())
+        sub = stdscr.subwin(3, 3, 0, 0)
+        self.assertIs(sub.getparent(), stdscr)
+
     @requires_curses_window_meth('is_scrollok')
     def test_state_getters(self):
         stdscr = self.stdscr
@@ -1771,13 +1779,11 @@ class TestCurses(unittest.TestCase):
         stdscr.setscrreg(5, 10)
         self.assertEqual(stdscr.getscrreg(), (5, 10))
 
-        # is_pad()/is_subwin()/getparent().
+        # is_pad()/is_subwin().
         self.assertIs(stdscr.is_pad(), False)
         self.assertIs(stdscr.is_subwin(), False)
-        self.assertIsNone(stdscr.getparent())
         sub = stdscr.subwin(3, 3, 0, 0)
         self.assertIs(sub.is_subwin(), True)
-        self.assertIs(sub.getparent(), stdscr)
         pad = curses.newpad(5, 5)
         self.assertIs(pad.is_pad(), True)
 

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -1870,6 +1870,7 @@ PyCursesWindow_getscrreg(PyObject *op, PyObject *Py_UNUSED(ignored))
     }
     return Py_BuildValue("(ii)", top, bottom);
 }
+#endif /* NCURSES_EXT_FUNCS >= 20110404 || PDCURSES */
 
 static PyObject *
 PyCursesWindow_getparent(PyObject *op, PyObject *Py_UNUSED(ignored))
@@ -1882,7 +1883,6 @@ PyCursesWindow_getparent(PyObject *op, PyObject *Py_UNUSED(ignored))
     }
     return Py_NewRef((PyObject *)self->orig);
 }
-#endif /* NCURSES_EXT_FUNCS >= 20110404 || PDCURSES */
 
 Window_NoArgNoReturnVoidFunction(wsyncup)
 Window_NoArgNoReturnVoidFunction(wsyncdown)
@@ -4963,11 +4963,9 @@ static PyMethodDef PyCursesWindow_methods[] = {
     {"getmaxyx", PyCursesWindow_getmaxyx, METH_NOARGS,
      "getmaxyx($self, /)\n--\n\n"
      "Return a tuple (y, x) of the window height and width."},
-#if (defined(NCURSES_EXT_FUNCS) && NCURSES_EXT_FUNCS >= 20110404) || defined(PDCURSES)
     {"getparent", PyCursesWindow_getparent, METH_NOARGS,
      "getparent($self, /)\n--\n\n"
      "Return the parent window, or None if this is not a subwindow."},
-#endif
     {"getparyx", PyCursesWindow_getparyx, METH_NOARGS,
      "getparyx($self, /)\n--\n\n"
      "Return (y, x) relative to the parent window, or (-1, -1) if none."},


### PR DESCRIPTION
`window.getparent()` calls no curses function: it returns the window's stored parent. It was
compiled only when the ncurses extension functions were present, so it was missing on
backends without them, although the documentation lists no availability requirement for it.
The guard now closes after `getscrreg()`, which does need it.

The test moves out of `test_state_getters`, which is gated on `is_scrollok()`, so that
`getparent()` is covered on backends without the extensions.

Compiling the extensions-absent configuration is not possible here, since the ncurses header
defines `NCURSES_EXT_FUNCS`, so that side rests on reading the code. `getparent()` is new in
3.16, so there is no NEWS entry.


<!-- gh-issue-number: gh-154788 -->
* Issue: gh-154788
<!-- /gh-issue-number -->
