### PR TITLE
gh-154746: Update doc string for `collections.Counter`

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -553,8 +553,8 @@ class Counter(dict):
     or multiset.  Elements are stored as dictionary keys and their counts
     are stored as dictionary values.
 
-    Note: If a Mapping or Counter is used to initialize a Counter object
-    the values from that object will be preserved.
+    When constructed from a Mapping or Counter, the original object's
+    values will be used as the initial counts.
 
     >>> c = Counter('abcdeabcdabcaba')  # count elements from a string
 

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -553,6 +553,9 @@ class Counter(dict):
     or multiset.  Elements are stored as dictionary keys and their counts
     are stored as dictionary values.
 
+    Note: If a Mapping or Counter is used to initialize a Counter object
+    the values from that object will be preserved.
+
     >>> c = Counter('abcdeabcdabcaba')  # count elements from a string
 
     >>> c.most_common(3)                # three most common elements


### PR DESCRIPTION
Issue #154746 

Added a note to `collections.Counter`'s doc string that initializing a `Counter` from a `Mapping` or `Counter` will have different behaviour than initializing from other `Iterable`s.

This behaviour is already documented in the [docs](https://docs.python.org/3.15/library/collections.html#collections.Counter) but is missing from the `help()` output. 

<!-- gh-issue-number: gh-154746 -->
* Issue: gh-154746
<!-- /gh-issue-number -->
