### PR TITLE
gh-154791: Fix asyncio Future losing traceback on repeated result() call

### DIFF
--- a/Lib/test/test_asyncio/test_futures2.py
+++ b/Lib/test/test_asyncio/test_futures2.py
@@ -28,6 +28,26 @@ class FutureTests:
             else:
                 self.fail('TypeError was not raised')
 
+    async def test_future_traceback_preserved_after_suppress(self):
+        async def raise_exc():
+            raise TypeError(42)
+
+        future = self.cls(raise_exc())
+        try:
+            await future
+        except TypeError:
+            pass
+
+        try:
+            await future
+        except TypeError as e:
+            tb = ''.join(traceback.format_tb(e.__traceback__))
+            self.assertIn('raise_exc', tb,
+                'Original raise site lost after first result() call')
+        else:
+            self.fail('TypeError was not raised')
+
+
     async def test_task_exc_handler_correct_context(self):
         # see https://github.com/python/cpython/issues/96704
         name = contextvars.ContextVar('name', default='foo')

--- a/Misc/NEWS.d/next/Library/2026-07-28-08-02-41.gh-issue-154791.ey7POa.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-28-08-02-41.gh-issue-154791.ey7POa.rst
@@ -1,4 +1,5 @@
-Fix `asyncio._CFuture` losing the initial exception traceback frames when
-`Future.result()` is called more than once. Previously, the C implementation
-cleared the stored traceback after the first call, causing subsequent raises
-to omit the original raise site. The Python implementation was unaffected.
+Fix :class:`asyncio.Future` (C implementation) losing the initial exception
+traceback frames when ``Future.result()`` is called more than once. Previously,
+the C implementation cleared the stored traceback after the first call, causing
+subsequent raises to omit the original raise site. The pure-Python
+implementation was unaffected.

--- a/Misc/NEWS.d/next/Library/2026-07-28-08-02-41.gh-issue-154791.ey7POa.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-28-08-02-41.gh-issue-154791.ey7POa.rst
@@ -1,0 +1,4 @@
+Fix `asyncio._CFuture` losing the initial exception traceback frames when
+`Future.result()` is called more than once. Previously, the C implementation
+cleared the stored traceback after the first call, causing subsequent raises
+to omit the original raise site. The Python implementation was unaffected.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -769,7 +769,6 @@ future_get_result(asyncio_state *state, FutureObj *fut, PyObject **result)
             return -1;
         }
         *result = Py_NewRef(fut->fut_exception);
-        Py_CLEAR(fut->fut_exception_tb);
         return 1;
     }
 


### PR DESCRIPTION
PR #30274 fixed repeating traceback frames in `asyncio.Future`  by storing tracebacks separately from exceptions in `fut_exception_tb`. However, it also added `Py_CLEAR(fut->fut_exception_tb)` in `future_get_result()` after the first `result()` call. This means any subsequent `await`/`result()` raises with `PyException_SetTraceback(exc, None)`, losing traceback frames.

The `_PyFuture` implementation never clears `_exception_tb` and has always behaved correctly. This change makes the C implementation match.

The reference cycle concern motivating the `Py_CLEAR` is already covered: `fut_exception_tb` is registered in `FutureObj_traverse`, so GC can collect any cycle through it.

<!-- gh-issue-number: gh-154791 -->
* Issue: gh-154791
<!-- /gh-issue-number -->