### PR TITLE
gh-98894: fix `CheckDtraceProbes` tests on Solaris

### DIFF
--- a/Lib/test/test_dtrace.py
+++ b/Lib/test/test_dtrace.py
@@ -74,7 +74,7 @@ def kill_process_group(proc):
     proc.communicate()  # Clean up
 
 
-def run_readelf(cmd):
+def run_command(cmd):
     # Force the C locale to disable localization.
     env = dict(os.environ, LC_ALL="C")
     try:
@@ -86,7 +86,7 @@ def run_readelf(cmd):
             env=env,
         )
     except OSError:
-        raise unittest.SkipTest("Couldn't find readelf on the path")
+        raise unittest.SkipTest(f"Couldn't find {cmd[0]!r} on the path")
 
     with proc:
         stdout, stderr = proc.communicate()
@@ -437,6 +437,12 @@ class BPFTraceOptimizedTests(TraceTests, unittest.TestCase):
 class CheckDtraceProbes(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        if sys.platform == "sunos5":
+            # Solaris does not expose available probes through readable ELF
+            # section; it uses DTrace itself instead.
+            DTraceBackend().assert_usable()
+            return
+
         readelf_major_version, readelf_minor_version = cls.get_readelf_version()
         if support.verbose:
             print(f"readelf version: {readelf_major_version}.{readelf_minor_version}")
@@ -444,7 +450,7 @@ class CheckDtraceProbes(unittest.TestCase):
 
     @staticmethod
     def get_readelf_version():
-        version = run_readelf(["readelf", "--version"])
+        version = run_command(["readelf", "--version"])
 
         # Regex to parse:
         # 'GNU readelf (GNU Binutils) 2.40.0\n' -> 2.40
@@ -454,7 +460,13 @@ class CheckDtraceProbes(unittest.TestCase):
 
         return int(match.group(1)), int(match.group(2))
 
-    def get_readelf_output(self):
+    def get_probe_output(self):
+        if sys.platform == "sunos5":
+            # Get probes available in this process.
+            return run_command(
+                ["dtrace", "-l", "-P", f"python{os.getpid()}"]
+            )
+
         binary = sys.executable
         if sysconfig.get_config_var("Py_ENABLE_SHARED"):
             lib_dir = sysconfig.get_config_var("LIBDIR")
@@ -476,37 +488,43 @@ class CheckDtraceProbes(unittest.TestCase):
                         binary = libpython_path
                         break
 
-        return run_readelf(["readelf", "-n", binary])
+        return run_command(["readelf", "-n", binary])
+
+    def assert_probe_present(self, probe_name, output):
+        if sys.platform == "sunos5":
+            self.assertIn(probe_name.replace("__", "-"), output)
+        else:
+            self.assertIn(f"Name: {probe_name}", output)
 
     def test_check_probes(self):
-        readelf_output = self.get_readelf_output()
+        probe_output = self.get_probe_output()
 
         available_probe_names = [
-            "Name: import__find__load__done",
-            "Name: import__find__load__start",
-            "Name: audit",
-            "Name: gc__start",
-            "Name: gc__done",
-            "Name: function__entry",
-            "Name: function__return",
+            "import__find__load__done",
+            "import__find__load__start",
+            "audit",
+            "gc__start",
+            "gc__done",
+            "function__entry",
+            "function__return",
         ]
 
         for probe_name in available_probe_names:
             with self.subTest(probe_name=probe_name):
-                self.assertIn(probe_name, readelf_output)
+                self.assert_probe_present(probe_name, probe_output)
 
     @unittest.expectedFailure
     def test_missing_probes(self):
-        readelf_output = self.get_readelf_output()
+        probe_output = self.get_probe_output()
 
         # Missing probes will be added in the future.
         missing_probe_names = [
-            "Name: line",
+            "line",
         ]
 
         for probe_name in missing_probe_names:
             with self.subTest(probe_name=probe_name):
-                self.assertIn(probe_name, readelf_output)
+                self.assert_probe_present(probe_name, probe_output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Solaris does not use the notes section to list available probes (`readelf -n <binary>` returns nothing), which makes the `test_check_probes` fail.

This PR adds a Solaris specific path which gets all the available probes by listing those available in the running test process instead.

The output below is very different so the comparison needs to be updated a little as well.

```
>>> import subprocess
>>> import os
>>> res = subprocess.run(["dtrace", "-l", "-P", f"python{os.getpid()}"])
   ID   PROVIDER            MODULE                          FUNCTION NAME
   34 python1427 libpython3.16.so.1.0                         sys_audit audit
   35 python1427 libpython3.16.so.1.0           sys_audit_tstate.part.0 audit
   36 python1427 libpython3.16.so.1.0             dtrace_function_entry function-entry
   37 python1427 libpython3.16.so.1.0          _PyEval_EvalFrameDefault function-entry
   38 python1427 libpython3.16.so.1.0            dtrace_function_return function-return
   39 python1427 libpython3.16.so.1.0          _PyEval_EvalFrameDefault function-return
   40 python1427 libpython3.16.so.1.0                   gc_collect_main gc-done
   41 python1427 libpython3.16.so.1.0                   gc_collect_main gc-start
   42 python1427 libpython3.16.so.1.0 import_find_and_load_with_name.isra.0 import-find-load-done
   43 python1427 libpython3.16.so.1.0 import_find_and_load_with_name.isra.0 import-find-load-start
```
A little unfortunate thing is that the test now requires elevated privileges, but that is true of all other DTrace tests as well, so I don't think that's a big deal.

BTW: there is Solaris specific ELF section for DTrace metadata and at first I wanted to fix the test by reading that one (with `readelf -p .SUNW_dof <binary>`). Unfortunately, the section includes more metadata than just available probes, and the now removed line probe is also present in the dumped strings (so `test_check_probes` passes, but `test_missing_probes` unexpectedly passes as well).

It's possible to use `elfdump` and do some binary parsing to extract only the available ones, but that is a huge overkill for a test like this. For those interested, the change is here: https://github.com/kulikjak/cpython/commit/564e946aa219d8d933a0ae7a7149a2d74c025a29
 

<!-- gh-issue-number: gh-98894 -->
* Issue: gh-98894
<!-- /gh-issue-number -->
