### PR TITLE
gh-154817: Fix OrderedDict.pop() crash with inconsistent equality

### DIFF
--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -1014,6 +1014,28 @@ class CPythonOrderedDictTests(OrderedDictTests,
 
         gc.collect()
 
+    def test_pop_inconsistent_eq(self):
+        class K:
+            def __init__(self):
+                self.calls = 0
+
+            def __hash__(self):
+                return 12345
+
+            # Behave inconsistently across repeated equality checks.
+            def __eq__(self, other):
+                self.calls += 1
+                return self.calls <= 2
+
+        k1 = K()
+        k2 = K()
+
+        od = self.OrderedDict()
+        od[k1] = "value"
+
+        with self.assertRaises(KeyError):
+            od.pop(k2)
+
 
 class PurePythonOrderedDictSubclassTests(PurePythonOrderedDictTests):
 

--- a/Misc/NEWS.d/next/Library/2026-07-28-17-56-37.gh-issue-154817.PYfwpm.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-28-17-56-37.gh-issue-154817.PYfwpm.rst
@@ -1,0 +1,4 @@
+Fix a crash in collections.OrderedDict.pop() when a key's __eq__
+implementation returns inconsistent results across repeated comparisons.
+OrderedDict.pop() now raises KeyError instead of crashing when no default
+value is provided.

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1095,7 +1095,12 @@ _odict_popkey_hash(PyObject *od, PyObject *key, PyObject *failobj,
         /* Now delete the value from the dict. */
         if (_PyDict_Pop_KnownHash((PyDictObject *)od, key, hash,
                                   &value) == 0) {
-            value = Py_NewRef(failobj);
+            if (failobj) {
+                value = Py_NewRef(failobj);
+            }
+            else {
+                PyErr_SetObject(PyExc_KeyError, key);
+            }
         }
     }
     else if (value == NULL && !PyErr_Occurred()) {


### PR DESCRIPTION
## Summary

Fix a crash in `collections.OrderedDict.pop()` when a key's `__eq__`
implementation returns inconsistent results across repeated comparisons.

If the initial lookup succeeds but the subsequent removal lookup fails,
and no default value is supplied, `OrderedDict.pop()` could dereference
a `NULL` default value and crash the interpreter.

This change raises `KeyError` instead of dereferencing the `NULL` default
value and adds a C implementation regression test covering this scenario.

This PR intentionally fixes only the `NULL` dereference. It does not
address the broader `OrderedDict` container desynchronization that can
occur when the multiple internal lookups performed by
`OrderedDict.pop()` disagree due to inconsistent equality results.

## Changes

- Fix the missing-key path in `OrderedDict.pop()` when no default value is provided.
- Raise `KeyError` instead of dereferencing a `NULL` default value.
- Add a C implementation regression test for a key with stateful equality.

## Testing

```text
./python -m test test_ordered_dict
./python -m test test_collections
```

Closes gh-154817