### PR TITLE
gh-154594: Fix copy.deepcopy() re-copying objects whose __deepcopy__ returns None

### DIFF
--- a/Lib/copy.py
+++ b/Lib/copy.py
@@ -122,9 +122,10 @@ def deepcopy(x, memo=None):
     if memo is None:
         memo = {}
     else:
-        y = memo.get(d, None)
-        if y is not None:
-            return y
+        try:
+            return memo[d]
+        except KeyError:
+            pass
 
     copier = _deepcopy_dispatch.get(cls)
     if copier is not None:

--- a/Lib/copy.py
+++ b/Lib/copy.py
@@ -121,11 +121,8 @@ def deepcopy(x, memo=None):
     d = id(x)
     if memo is None:
         memo = {}
-    else:
-        try:
-            return memo[d]
-        except KeyError:
-            pass
+    elif d in memo:
+        return memo[d]
 
     copier = _deepcopy_dispatch.get(cls)
     if copier is not None:

--- a/Lib/test/test_copy.py
+++ b/Lib/test/test_copy.py
@@ -509,6 +509,22 @@ class TestCopy(unittest.TestCase):
         self.assertIsNot(y, x)
         self.assertIsNot(y.foo, x.foo)
 
+    def test_deepcopy_inst_deepcopy_returns_none(self):
+        # gh-154594: the memo used to use None as its own "not cached"
+        # sentinel, so a __deepcopy__ that legitimately returns None was
+        # indistinguishable from a memo miss and got invoked again on
+        # every subsequent reference to the same object.
+        calls = []
+        class C:
+            def __deepcopy__(self, memo):
+                calls.append(1)
+                memo[id(self)] = None
+                return None
+        x = C()
+        y = copy.deepcopy([x, x, x])
+        self.assertEqual(y, [None, None, None])
+        self.assertEqual(len(calls), 1)
+
     def test_deepcopy_inst_getinitargs(self):
         class C:
             def __init__(self, foo):

--- a/Misc/NEWS.d/next/Library/2026-07-28-10-00-00.gh-issue-154594.lRVvrN.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-28-10-00-00.gh-issue-154594.lRVvrN.rst
@@ -1,0 +1,3 @@
+Fix :func:`copy.deepcopy` re-invoking an object's :meth:`~object.__deepcopy__`
+on every subsequent reference to that object when it returns :const:`None`.
+The memo dict now distinguishes a cached ``None`` result from a cache miss.


### PR DESCRIPTION
Fixes gh-154594.

`copy.deepcopy()` uses `memo.get(d, None)` to check the memo dict, treating `None` both as the "not cached" sentinel and as a value a `__deepcopy__` can legitimately return. When an object's `__deepcopy__` returns `None`, the memo hit is indistinguishable from a miss, so the object gets deep-copied again on every subsequent reference instead of once:

```python
import copy

call_count = 0

class C:
    def __deepcopy__(self, memo):
        global call_count
        call_count += 1
        memo[id(self)] = None
        return None

obj = C()
copy.deepcopy([obj, obj, obj])
print(call_count)  # 3, expected 1
```

This was introduced by gh-132657 / GH-138429, which replaced the previous `_nil = []` sentinel with `None` specifically because `None` is an immortal singleton in CPython, avoiding refcount contention under free-threading that a plain sentinel object would reintroduce.

The fix switches the lookup to `if d in memo: return memo[d]` (as suggested by @pochmann in the issue discussion), rather than reintroducing a sentinel object or special-casing `None`. This distinguishes every possible cached value (including `None`) from a genuine cache miss, without any shared sentinel object and without the exception-handling overhead a `try`/`except KeyError` form would add on every miss.

I benchmarked three candidate approaches (current `is not None` check, `try`/`except KeyError`, and `d in memo`) with pyperf on hit-heavy and miss-heavy workloads, and with `Tools/ftscalingbench` under free-threading:

| workload | baseline (`is not None`) | `try`/`except` | `d in memo` (this PR) |
|---|---|---|---|
| hit-heavy (pyperf) | 781 µs | 877 µs | 810 µs |
| miss-heavy (pyperf) | 9.86 ms | 11.5 ms | 9.62 ms |
| ftscalingbench, 8 threads | ~2.8x scaling | ~2.4x scaling | ~2.8x scaling |

`d in memo` ties or beats the current baseline on every axis. The earlier `try`/`except` version of this PR was ~17% slower on misses (the common case, per discussion in the issue) and scaled worse under free-threading contention; `d in memo` doesn't have either regression.

Added a regression test and a changelog entry.