### PR TITLE
[3.14] gh-149619: Fix `_remote_debugging` permissions error on Linux (GH-150012)

### DIFF
--- a/Python/remote_debug.h
+++ b/Python/remote_debug.h
@@ -159,7 +159,9 @@ _Py_RemoteDebug_ValidatePyRuntimeCookie(proc_handle_t *handle, uintptr_t address
     }
     char buf[sizeof(_Py_Debug_Cookie) - 1];
     if (_Py_RemoteDebug_ReadRemoteMemory(handle, address, sizeof(buf), buf) != 0) {
-        PyErr_Clear();
+        if (!_Py_RemoteDebug_HasPermissionError()) {
+            PyErr_Clear();
+        }
         return 0;
     }
     return memcmp(buf, _Py_Debug_Cookie, sizeof(buf)) == 0;
@@ -1062,12 +1064,14 @@ _Py_RemoteDebug_GetPyRuntimeAddress(proc_handle_t* handle)
     address = search_linux_map_for_section(handle, "PyRuntime", "python",
                                            _Py_RemoteDebug_ValidatePyRuntimeCookie);
     if (address == 0) {
-        // Error out: 'python' substring covers both executable and DLL
-        PyObject *exc = PyErr_GetRaisedException();
-        PyErr_Format(PyExc_RuntimeError,
-            "Failed to find the PyRuntime section in process %d on Linux platform",
-            handle->pid);
-        _PyErr_ChainExceptions1(exc);
+        if (!_Py_RemoteDebug_HasPermissionError()) {
+            // Error out: 'python' substring covers both executable and DLL
+            PyObject *exc = PyErr_GetRaisedException();
+            PyErr_Format(PyExc_RuntimeError,
+                "Failed to find the PyRuntime section in process %d on Linux platform",
+                handle->pid);
+            _PyErr_ChainExceptions1(exc);
+        }
     }
 #elif defined(__APPLE__) && defined(TARGET_OS_OSX) && TARGET_OS_OSX
     // On macOS, try libpython first, then fall back to python


### PR DESCRIPTION
Backport of GH-150012 to Python 3.14.

This preserves `PermissionError` when runtime-cookie validation fails and prevents the Linux runtime lookup from replacing it with a misleading `RuntimeError`. Python 3.14 already contains the overlapping map-search propagation from GH-151032, so this backport includes only the two remaining required changes.

Without this fix, `process_vm_readv()` returning `EPERM` is reported as “Failed to find the PyRuntime section” instead of the actual permissions error.

(cherry picked from commit 0563890872b3c63f94953e983fe396615b708540)

<!-- gh-issue-number: gh-149619 -->
* Issue: gh-149619
<!-- /gh-issue-number -->
