### PR TITLE
[3.15] Backport GH-148874: Make sure that mngr.__exit__() is always called in a with statement (GH-150911)

### DIFF
--- a/Lib/test/test_with.py
+++ b/Lib/test/test_with.py
@@ -10,6 +10,7 @@ import traceback
 import unittest
 from collections import deque
 from contextlib import _GeneratorContextManager, contextmanager, nullcontext
+from _testinternalcapi import SelfInterruptingContextManager
 
 
 def do_with(obj):
@@ -848,6 +849,22 @@ class NestedWith(unittest.TestCase):
                 self.assertEqual(f.end_lineno, co.co_firstlineno + 2)
                 self.assertEqual(f.line[f.colno - indent : f.end_colno - indent],
                                  expected)
+
+
+class InterruptDuringEnter(unittest.TestCase):
+
+    def test_exit_called_after_interrupt(self):
+        cm = SelfInterruptingContextManager()
+        self.assertFalse(cm.within())
+        try:
+            with cm:
+                self.assertTrue(cm.within())
+        except KeyboardInterrupt:
+            self.assertFalse(cm.within())
+            return
+        except:
+            self.fail("Wrong exception raised")
+        self.fail("No exception raised")
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-06-04-12-53-10.gh-issue-148874.r121cG.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-06-04-12-53-10.gh-issue-148874.r121cG.rst
@@ -1,0 +1,3 @@
+Ignore interrupts immediately after calling the ``__enter__`` method of a
+context menager in a ``with`` statement. This ensures that the ``__exit__``
+method is always called in a ``with`` statement.

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -3194,6 +3194,66 @@ test_thread_state_ensure_from_view_interp_switch(PyObject *self, PyObject *unuse
     Py_RETURN_NONE;
 }
 
+/* Self interrupting context manager */
+
+typedef struct {
+    PyObject_HEAD
+    int within;
+} SelfInterruptingContextManagerObject;
+
+static PyObject *
+new_self_interrupting(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    SelfInterruptingContextManagerObject *self =
+        (SelfInterruptingContextManagerObject *)type->tp_alloc(type, 0);
+    if (self != NULL) {
+        self->within = 0;
+    }
+    return (PyObject *)self;
+}
+
+static PyObject *
+self_interrupting_enter(PyObject *op, PyObject *Py_UNUSED(dummy))
+{
+    ((SelfInterruptingContextManagerObject *)op)->within = 1;
+    PyThreadState *tstate = PyThreadState_Get();
+    PyObject *ki = Py_NewRef(PyExc_KeyboardInterrupt);
+    PyObject *old_exc = _Py_atomic_exchange_ptr(&tstate->async_exc, ki);
+    _Py_set_eval_breaker_bit(tstate, _PY_ASYNC_EXCEPTION_BIT);
+    Py_XDECREF(old_exc);
+
+    return Py_NewRef(op);
+}
+
+static PyObject *
+self_interrupting_within(PyObject *op, PyObject *Py_UNUSED(dummy))
+{
+    return PyBool_FromLong(((SelfInterruptingContextManagerObject *)op)->within);
+}
+
+static PyObject *
+self_interrupting_exit(PyObject *op, PyObject *Py_UNUSED(args)) {
+    ((SelfInterruptingContextManagerObject *)op)->within = 0;
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef self_interrupting_methods[] = {
+    {"__enter__", self_interrupting_enter, METH_NOARGS, NULL},
+    {"within", self_interrupting_within, METH_NOARGS, NULL},
+    {"__exit__", self_interrupting_exit, METH_VARARGS, NULL},
+    {NULL, NULL} /* sentinel */
+};
+
+static PyTypeObject SelfInterruptingContextManager_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "_testcapi.SelfInterruptingContextManager",
+    sizeof(SelfInterruptingContextManagerObject),
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE,
+    .tp_new = new_self_interrupting,
+    .tp_methods = self_interrupting_methods,
+};
+
+
 static PyMethodDef module_functions[] = {
     {"get_configs", get_configs, METH_NOARGS},
     {"get_eval_frame_stats", get_eval_frame_stats, METH_NOARGS, NULL},
@@ -3415,6 +3475,11 @@ module_exec(PyObject *module)
         return 1;
     }
 #endif
+
+    if (PyType_Ready(&SelfInterruptingContextManager_Type) < 0) {
+        return 1;
+    }
+    PyModule_AddObject(module, "SelfInterruptingContextManager", (PyObject *)&SelfInterruptingContextManager_Type);
 
     return 0;
 }

--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -1866,7 +1866,7 @@
                 stack_pointer += -1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -2364,7 +2364,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -2452,7 +2452,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -2536,7 +2536,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -2643,7 +2643,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -2749,7 +2749,7 @@
                 stack_pointer += 1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -3056,7 +3056,7 @@
                 stack_pointer += 1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -3544,7 +3544,7 @@
                 stack_pointer += -2 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -3943,7 +3943,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -4055,7 +4055,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -4173,7 +4173,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -4303,7 +4303,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -4378,7 +4378,7 @@
                 stack_pointer += -1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -4668,7 +4668,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -4743,7 +4743,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -6914,7 +6914,7 @@
                 stack_pointer += -1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -7082,7 +7082,7 @@
                 stack_pointer += 1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -161,7 +161,7 @@ dummy_func(
         }
 
         replaced op(_CHECK_PERIODIC_AT_END, (--)) {
-            int err = check_periodics(tstate);
+            int err = check_periodics_at_end(tstate, frame);
             ERROR_IF(err != 0);
         }
 

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -527,6 +527,22 @@ check_periodics(PyThreadState *tstate) {
     return 0;
 }
 
+static inline int
+check_periodics_at_end(PyThreadState *tstate, _PyInterpreterFrame *frame) {
+    _Py_CHECK_EMSCRIPTEN_SIGNALS_PERIODICALLY();
+    QSBR_QUIESCENT_STATE(tstate);
+    if (_Py_atomic_load_uintptr_relaxed(&tstate->eval_breaker) & _PY_EVAL_EVENTS_MASK) {
+        // Do not handle pending interrupts if the previous instruction was LOAD_SPECIAL
+        // This may also not handle interrupts if a cache looks like LOAD_SPECIAL,
+        // but this is benign as we won't skip periodic checks indefinitely.
+        if (frame->instr_ptr[-1].op.code == LOAD_SPECIAL) {
+            return 0;
+        }
+        return _Py_HandlePending(tstate);
+    }
+    return 0;
+}
+
 // Mark the generator as executing. Returns true if the state was changed,
 // false if it was already executing or finished.
 static inline bool

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1866,7 +1866,7 @@
                 stack_pointer += -1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -2364,7 +2364,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -2452,7 +2452,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -2536,7 +2536,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -2643,7 +2643,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -2749,7 +2749,7 @@
                 stack_pointer += 1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -3056,7 +3056,7 @@
                 stack_pointer += 1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -3544,7 +3544,7 @@
                 stack_pointer += -2 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -3943,7 +3943,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -4055,7 +4055,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -4173,7 +4173,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -4303,7 +4303,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -4378,7 +4378,7 @@
                 stack_pointer += -1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -4668,7 +4668,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -4743,7 +4743,7 @@
             // _CHECK_PERIODIC_AT_END
             {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -6914,7 +6914,7 @@
                 stack_pointer += -1 - oparg;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);
@@ -7082,7 +7082,7 @@
                 stack_pointer += 1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int err = check_periodics(tstate);
+                int err = check_periodics_at_end(tstate, frame);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 if (err != 0) {
                     JUMP_TO_LABEL(error);

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -994,10 +994,15 @@ _PyJit_translate_single_bytecode_to_trace(
                     case OPARG_REPLACED:
                         uop = _PyUOp_Replacements[uop];
                         assert(uop != 0);
-
                         uint32_t next_inst = target + 1 + _PyOpcode_Caches[_PyOpcode_Deopt[opcode]];
                         if (uop == _TIER2_RESUME_CHECK) {
-                            target = next_inst;
+                            if (this_instr[-1].op.code == LOAD_SPECIAL) {
+                                // Don't check eval breaker immediately after LOAD_SPECIAL
+                                uop = _NOP;
+                            }
+                            else {
+                                target = next_inst;
+                            }
                         }
                         else {
                             int extended_arg = orig_oparg > 255;

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -577,6 +577,7 @@ Modules/_testimportmultiple.c	-	_testimportmultiple	-
 Modules/_testinternalcapi.c	-	pending_identify_result	-
 Modules/_testinternalcapi.c	-	Test_EvalFrame_Resumes	-
 Modules/_testinternalcapi.c	-	Test_EvalFrame_Loads	-
+Modules/_testinternalcapi.c	-	SelfInterruptingContextManager_Type	-
 Modules/_testinternalcapi/interpreter.c	-	Test_EvalFrame_Resumes	-
 Modules/_testinternalcapi/interpreter.c	-	Test_EvalFrame_Loads	-
 Modules/_testlimitedcapi/slots.c	-	TestMethods	-


### PR DESCRIPTION

* Even if there is an interrupt during the call to `mngr.__enter__()`


<!-- gh-issue-number: gh-148874 -->
* Issue: gh-148874
<!-- /gh-issue-number -->
