### PR TITLE
Narrow bare except in email._header_value_parser

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2537,7 +2537,7 @@ def get_parameter(value):
         else:
             try:
                 token, rest = get_extended_attrtext(inner_value)
-            except:
+            except errors.HeaderParseError:
                 pass
             else:
                 if not rest:


### PR DESCRIPTION
## Summary

Replace a bare `except` in `email._header_value_parser.get_parameter()` with
`except errors.HeaderParseError`.

## Rationale

`get_extended_attrtext()` is the only operation inside the `try` block. It
raises `errors.HeaderParseError` for the parse failures this code is intended
to recover from. Narrowing the exception handler avoids suppressing unrelated
exceptions while preserving the existing recovery behavior.

I verified that the recovery path is exercised by the existing test suite and
that `HeaderParseError` is the expected exception for this code path.

## Tests

- `./python -m test test_email.test__header_value_parser test_email.test_headerregistry`
- `./python -m test test_email`
