### PR TITLE
gh-154842: Reject repack() while a reading handle is open

### DIFF
--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -583,7 +583,7 @@ ZipFile objects
    Rewrites the archive to remove unreferenced local file entries, shrinking
    its file size.  The archive must be opened with mode ``'a'``, and any file
    object returned by :meth:`ZipFile.open` must be closed first, since
-   repacking moves the member data those objects read from.
+   repacking moves the member data such objects refer to.
 
    If *removed* is provided, it must be a sequence of :class:`ZipInfo` objects
    representing the recently removed members, and only their corresponding

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -581,7 +581,9 @@ ZipFile objects
                            strict_descriptor=True[, chunk_size])
 
    Rewrites the archive to remove unreferenced local file entries, shrinking
-   its file size.  The archive must be opened with mode ``'a'``.
+   its file size.  The archive must be opened with mode ``'a'``, and any file
+   object returned by :meth:`ZipFile.open` must be closed first, since
+   repacking moves the member data those objects read from.
 
    If *removed* is provided, it must be a sequence of :class:`ZipInfo` objects
    representing the recently removed members, and only their corresponding

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -2383,6 +2383,18 @@ class AbstractRepackTests(RepackHelperMixin):
         m_repack.assert_not_called()
 
     @mock.patch.object(zipfile, '_ZipRepacker')
+    def test_repack_reading(self, m_repack):
+        self._prepare_zip_from_test_files(TESTFN, self.test_files)
+        with zipfile.ZipFile(TESTFN, 'a') as zh:
+            with zh.open(self.test_files[0][0]):
+                with self.assertRaises(ValueError):
+                    zh.repack()
+            m_repack.assert_not_called()
+            # Allowed once the reading handle is closed.
+            zh.repack()
+        m_repack.assert_called_once()
+
+    @mock.patch.object(zipfile, '_ZipRepacker')
     def test_repack_mode_r(self, m_repack):
         self._prepare_zip_from_test_files(TESTFN, self.test_files)
         with zipfile.ZipFile(TESTFN, 'r') as zh:

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -2397,20 +2397,16 @@ class ZipFile:
         truncation."""
         if self.mode != 'a':
             raise ValueError("repack() requires mode 'a'")
-        if not self.fp:
-            raise ValueError(
-                "Attempt to write to ZIP archive that was already closed")
-        if self._writing:
-            raise ValueError(
-                "Can't write to ZIP archive while an open writing handle exists"
-            )
-        if self._fileRefCnt > 1:
-            raise ValueError(
-                "Can't repack the ZIP archive while an open reading handle "
-                "exists. Close the reading handle before repacking."
-            )
 
         with self._lock:
+            if not self.fp:
+                raise ValueError(
+                    "Attempt to write to ZIP archive that was already closed")
+            if self._writing or self._fileRefCnt > 1:
+                raise ValueError(
+                    "Can't repack ZIP archive while an open handle exists"
+                )
+
             self._writing = True
             try:
                 repacker = _ZipRepacker(

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -2404,6 +2404,11 @@ class ZipFile:
             raise ValueError(
                 "Can't write to ZIP archive while an open writing handle exists"
             )
+        if self._fileRefCnt > 1:
+            raise ValueError(
+                "Can't repack the ZIP archive while an open reading handle "
+                "exists. Close the reading handle before repacking."
+            )
 
         with self._lock:
             self._writing = True


### PR DESCRIPTION
`ZipFile.repack()` moves member data to lower offsets, but a `ZipExtFile` from an earlier `open()` keeps its own absolute position, so it silently returned data from the wrong place and a full read failed with `BadZipFile: Bad CRC-32`. Raise `ValueError` while an open reading handle exists, as the writing-handle case already does.

The test fails without the guard. `repack()` is new in 3.16, so no NEWS entry.


<!-- gh-issue-number: gh-154842 -->
* Issue: gh-154842
<!-- /gh-issue-number -->

