### PR TITLE
gh-127172: Honor umask and default ACL when installing venv activation scripts

### DIFF
--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -603,6 +603,27 @@ class BasicTest(BaseTest):
             venv.create(self.env_dir)
             listxattr_mock.assert_not_called()
 
+    @unittest.skipIf(os.name == 'nt', 'POSIX-specific permission test')
+    def test_install_scripts_honors_umask(self):
+        """
+        gh-127172: Activation scripts must inherit the process umask (and any
+        default ACL) like every other created file, rather than a fixed mode
+        copied from the source template.
+        """
+        old_umask = os.umask(0o002)
+        try:
+            venv.create(self.env_dir, with_pip=False)
+            bindir = os.path.join(self.env_dir, self.bindir)
+            control = os.path.join(bindir, 'control')
+            with open(control, 'w'):
+                pass
+            expected = os.stat(control).st_mode & 0o777
+            for name in ('activate', 'activate.csh', 'activate.fish'):
+                mode = os.stat(os.path.join(bindir, name)).st_mode & 0o777
+                self.assertEqual(mode, expected)
+        finally:
+            os.umask(old_umask)
+
     def test_overwrite_existing(self):
         """
         Test creating environment in an existing directory.

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -592,11 +592,10 @@ class EnvBuilder:
                                    'may be binary: %s', srcfile, e)
                     continue
                 if new_data == data:
-                    shutil.copy(srcfile, dstfile)
+                    shutil.copyfile(srcfile, dstfile)
                 else:
                     with open(dstfile, 'wb') as f:
                         f.write(new_data)
-                    shutil.copymode(srcfile, dstfile)
 
     def upgrade_dependencies(self, context):
         logger.debug(

--- a/Misc/NEWS.d/next/Library/2026-07-29-12-20-39.gh-issue-127172.Kf3Xa9.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-12-20-39.gh-issue-127172.Kf3Xa9.rst
@@ -1,0 +1,4 @@
+Creating a virtual environment with :mod:`venv` now writes the activation
+scripts using permissions derived from the process umask (and any default
+ACL), consistent with the other files it creates, instead of a fixed mode
+copied from the packaged templates. Patch by tonghuaroot.


### PR DESCRIPTION
`venv` installs the activation scripts (`activate`, `activate.csh`,
`activate.fish`) by copying the packaged template's mode onto the output, so
they always end up `0644` regardless of the process umask or any default ACL on
the target directory. Every other file `venv` creates (the `pip` wrappers, and
any file written afterwards) honors the umask and ACL, so the activation scripts
are the odd ones out: on a directory with a group-writable default ACL they come
out `rw-r--r--` while `pip*` come out `rw-rw-rw-`.

Activation scripts are sourced, not executed, so they need no special mode. This
drops the mode-copying in `install_scripts` so the scripts inherit the umask and
default ACL like everything else `venv` writes.

The added regression test drives the process umask, so it needs no ACL support
and runs on every POSIX platform.


<!-- gh-issue-number: gh-127172 -->
* Issue: gh-127172
<!-- /gh-issue-number -->
