### PR TITLE
gh-131484: Document that directory and zipfile script targets stay on sys.path

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -163,10 +163,11 @@ source.
    added to the start of :data:`sys.path` and the ``__main__.py`` file in
    that location is executed as the :mod:`__main__` module.
 
-   :option:`-I` option can  be used to run the script in isolated mode where
-   :data:`sys.path` contains neither the script's directory nor the user's
-   site-packages directory. All ``PYTHON*`` environment variables are
-   ignored, too.
+   :option:`-I` can be used to run the script in isolated mode. For a Python
+   file, the containing directory is then omitted from :data:`sys.path`, as
+   is the user's site-packages directory; a directory or zipfile target
+   remains, as described under :option:`-P`. All ``PYTHON*`` environment
+   variables are ignored, too.
 
    .. audit-event:: cpython.run_file filename
 
@@ -361,6 +362,13 @@ Miscellaneous options
      If it's a symbolic link, resolve symbolic links.
    * ``python -c code`` and ``python`` (REPL) command lines: Don't prepend an
      empty string, which means the current working directory.
+
+   If the script name refers to a directory or zipfile (see
+   :ref:`using-on-interface-options`), the script name is still added to the
+   start of :data:`sys.path`. This also applies when safe-path mode is
+   enabled by :option:`-I` or :envvar:`PYTHONSAFEPATH`. The entry is used to
+   locate ``__main__.py`` and makes other modules stored in the target
+   importable.
 
    See also the :envvar:`PYTHONSAFEPATH` environment variable, and :option:`-E`
    and :option:`-I` (isolated) options.

--- a/Misc/NEWS.d/next/Documentation/2026-07-29-12-50-00.gh-issue-131484.Xk2mVq.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-07-29-12-50-00.gh-issue-131484.Xk2mVq.rst
@@ -1,0 +1,2 @@
+Clarify that a directory or zipfile passed as the script argument remains on
+:data:`sys.path` in safe-path and isolated modes.


### PR DESCRIPTION
The `-P` documentation covers only the `-m` / script / `-c` / REPL cases. A directory
or zipfile passed as the script argument stays at the start of `sys.path`, in
safe-path and isolated modes alike: that entry is used to locate `__main__` and makes
other modules stored in the target importable.

This documents existing behavior; there is no code change. It assumes keeping the
named target is intended — if it should change instead, please close this; the
analysis is in #131484.

Verified with 3.14.6 and main at 8b048eb35e.

AI-assisted; I reviewed the changes and verified the behavior and cited source myself.


<!-- gh-issue-number: gh-131484 -->
* Issue: gh-131484
<!-- /gh-issue-number -->
