### PR TITLE
gh-151728: Clear the typing caches at interpreter shutdown

### DIFF
--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -272,8 +272,7 @@ def clear_caches():
     except KeyError:
         pass
     else:
-        for f in typing._cleanups:
-            f()
+        typing._clear_caches()
 
         import inspect
         abs_classes = filter(inspect.isabstract, typing.__dict__.values())

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -19,6 +19,7 @@ that may be changed without notice. Use at your own risk!
 """
 
 from abc import abstractmethod, ABCMeta
+import atexit
 import collections
 from collections import defaultdict
 import collections.abc
@@ -390,6 +391,16 @@ def _flatten_literal_params(parameters):
 
 _cleanups = []
 _caches = {}
+
+
+def _clear_caches():
+    for cleanup in _cleanups:
+        cleanup()
+
+
+# Release the LRU caches at shutdown, they otherwise redistribute reference
+# leaks of one extension to types of unrelated ones. See GH-151728.
+atexit.register(_clear_caches)
 
 
 def _tp_cache(func=None, /, *, typed=False):

--- a/Misc/NEWS.d/next/Library/2026-07-29-11-05-00.gh-issue-151728.Kq3vTn.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-11-05-00.gh-issue-151728.Kq3vTn.rst
@@ -1,0 +1,4 @@
+Clear the internal :mod:`typing` caches from an exit handler. Previously, an
+extension module that leaked a reference to :mod:`typing` would also keep every
+subscripted type alive past interpreter shutdown, including types owned by
+unrelated extension modules.


### PR DESCRIPTION
`typing` caches every subscripted type in module-level `lru_cache`es. Those caches are only released when the `typing` module itself is torn down, which does not happen when some extension module leaks a reference to it. Since `typing` is nearly universal, a single such leak (e.g. via `torch`) keeps the cached types alive past interpreter shutdown, including types owned by unrelated, correctly written extensions. Those extensions then look like they are leaking: `valgrind` reports them, and nanobind prints warnings about types, functions, and instances that were never freed.

`typing._cleanups` already holds callables to clean caches but does nothing with them. This PR registers an atexit callback that triggers them during Python finalization so that the process is leak-free upon termination. This complements gh-98253, which broke a cycle inside `_tp_cache` but left the retention itself in place.

The PR adds no tests because reproducing the problem requires an extension module that deliberately leaks a reference (i.e. one with a missing `tp_traverse`). A minimal one is at https://github.com/wjakob/typing-leak.


<!-- gh-issue-number: gh-151728 -->
* Issue: gh-151728
<!-- /gh-issue-number -->
