### PR TITLE
gh-109564: check server._sockets before attaching a new transport

### DIFF
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -225,6 +225,16 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         protocol = None
         transport = None
         try:
+            # gh-109564: create_task() defers this coroutine's first
+            # step by at least one loop iteration, so the server can
+            # legitimately close() in the gap between "connection
+            # accepted" and "this task actually runs". Attaching to an
+            # already-closed server crashes deep inside transport
+            # construction (Server._attach()'s assert); check up front
+            # instead and drop the already-accepted connection cleanly.
+            if server is not None and server._sockets is None:
+                conn.close()
+                return
             protocol = protocol_factory()
             waiter = self.create_future()
             if sslcontext:

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -421,6 +421,45 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         self.assertEqual(self.loop.call_exception_handler.call_count, 1)
         self.assertEqual(self.loop.call_later.call_count, 1)
 
+    def test_accept_connection2_server_already_closed(self):
+        # gh-109564: Server.close() sets Server._sockets = None
+        # synchronously, but _accept_connection2() only starts running at
+        # least one event-loop iteration after it's scheduled (it's a
+        # Task). If close() lands in that gap, attaching a transport to
+        # the now-closed server used to raise an uncatchable
+        # AssertionError deep inside transport construction instead of
+        # just dropping the already-accepted connection.
+        conn = mock.Mock()
+        protocol_factory = mock.Mock()
+        server = mock.Mock()
+        server._sockets = None
+
+        coro = self.loop._accept_connection2(
+            protocol_factory, conn, {}, server=server)
+        self.loop.run_until_complete(coro)
+
+        conn.close.assert_called_with()
+        protocol_factory.assert_not_called()
+
+    def test_accept_connection2_no_server(self):
+        # _accept_connection2's server parameter defaults to None (no
+        # Server object to check), which must not itself raise -- only
+        # an actual closed Server should short-circuit.
+        conn = mock.Mock()
+        protocol = mock.Mock()
+        protocol_factory = mock.Mock(return_value=protocol)
+        waiter = self.loop.create_future()
+        waiter.set_result(None)
+        self.loop.create_future = mock.Mock(return_value=waiter)
+        self.loop._make_socket_transport = mock.Mock()
+
+        coro = self.loop._accept_connection2(
+            protocol_factory, conn, {}, server=None)
+        self.loop.run_until_complete(coro)
+
+        protocol_factory.assert_called_with()
+        conn.close.assert_not_called()
+
 class SelectorTransportTests(test_utils.TestCase):
 
     def setUp(self):

--- a/Misc/NEWS.d/next/Library/2026-07-29-08-01-59.gh-issue-109564.PWM3XU.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-08-01-59.gh-issue-109564.PWM3XU.rst
@@ -1,0 +1,4 @@
+Fix a race in :class:`asyncio.Server` where calling :meth:`~asyncio.Server.close`
+while a connection was in the process of being accepted could raise an
+uncatchable :exc:`AssertionError` deep inside transport creation instead of
+simply dropping the connection.


### PR DESCRIPTION
Independent, narrower alternative to #131009 (the `_ServerState` enum
redesign) — flagging that up front since #131009 is already open and
maintainer-preferred for this issue. This PR is a small, local guard
that fixes the specific reproduced crash; it doesn't replace the
broader design #131009 is doing.

`Server.close()` sets `self._sockets = None` synchronously, but
`_accept_connection2()` runs as a `Task`, which always defers its first
step by at least one event-loop iteration. If `close()` lands in that
gap, `_attach()`'s `assert self._sockets is not None` fires.

Reproduced deterministically with real sockets (no mocking): closing
the server after exactly 3 `asyncio.sleep(0)` yields following a client
connect crashes 300/300 times on current `main`; every other yield
count, 0/300. The same trigger also produces a second, previously
undocumented crash: a `TypeError: 'NoneType' object is not iterable` in
`_wakeup()`, fired during garbage collection when the never-fully-
attached transport's `__del__` calls `_detach()` a second time. That one
doesn't show up in `loop.call_exception_handler()` output at all —
`__del__` failures are reported through a separate path — so it's easy
to miss even while actively looking at this bug. Both crashes are fixed
by the same change, confirmed 300/300 → 0/300 for the first and 300 → 0
occurrences for the second.

```diff
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -218,6 +218,16 @@
         protocol = None
         transport = None
         try:
+            # gh-109564: create_task() defers this coroutine's first
+            # step by at least one loop iteration, so the server can
+            # legitimately close() in the gap between "connection
+            # accepted" and "this task actually runs". Attaching to an
+            # already-closed server crashes deep inside transport
+            # construction (Server._attach()'s assert); check up front
+            # instead and drop the already-accepted connection cleanly.
+            if server is not None and server._sockets is None:
+                conn.close()
+                return
             protocol = protocol_factory()
             waiter = self.create_future()
             if sslcontext:
```

Also includes two new regression tests in `test_selector_events.py`
(deterministic, mock-based — no real-socket timing dependency, so
they're portable to CI) and a `Misc/NEWS.d` entry.

Validated on current `main`: the new tests fail without the fix and
pass with it; the full `test_asyncio` suite passes (2,811 tests, 0
failures, same skip set before and after); `Tools/patchcheck/patchcheck.py`
runs clean.

<details>
<summary>Why this doesn't implement the #131009 design, and one thing it doesn't cover</summary>

- Checked both linked PRs before writing this: #126660 (closed,
  unmerged, targeted the `_wakeup()` double-call symptom specifically)
  and #131009 (open, the maintainer-preferred `_ServerState` enum,
  still awaiting core review). This PR is a narrower, local guard, not
  a replacement for #131009's broader design.
- The secondary concern from the issue thread — `connection_made()`
  firing asynchronously after `close()` has already returned — isn't
  addressed here.

</details>