### PR TITLE
Fix ZstdDecompressor exception documentation

### DIFF
--- a/Doc/library/compression.zstd.rst
+++ b/Doc/library/compression.zstd.rst
@@ -346,7 +346,7 @@ Compressing and decompressing data in memory
       will be set to ``True``.
 
       Attempting to decompress data after the end of a frame will raise a
-      :exc:`ZstdError`. Any data found after the end of the frame is ignored
+      :exc:`EOFError`. Any data found after the end of the frame is ignored
       and saved in the :attr:`~.unused_data` attribute.
 
    .. attribute:: eof


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

The documentation for `compression.zstd.ZstdDecompressor.decompress()` stated that calling the method after reaching the end of a frame raises `ZstdError`.

The implementation raises `EOFError`, which is also the behavior expected by the tests. Update the documentation to match the actual behavior.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

The documentation for `compression.zstd.ZstdDecompressor.decompress()` stated that calling the method after reaching the end of a frame raises `ZstdError`.

The implementation raises `EOFError`, which is also the behavior expected by the tests. Update the documentation to match the actual behavior.
