### PR TITLE
[3.15] gh-109638: Fix exponential time in csv.Sniffer for doubled quotes

### DIFF
--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -328,20 +328,17 @@ class Sniffer:
             delim = ''
             skipinitialspace = 0
 
-        # if we see an extra quote between delimiters, we've got a
-        # double quoted format
+        # A doubled quote character inside a quoted field means
+        # a double quoted format.  Match whole fields, so that a match
+        # cannot slide across field boundaries.
         dq_regexp = re.compile(
-                r"(?:%(delim)s|^) *+%(quote)s"              # ,"
-                r"[^%(quote)s]*+%(quote)s%(quote)s"         # the doubled quote
-                r"(?:%(quote)s%(quote)s|[^%(quote)s]++)*+"  # the rest of the field
-                r"%(quote)s(?:%(delim)s|$)"                 # ",
+                r"(?:(?<=%(delim)s)|^) *+%(quote)s"           # ,"
+                r"((?:%(quote)s%(quote)s|[^%(quote)s]++)*+)"  # the body
+                r"%(quote)s(?:%(delim)s|$)"                   # ",
                 % {'delim': re.escape(delim), 'quote': quotechar},
                 re.MULTILINE)
-
-        if dq_regexp.search(data):
-            doublequote = True
-        else:
-            doublequote = False
+        dquotechar = quotechar * 2
+        doublequote = any(dquotechar in m[1] for m in dq_regexp.finditer(data))
 
         return (quotechar, doublequote, delim, skipinitialspace)
 

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -243,6 +243,8 @@ class Sniffer:
         Returns a dialect (or None) corresponding to the sample
         """
 
+        sample = sample.replace('\r\n', '\n').replace('\r', '\n')
+
         quotechar, doublequote, delimiter, skipinitialspace = \
                    self._guess_quote_and_delimiter(sample, delimiters)
         if not delimiter:
@@ -331,14 +333,17 @@ class Sniffer:
         # A doubled quote character inside a quoted field means
         # a double quoted format.  Match whole fields, so that a match
         # cannot slide across field boundaries.
-        dq_regexp = re.compile(
-                r"(?:(?<=%(delim)s)|^) *+%(quote)s"           # ,"
-                r"((?:%(quote)s%(quote)s|[^%(quote)s]++)*+)"  # the body
-                r"%(quote)s(?:%(delim)s|$)"                   # ",
-                % {'delim': re.escape(delim), 'quote': quotechar},
-                re.MULTILINE)
-        dquotechar = quotechar * 2
-        doublequote = any(dquotechar in m[1] for m in dq_regexp.finditer(data))
+        doublequote = False
+        if delim:
+            dq_regexp = re.compile(
+                    r"(?:(?<=%(delim)s)|^) *+%(quote)s"           # ,"
+                    r"((?:%(quote)s%(quote)s|[^%(quote)s]++)*+)"  # the body
+                    r"%(quote)s(?:%(delim)s|$)"                   # ",
+                    % {'delim': re.escape(delim), 'quote': quotechar},
+                    re.MULTILINE)
+            dquotechar = quotechar * 2
+            doublequote = any(dquotechar in m[1]
+                              for m in dq_regexp.finditer(data))
 
         return (quotechar, doublequote, delim, skipinitialspace)
 

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -331,10 +331,12 @@ class Sniffer:
         # if we see an extra quote between delimiters, we've got a
         # double quoted format
         dq_regexp = re.compile(
-                               r"((%(delim)s)|^)\W*%(quote)s[^%(delim)s\n]*%(quote)s[^%(delim)s\n]*%(quote)s\W*((%(delim)s)|$)" % \
-                               {'delim':re.escape(delim), 'quote':quotechar}, re.MULTILINE)
-
-
+                r"(?:%(delim)s|^) *+%(quote)s"              # ,"
+                r"[^%(quote)s]*+%(quote)s%(quote)s"         # the doubled quote
+                r"(?:%(quote)s%(quote)s|[^%(quote)s]++)*+"  # the rest of the field
+                r"%(quote)s(?:%(delim)s|$)"                 # ",
+                % {'delim': re.escape(delim), 'quote': quotechar},
+                re.MULTILINE)
 
         if dq_regexp.search(data):
             doublequote = True

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -336,10 +336,12 @@ class Sniffer:
         doublequote = False
         if delim:
             dq_regexp = re.compile(
-                    r"(?:(?<=%(delim)s)|^) *+%(quote)s"           # ,"
+                    r"(?:(?<=%(delim)s)|^)%(space)s%(quote)s"     # ,"
                     r"((?:%(quote)s%(quote)s|[^%(quote)s]++)*+)"  # the body
                     r"%(quote)s(?:%(delim)s|$)"                   # ",
-                    % {'delim': re.escape(delim), 'quote': quotechar},
+                    % {'delim': re.escape(delim), 'quote': quotechar,
+                       # Skipping spaces after a space rescans them.
+                       'space': ' *+' if delim != ' ' else ''},
                     re.MULTILINE)
             dquotechar = quotechar * 2
             doublequote = any(dquotechar in m[1]

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1582,6 +1582,23 @@ ghi\0jkl
         self.assertEqual(next(csv.reader(StringIO(sample), dialect)),
                          [',', '', ','])
 
+    def test_sniff_doublequote_record_separators(self):
+        # The record separator ends a field as a delimiter does.
+        sniffer = csv.Sniffer()
+        for sep in '\n', '\r\n', '\r':
+            with self.subTest(sep=sep):
+                sample = ('x,"a""b"' + sep + 'y,"c"' + sep) * 2
+                self.assertIs(sniffer.sniff(sample).doublequote, True)
+                sample = ('"",","' + sep) * 4
+                self.assertIs(sniffer.sniff(sample).doublequote, False)
+
+    def test_sniff_single_column(self):
+        # This sample used to be quadratic.
+        sniffer = csv.Sniffer()
+        sample = '"a"\n' + ' ' * 100000
+        with self.assertRaisesRegex(csv.Error, "Could not determine delimiter"):
+            sniffer.sniff(sample, delimiters=',;')
+
 
 class NUL:
     def write(s, *args):

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1564,6 +1564,13 @@ ghi\0jkl
             sniffer.sniff(sample)
 
 
+    def test_sniff_regex_backtracking(self):
+        # gh-109638: this artificial sample used to take minutes.
+        sniffer = csv.Sniffer()
+        sample = '"",' * 100 + '"' * 100 + '0' + '"' * 100 + '0'
+        self.assertEqual(sniffer.sniff(sample).delimiter, ',')
+
+
 class NUL:
     def write(s, *args):
         pass

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1599,6 +1599,14 @@ ghi\0jkl
         with self.assertRaisesRegex(csv.Error, "Could not determine delimiter"):
             sniffer.sniff(sample, delimiters=',;')
 
+    def test_sniff_space_delimiter(self):
+        # This sample used to be quadratic.
+        sniffer = csv.Sniffer()
+        sample = '"a" "b"\n' + ' ' * 100000
+        dialect = sniffer.sniff(sample)
+        self.assertEqual(dialect.delimiter, ' ')
+        self.assertIs(dialect.doublequote, False)
+
 
 class NUL:
     def write(s, *args):

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1570,6 +1570,18 @@ ghi\0jkl
         sample = '"",' * 100 + '"' * 100 + '0' + '"' * 100 + '0'
         self.assertEqual(sniffer.sniff(sample).delimiter, ',')
 
+    def test_sniff_doublequote_across_fields(self):
+        # A quoted field which contains the delimiter, followed by
+        # an empty quoted field, is not a doubled quote.
+        sniffer = csv.Sniffer()
+        sample = '",","",","\n' * 4
+        dialect = sniffer.sniff(sample)
+        self.assertEqual(dialect.delimiter, ',')
+        self.assertEqual(dialect.quotechar, '"')
+        self.assertIs(dialect.doublequote, False)
+        self.assertEqual(next(csv.reader(StringIO(sample), dialect)),
+                         [',', '', ','])
+
 
 class NUL:
     def write(s, *args):

--- a/Misc/NEWS.d/next/Library/2026-07-29-11-25-00.gh-issue-109638.Vt2Rn9.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-11-25-00.gh-issue-109638.Vt2Rn9.rst
@@ -1,0 +1,3 @@
+Fix exponential time in :meth:`csv.Sniffer.sniff` for a sample which contains
+many quote characters.  A doubled quote character is now also detected in
+a field which contains the delimiter or a line break.


### PR DESCRIPTION
The regular expression which detects a doubled quote character lets its runs match the quote character too, so every quote can be taken either as part of a run or as one of the three matched quotes. With three unbounded quantifiers over a region of quotes and delimiters the search is O(n^5) -- 254 s at n=100 in the report.

```pycon
>>> sample = '"",' * 100 + '"' * 100 + '0' + '"' * 100 + '0'
>>> csv.Sniffer().sniff(sample)   # minutes
```

The runs now exclude the quote character and are matched possessively, which leaves exactly one way to read any input.

```
   n      before      after
  60    6.1300 s    0.0002 s
2000        --      0.0009 s
```

The runs also no longer exclude the delimiter and the line break, which the original did for no reason a reader shares -- so a doubled quote is now found in a field containing them as well, e.g. `,"All-Weather Dining Table, Round 48""",`. That is the bulk of the behaviour change: 42 of 560 corpus files, and against ground truth `doublequote=True` improves from 25.8% to 36.7% and `doublequote=False` from 77.0% to 78.7%, with delimiter and quotechar unchanged.

Note #109639 proposed an atomic group on the first run only. It removes the time but also the detection: `doublequote` becomes unconditionally `False` (0 of 126 annotated files, vs 32 for 3.15).

main is not affected: the sniffer was rewritten there in gh-83273.


<!-- gh-issue-number: gh-109638 -->
* Issue: gh-109638
<!-- /gh-issue-number -->
