### PR TITLE
[3.15] gh-111487: Fix csv.Sniffer never testing the minimum delimiter consistency

### DIFF
--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -404,18 +404,19 @@ class Sniffer:
 
             # build a list of possible delimiters
             modeList = modes.items()
-            total = float(min(chunkLength * iteration, len(data)))
-            # (rows of consistent data) / (number of rows) = 100%
-            consistency = 1.0
-            # minimum consistency threshold
-            threshold = 0.9
-            while len(delims) == 0 and consistency >= threshold:
+            total = min(chunkLength * iteration, len(data))
+            # (rows of consistent data) / (number of rows) = 100%, counted down
+            # in whole percent to a minimum consistency threshold of 90%.
+            # Integer arithmetic: subtracting 0.01 from a float stopped at
+            # 0.9099999999999999, so the pass at the threshold never ran.
+            for consistency in range(100, 89, -1):
+                if delims:
+                    break
                 for k, v in modeList:
                     if v[0] > 0 and v[1] > 0:
-                        if ((v[1]/total) >= consistency and
+                        if (v[1] * 100 >= consistency * total and
                             (delimiters is None or k in delimiters)):
                             delims[k] = v
-                consistency -= 0.01
 
             if len(delims) == 1:
                 delim = list(delims.keys())[0]

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -404,19 +404,22 @@ class Sniffer:
 
             # build a list of possible delimiters
             modeList = modes.items()
-            total = min(chunkLength * iteration, len(data))
-            # (rows of consistent data) / (number of rows) = 100%, counted down
-            # in whole percent to a minimum consistency threshold of 90%.
-            # Integer arithmetic: subtracting 0.01 from a float stopped at
-            # 0.9099999999999999, so the pass at the threshold never ran.
-            for consistency in range(100, 89, -1):
-                if delims:
-                    break
+            total = float(min(chunkLength * iteration, len(data)))
+            # (rows of consistent data) / (number of rows) = 100%
+            consistency = 1.0
+            # minimum consistency threshold
+            threshold = 0.9
+            # Tolerance for the rounding error accumulated by stepping
+            # 'consistency' down by 0.01: without it the counter stops at
+            # 0.9099999999999999 and the pass at the threshold never runs.
+            epsilon = 1e-9
+            while len(delims) == 0 and consistency >= threshold - epsilon:
                 for k, v in modeList:
                     if v[0] > 0 and v[1] > 0:
-                        if (v[1] * 100 >= consistency * total and
+                        if ((v[1]/total) >= consistency and
                             (delimiters is None or k in delimiters)):
                             delims[k] = v
+                consistency -= 0.01
 
             if len(delims) == 1:
                 delim = list(delims.keys())[0]

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1521,6 +1521,21 @@ ghi\0jkl
         self.assertEqual(sniffer.sniff(sample).delimiter, "|")
         self.assertNotEqual(sniffer.sniff(sample).delimiter, "\r")
 
+    def test_guess_delimiter_at_minimum_consistency(self):
+        # gh-111487: the consistency counter was stepped down by repeatedly
+        # subtracting 0.01 from a float, so it stopped at 0.9099999999999999
+        # and the pass at the documented 0.9 threshold never ran.  Here ";" is
+        # modal on 19 of the 20 rows, which scores (19 - 1) / 20 == 90% once
+        # the non-matching row is subtracted -- exactly the threshold.
+        # Every row uses a different letter so nothing else is consistent, and
+        # the odd row sits in the first chunk, which keeps that chunk below the
+        # threshold and defers the decision to the full 20-row chunk.
+        rows = [(chr(ord('a') + i) + ';') * 3 + chr(ord('a') + i)
+                for i in range(20)]
+        rows[4] = 'e;e;e'
+        sniffer = csv.Sniffer()
+        self.assertEqual(sniffer.sniff('\n'.join(rows)).delimiter, ';')
+
     def test_zero_mode_tie_order_independence(self):
         sniffer = csv.Sniffer()
         # ":" appears in half the rows (1, 0, 1, 0) - a tie between

--- a/Misc/NEWS.d/next/Library/2026-07-29-13-21-44.gh-issue-111487.Kw9pTz.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-13-21-44.gh-issue-111487.Kw9pTz.rst
@@ -1,5 +1,5 @@
 Fix :meth:`csv.Sniffer.sniff` never testing the documented minimum delimiter
 consistency of 90%.  The consistency counter was stepped down by repeatedly
 subtracting ``0.01`` from a float, so it stopped at ``0.9099999999999999`` and
-the final pass at the threshold was skipped; it now counts down in whole
-percent using exact integer arithmetic.
+the final pass at the threshold was skipped; the comparison against the
+threshold now allows for that accumulated error.

--- a/Misc/NEWS.d/next/Library/2026-07-29-13-21-44.gh-issue-111487.Kw9pTz.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-13-21-44.gh-issue-111487.Kw9pTz.rst
@@ -1,0 +1,5 @@
+Fix :meth:`csv.Sniffer.sniff` never testing the documented minimum delimiter
+consistency of 90%.  The consistency counter was stepped down by repeatedly
+subtracting ``0.01`` from a float, so it stopped at ``0.9099999999999999`` and
+the final pass at the threshold was skipped; it now counts down in whole
+percent using exact integer arithmetic.


### PR DESCRIPTION
`Sniffer._guess_delimiter` counts a consistency threshold down from 100% and
accepts the first candidate delimiter at or above a documented minimum of 90%:

```python
consistency = 1.0
# minimum consistency threshold
threshold = 0.9
while len(delims) == 0 and consistency >= threshold:
    ...
    consistency -= 0.01
```

Stepping a float down by `0.01` accumulates rounding error. The counter runs
`1.0, 0.99, ... , 0.9199999999999999, 0.9099999999999999` and then reaches
`0.8999999999999999`, which fails `>= 0.9`. So the loop makes ten passes
instead of eleven, and **the 90% threshold it documents is never actually
tested** — the lowest consistency it really accepts is about 91%.

The loop guard now allows for that accumulated error:

```python
epsilon = 1e-9
while len(delims) == 0 and consistency >= threshold - epsilon:
```

Only the guard needs it. Of the eleven counter values one is exact (`1.0`) and
the other ten all land *below* the whole percent they stand for, never above, so
the per-delimiter comparison `(v[1]/total) >= consistency` never rejects a score
sitting exactly on a documented percent — it is left untouched.

(An earlier revision of this PR counted down in whole percent with integer
arithmetic instead. @serhiy-storchaka suggested the tolerance in review; it is
both a smaller change and a stronger one, for the reason in the next section.)

### Scope — worth reading before reviewing

**This does not fix the sample in the issue report.** That sample is 10 rows in
which the delimiter occurs 30 times on 9 of them and 29 times on the 10th. The
score is not the fraction of matching rows — the mode's count has the
non-matching rows subtracted from it:

```python
modes[char] = (modes[char][0], modes[char][1] - sum(item[1] for item in items))
```

so that sample scores `(9 - 1) / 10` = 80%, which is below the threshold at
every level and is unaffected by the rounding. I checked, and it still raises
`Could not determine delimiter` with this patch applied. Making that sample work
means changing the scoring or lowering the threshold itself, which is a much
larger behaviour change than I think belongs on a maintenance branch.

What this fixes is narrower: the pass at exactly the documented threshold now
runs. Concretely, it newly accepts delimiters scoring in `[90%, 91%)`, which
corresponds to being modal on 95.0%–95.5% of the rows.

### On the earlier objection

@rhettinger wrote on the issue:

> We could use exact fractional arithmetic in this section. However, the
> threshold of `90%` was arbitrary so it likely doesn't make sense to make
> accumulation more exact. Also, we should be cautious about making any changes
> to guessing or sniffing logic. Code that is currently working but is on the
> margins may stop working.

That caution is fair and I would rather address it than talk past it. The
argument for changing it is that the threshold being arbitrary is what makes the
current state confusing: the constant says `0.9`, the code effectively stops at
`0.91`, and the two differ for no stated reason rather than by choice.

On the risk to code that currently works: the change is one-directional by
construction. Touching only the guard leaves the counter values and the
per-delimiter comparison exactly as they were, so the loop makes the same passes
with the same values in the same order and adds one more at the end. Anything
the old loop accepted the new one still accepts, at the same level, and nothing
that previously matched can stop matching. I also compared patched against
unpatched `sniff()` results across 6795 samples — row and inconsistency sweeps
across four delimiters, ordinary well-formed CSV, `TestSniffer`'s own corpus,
the sample from the issue report, and 6000 randomized strings. 16 results
changed, every one of them from `Could not determine delimiter` to a correctly
identified delimiter. No sample that already returned a dialect returned a
different one, and none began failing.

If you would still rather not touch the sniffing heuristics on a maintenance
branch at all, I am happy to close this.

### Test

`test_guess_delimiter_at_minimum_consistency` builds 20 rows in which `;` is
modal on 19 of them, scoring `(19 - 1) / 20` = exactly 90%. Every row uses a
different letter so no other character is consistent, and the odd row sits in
the first chunk, which keeps that chunk below the threshold and defers the
decision to the full 20-row chunk. Without the fix it fails with:

```
_csv.Error: Could not determine delimiter
```

### Branch

`_guess_delimiter` was replaced by the `Sniffer` rewrite in gh-83273, so this
does not apply to `main` and is based directly on `3.15`. 3.14 and 3.13 are
affected as well; I will open those if this one is accepted.

Note that 3.15.0rc1 was tagged on 2026-08-04, after this PR was opened. The
change is small and one-directional, but it is still a behaviour change to the
sniffing heuristics on a branch in rc, so if it is too late for 3.15.0 I am
happy to retarget it at 3.14 and 3.13.

---

*Disclosure: prepared with AI assistance (Claude Code) — used to analyse the
rounding behaviour, construct the threshold test case, run the differential
check above, and draft the patch and this description.*


<!-- gh-issue-number: gh-111487 -->
* Issue: gh-111487
<!-- /gh-issue-number -->
