### PR TITLE
gh-154874: Fix the sign of curses.termattrs()

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -3242,5 +3242,33 @@ class SLKTests(NewtermTestBase):
         curses.slk_color(0)
 
 
+@unittest.skipUnless(hasattr(curses, 'newterm'), 'requires curses.newterm()')
+@unittest.skipIf(BROKEN_NEWTERM, 'ncurses < 6.5 mishandles repeated newterm()')
+@unittest.skipIf(not term or term == 'unknown',
+                 f"$TERM={term!r}, newterm() may not work")
+@unittest.skipIf(sys.platform == "cygwin",
+                 "cygwin's curses mostly just hangs")
+class TermAttrsTests(NewtermTestBase):
+    # A_ITALIC is the topmost bit of a 32-bit attribute mask, so termattrs()
+    # only tells a signed result from an unsigned one on a terminal that
+    # advertises it.  Drive a known terminal type over a pseudo-terminal
+    # instead of relying on whatever $TERM happens to be.
+
+    def test_termattrs_is_not_negative(self):
+        s = self.make_pty()
+        try:
+            curses.newterm('xterm-256color', s, s)
+        except curses.error:
+            self.skipTest('no xterm-256color terminfo entry')
+        attrs = curses.termattrs()
+        italic = getattr(curses, 'A_ITALIC', 0)
+        if not italic or not attrs & italic:
+            self.skipTest('the terminal advertises no attribute in the top bit')
+        self.assertGreaterEqual(attrs, 0)
+        # termattrs() exists to be passed back to the attribute functions,
+        # which reject a negative mask.
+        curses.newwin(1, 1).attrset(attrs)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2026-07-29-11-58-17.gh-issue-154874.NAPdBp.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-11-58-17.gh-issue-154874.NAPdBp.rst
@@ -1,0 +1,3 @@
+Fix :func:`curses.termattrs` returning a negative value on a terminal that
+supports :const:`curses.A_ITALIC`, which left its result unusable as an
+attribute mask.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -7899,7 +7899,11 @@ Return a logical OR of all video attributes supported by the terminal.
 static PyObject *
 _curses_termattrs_impl(PyObject *module)
 /*[clinic end generated code: output=b06f437fce1b6fc4 input=0559882a04f84d1d]*/
-NoArgReturnIntFunctionBody(termattrs)
+{
+    PyCursesStatefulInitialised(module);
+
+    return PyLong_FromUnsignedLong((unsigned long)(chtype)termattrs());
+}
 
 #ifdef HAVE_CURSES_TERM_ATTRS
 /*[clinic input]


### PR DESCRIPTION
`termattrs()` returns a `chtype` mask, but GH-134327 routed it through an `int` to check
for `ERR`. On a terminal that advertises `A_ITALIC`, the topmost bit of a 32-bit mask,
the result comes back negative and the attribute functions reject it:

```
>>> curses.termattrs()
-2130771968
>>> curses.term_attrs()          # the same bits, unsigned
2164195328
>>> curses.newwin(1, 1).attrset(curses.termattrs())
OverflowError: can't convert negative value to unsigned int
```

It now returns the mask unsigned, the same way `getattrs()`, `slk_attr()` and
`term_attrs()` already do. `baudrate()`, the macro's only other user, really does return
a status, so it keeps the `ERR` check.

The test drives `newterm('xterm-256color')` over a pseudo-terminal rather than using
`$TERM`, which on CI is usually `linux` and advertises no italic, so a signed result
would slip through. It fails without the change.

3.15 has the same bug, so this needs a backport. 3.14 is fine.


<!-- gh-issue-number: gh-154874 -->
* Issue: gh-154874
<!-- /gh-issue-number -->
