### PR TITLE
[3.14] gh-149221: Add missing `test_binomialvariate_log_zero`

### DIFF
--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -1074,6 +1074,13 @@ class TestDistributions(unittest.TestCase):
             self.assertAlmostEqual(s2/(N-1), sigmasqrd, places=2,
                                    msg='%s%r' % (variate.__name__, args))
 
+    def test_binomialvariate_log_zero(self):
+        # gh-149222: Variety random() return 0.0 no input Error
+        with unittest.mock.patch.object(random.Random, 'random', side_effect=[0.0] + [0.5] * 20):
+            result = random.binomialvariate(10, 0.5)
+            self.assertIsInstance(result, int)
+            self.assertIn(result, range(11))
+
     def test_binomialvariate_btrs_random_zero(self):
         for p, expected in ((0.25, 25), (0.75, 75)):
             with self.subTest(p=p):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

The test added in the original PR (https://github.com/python/cpython/pull/149222) was missed in the original 3.14 backport (https://github.com/python/cpython/pull/149276).

Therefore, adding it here.

See also https://github.com/python/cpython/pull/149279#issuecomment-5117917502.

<!-- gh-issue-number: gh-149221 -->
* Issue: gh-149221
<!-- /gh-issue-number -->
