### PR TITLE
Update bytecode magic number for the 3.15 release candidate

### DIFF
--- a/Lib/test/test_importlib/test_util.py
+++ b/Lib/test/test_importlib/test_util.py
@@ -633,7 +633,7 @@ class MagicNumberTests(unittest.TestCase):
         'only applies to candidate or final python release levels'
     )
     def test_magic_number(self):
-        # Each python minor release should generally have a MAGIC_NUMBER
+        # Each Python feature release should generally have a MAGIC_NUMBER
         # that does not change once the release reaches candidate status.
 
         # Once a release reaches candidate status, the value of the constant
@@ -643,7 +643,7 @@ class MagicNumberTests(unittest.TestCase):
 
         # In exceptional cases, it may be required to change the MAGIC_NUMBER
         # for a maintenance release. In this case the change should be
-        # discussed in python-dev. If a change is required, community
+        # discussed in on Discourse. If a change is required, community
         # stakeholders such as OS package maintainers must be notified
         # in advance. Such exceptional releases will then require an
         # adjustment to this test case.
@@ -659,7 +659,7 @@ class MagicNumberTests(unittest.TestCase):
             "magic number in this test to the current MAGIC_NUMBER to "
             "continue with the release.\n\n"
             "Changing the MAGIC_NUMBER for a maintenance release "
-            "requires discussion in python-dev and notification of "
+            "requires discussion on Discourse and notification of "
             "community stakeholders."
         )
         self.assertEqual(EXPECTED_MAGIC_NUMBER, actual, msg)

--- a/Lib/test/test_importlib/test_util.py
+++ b/Lib/test/test_importlib/test_util.py
@@ -647,7 +647,7 @@ class MagicNumberTests(unittest.TestCase):
         # stakeholders such as OS package maintainers must be notified
         # in advance. Such exceptional releases will then require an
         # adjustment to this test case.
-        EXPECTED_MAGIC_NUMBER = 3625
+        EXPECTED_MAGIC_NUMBER = 3666
         actual = int.from_bytes(importlib.util.MAGIC_NUMBER[:2], 'little')
 
         msg = (


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
The release script reminds:

```
warning: Magic numbers in ../cpython/Include/internal/pycore_magic_number.h (3666) and ../cpython/Lib/test/test_importlib/test_util.py (3625) don't match.
Do you want to continue? This will fail tests in RC stage.
```
