### PR TITLE
Make `os.get_terminal_size` check `isatty` before calling `ioctl`

### DIFF
--- a/Lib/test/test_os/test_os.py
+++ b/Lib/test/test_os/test_os.py
@@ -3970,12 +3970,7 @@ class TermsizeTests(unittest.TestCase):
         try:
             size = os.get_terminal_size()
         except OSError as e:
-            known_errnos = [errno.EINVAL, errno.ENOTTY]
-            if sys.platform == "android":
-                # The Android testbed redirects the native stdout to a pipe,
-                # which returns a different error code.
-                known_errnos.append(errno.EACCES)
-            if sys.platform == "win32" or e.errno in known_errnos:
+            if sys.platform == "win32" or e.errno in (errno.EINVAL, errno.ENOTTY):
                 # Under win32 a generic OSError can be thrown if the
                 # handle cannot be retrieved
                 self.skipTest("failed to query terminal size")

--- a/Misc/NEWS.d/next/Library/2026-07-29-16-53-50.gh-issue-154885.ptofmI.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-16-53-50.gh-issue-154885.ptofmI.rst
@@ -1,0 +1,2 @@
+:func:`os.get_terminal_size` now checks ``isatty`` before calling ``ioctl``,
+which reduces log noise on Android.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -15971,6 +15971,13 @@ os_get_terminal_size_impl(PyObject *module, int fd)
 
 #ifdef TERMSIZE_USE_IOCTL
     {
+        // On Android, stdout is probably not connected, and calling TIOCGWINSZ
+        // on an invalid file descriptor causes a log message "avc:  denied  {
+        // ioctl }". Some common tools such as pytest call get_terminal_size
+        // very often, so check it's a TTY first to avoid cluttering the log.
+        if (!isatty(fd))
+            return PyErr_SetFromErrno(PyExc_OSError);
+
         struct winsize w;
         if (ioctl(fd, TIOCGWINSZ, &w))
             return PyErr_SetFromErrno(PyExc_OSError);


### PR DESCRIPTION
On Android, stdout is probably not connected, and calling `ioctl(TIOCGWINSZ)` on an invalid file descriptor causes a log message "avc:  denied  { ioctl }", and returns EACCES. This still meets the specification of `get_terminal_size`, which only says it throws an OSError. 

However, the log noise can be a problem. You can see it in [this run](https://github.com/python/cpython/actions/runs/30428657849/job/90500652460) of the CPython test suite, mostly in tests that involve `argparse`, such as `test_ast`. Some common tools such as pytest are even worse affected, as they call `get_terminal_size` very often.

So this PR adds an `isatty` check before caling `ioctl`. This should be harmless on other platforms, so I haven't made it Android-specific.

This isn't a bugfix, so it shouldn't be backported.