### PR TITLE
gh-154874: Fix curses.termattrs() returning a negative attribute mask

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -3248,7 +3248,7 @@ class SLKTests(NewtermTestBase):
                  f"$TERM={term!r}, newterm() may not work")
 @unittest.skipIf(sys.platform == "cygwin",
                  "cygwin's curses mostly just hangs")
-class TermAttrsTests(NewtermTestBase):
+class TermattrsTests(NewtermTestBase):
     # A signed termattrs() only differs from an unsigned one on a terminal
     # that advertises the topmost bit of the mask, which is A_ITALIC.  Drive
     # a terminal type that supports italics over a pseudo-terminal instead of

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -3242,5 +3242,32 @@ class SLKTests(NewtermTestBase):
         curses.slk_color(0)
 
 
+@unittest.skipUnless(hasattr(curses, 'newterm'), 'requires curses.newterm()')
+@unittest.skipIf(BROKEN_NEWTERM, 'ncurses < 6.5 mishandles repeated newterm()')
+@unittest.skipIf(not term or term == 'unknown',
+                 f"$TERM={term!r}, newterm() may not work")
+@unittest.skipIf(sys.platform == "cygwin",
+                 "cygwin's curses mostly just hangs")
+class TermAttrsTests(NewtermTestBase):
+    # A signed termattrs() only differs from an unsigned one on a terminal
+    # that advertises the topmost bit of the mask, which is A_ITALIC.  Drive
+    # a terminal type that supports italics over a pseudo-terminal instead of
+    # trusting $TERM, which on CI is usually 'linux' and advertises none.
+
+    def test_termattrs_is_a_usable_mask(self):
+        s = self.make_pty()
+        try:
+            screen = curses.newterm('xterm-256color', s, s)
+        except curses.error:
+            self.skipTest('no xterm-256color terminfo entry')
+        attrs = curses.termattrs()
+        # An attribute mask is unsigned, whichever attributes the terminal
+        # happens to support.
+        self.assertGreaterEqual(attrs, 0)
+        # termattrs() exists to be passed back to the attribute functions,
+        # which reject a negative mask with OverflowError.
+        screen.stdscr.attrset(attrs)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2026-07-29-14-22-08.gh-issue-154874.Kq7mZx.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-14-22-08.gh-issue-154874.Kq7mZx.rst
@@ -1,0 +1,3 @@
+Fix :func:`curses.termattrs` returning a negative value on a terminal that
+supports :const:`curses.A_ITALIC`. The attribute mask is now returned
+unsigned, so it can be passed back to the attribute functions.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -5495,6 +5495,10 @@ static PyType_Spec PyCursesScreen_Type_spec = {
     return curses_check_err(module, rtn, funcname, # X);    \
 }
 
+/* Only for a function returning an int that may be ERR.  A function returning
+   an attribute mask must not use this: the mask is unsigned and its topmost
+   bit is a valid attribute, so storing it in an int makes the result both
+   negative and, for an all-bits-set mask, indistinguishable from ERR. */
 #define NoArgReturnIntFunctionBody(X)           \
 {                                               \
     PyCursesStatefulInitialised(module);        \
@@ -7899,7 +7903,15 @@ Return a logical OR of all video attributes supported by the terminal.
 static PyObject *
 _curses_termattrs_impl(PyObject *module)
 /*[clinic end generated code: output=b06f437fce1b6fc4 input=0559882a04f84d1d]*/
-NoArgReturnIntFunctionBody(termattrs)
+{
+    PyCursesStatefulInitialised(module);
+
+    /* termattrs() returns a chtype mask, not a status, so there is no ERR to
+       check for.  Go through chtype rather than int: A_ITALIC is the topmost
+       bit of a 32-bit mask, and sign-extending it would make the result
+       negative and unusable as an attribute. */
+    return PyLong_FromUnsignedLong((unsigned long)(chtype)termattrs());
+}
 
 #ifdef HAVE_CURSES_TERM_ATTRS
 /*[clinic input]


### PR DESCRIPTION
`termattrs()` returns a `chtype` attribute mask, but GH-134327 routed it through
`NoArgReturnIntFunctionBody`, which stores the result in an `int` so it can be compared
against `ERR`. On a terminal that advertises `A_ITALIC` — the topmost bit of a 32-bit
mask — that sign-extends, and the mask comes back negative:

```
>>> curses.termattrs()
-2130771968
>>> curses.term_attrs()          # the same bits, unsigned
2164195328
>>> curses.newwin(1, 1).attrset(curses.termattrs())
OverflowError: can't convert negative value to unsigned int
```

The value is now returned unsigned, the same way `term_attrs()`, `slk_attr()` and
`window.getattrs()` already do. The cast goes through `chtype` rather than straight to
`unsigned long`, matching `getattrs()`, so no sign extension can happen on a platform
that declares `termattrs()` as returning an `int`.

`baudrate()` is the macro's only other user and really does return a status, so it keeps
the `ERR` check. The macro gains a short comment saying it is only for such functions —
the same mistake is easy to repeat, and an all-bits-set mask would additionally be
misread as `ERR`.

### Test

`TermAttrsTests` drives `newterm('xterm-256color')` over a pseudo-terminal rather than
relying on `$TERM`, which on CI is usually `linux` and advertises no italic. Its two
assertions hold on any terminal, so it never skips for lack of an italic-capable one; it
fails without the C change wherever the top bit is actually advertised.

### Backport

`git branch -r --contains 30dde1ee` (the GH-134327 merge) gives `main` and `3.15` only,
so this needs a 3.15 backport and nothing older. 3.14 is unaffected. The issue carries
3.14 and 3.16 labels as well, but 3.14 predates the regression.

### Notes

- gh-154875 proposes the same one-line fix; I opened this independently and only saw it
  afterwards. Happy for whichever is more useful to maintainers to land — closing this
  one is completely fine.
- I could not build or run `_curses` locally (Windows), so **the test here is unverified
  by me** and I am relying on CI to run it. Worth a careful look on that account.
- Prepared with AI assistance (Claude); the reasoning and the diff have been reviewed by
  me, but please weigh the point above accordingly.

<!-- gh-issue-number: gh-154874 -->
* Issue: gh-154874
<!-- /gh-issue-number -->
