### PR TITLE
Android fixes

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -802,9 +802,9 @@ process and user.
    Returns information identifying the current operating system.
    The return value is a :class:`uname_result`.
 
-   On macOS, iOS and Android, this returns the *kernel* name and version (i.e.,
+   On macOS, iOS and Android, this returns the *kernel* name and release (i.e.,
    ``'Darwin'`` on macOS and iOS; ``'Linux'`` on Android). :func:`platform.uname`
-   can be used to get the user-facing operating system name and version on iOS and
+   can be used to get the user-facing operating system name and release on iOS and
    Android.
 
    .. seealso::

--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -141,6 +141,8 @@ Cross platform
    Returns the system's release, e.g. ``'2.2.0'`` or ``'NT'``. An empty string is
    returned if the value cannot be determined.
 
+   On iOS and Android, this is the user-facing OS release. To obtain the
+   Darwin or Linux kernel release, use :func:`os.uname`.
 
 .. function:: system()
 
@@ -162,9 +164,6 @@ Cross platform
 
    Returns the system's release version, e.g. ``'#3 on degas'``. An empty string is
    returned if the value cannot be determined.
-
-   On iOS and Android, this is the user-facing OS version. To obtain the
-   Darwin or Linux kernel version, use :func:`os.uname`.
 
 .. function:: uname()
 

--- a/Platforms/Android/__main__.py
+++ b/Platforms/Android/__main__.py
@@ -625,7 +625,8 @@ async def read_logcat(stream):
     except ValueError:
         priority = LogPriority.UNKNOWN
 
-    payload_fields = (await read_bytes(payload_len - 1)).split(b"\0")
+    payload = await read_bytes(payload_len - 1)
+    payload_fields = payload.split(b"\0")
     if len(payload_fields) < 2:
         raise ValueError(
             f"payload {payload!r} does not contain at least 2 "

--- a/Platforms/Android/__main__.py
+++ b/Platforms/Android/__main__.py
@@ -158,7 +158,7 @@ def android_env(host):
         f"PREFIX={prefix}; "
         f". {ENV_SCRIPT}; "
         f"export",
-        check=True, shell=True, capture_output=True, encoding='utf-8',
+        check=True, shell=True, stdout=subprocess.PIPE, encoding='utf-8',
     ).stdout
 
     env = {}

--- a/Platforms/Android/android-env.sh
+++ b/Platforms/Android/android-env.sh
@@ -7,7 +7,7 @@
 : "${PREFIX:-}"  # Path in which to find required libraries
 
 
-# Print all messages on stderr so they're visible when running within build-wheel.
+# Print all messages on stderr so they're visible when stdout is captured.
 log() {
     echo "$1" >&2
 }
@@ -27,7 +27,7 @@ fail() {
 ndk_version=27.3.13750724
 
 ndk=$ANDROID_HOME/ndk/$ndk_version
-if ! [ -e "$ndk" ]; then
+if ! [ -e "$ndk/package.xml" ]; then
     log "Installing NDK - this may take several minutes"
     yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "ndk;$ndk_version"
 fi

--- a/Platforms/Android/testbed/app/src/main/java/org/python/testbed/MainActivity.kt
+++ b/Platforms/Android/testbed/app/src/main/java/org/python/testbed/MainActivity.kt
@@ -28,12 +28,11 @@ class PythonTestRunner(val context: Context) {
      * @param args Python command-line, encoded as JSON.
      * @return The Python exit status: zero on success, nonzero on failure. */
     fun run(args: String) : Int {
-        // We leave argument 0 as an empty string, which is a placeholder for the
-        // executable name in embedded mode.
+        // Argument 0 is a placeholder for the executable name in embedded mode.
         val argsJsonArray = JSONArray(args)
-        val argsStringArray = Array<String>(argsJsonArray.length() + 1) { it -> ""}
-        for (i in 0..<argsJsonArray.length()) {
-            argsStringArray[i + 1] = argsJsonArray.getString(i)
+        val argsStringArray = Array<String>(argsJsonArray.length() + 1) { i ->
+            if (i == 0) ""
+            else argsJsonArray.getString(i - 1)
         }
 
         // Python needs this variable to help it find the temporary directory,


### PR DESCRIPTION
* Clarify that the user-facing Android and iOS versions can be found in `platform.release`, not `platform.version`, which is a kernel build number that's much less likely to be useful.

* Don't capture stderr from android-env.py. This allows it to display the message "Installing NDK - this may take several minutes", which is quite important, otherwise the user will probably think the script has hung.

* Previously the NDK was detected only by checking for the existence of its directory, which will be left in an unusable state by interrupted installations. Fixed by checking for the package.xml file, which sdkmanager creates after installation is complete.

* Fix a couple of warnings found by linters: use of an undefined `payload` variable in `Android/__main__.py`, and defining an unused `it` variable in `MainActivity.kt`.