### PR TITLE
gh-154863: Fix iconv encoding of ISO-2022-CN-EXT returning empty bytes

### DIFF
--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -3818,20 +3818,28 @@ class IconvTest(unittest.TestCase):
 
     def test_encode_shift_state_flush(self):
         # Encoding ends with a flush that emits the pending shift sequence.  Its
-        # return value counts nonreversible conversions, which some iconv
-        # implementations make positive for the flush itself (glibc does for
-        # ISO-2022-CN-EXT); that must not be read as a substituted character,
-        # which used to discard the whole output.
+        # return value counts nonreversible conversions, and some iconv
+        # implementations make it positive for the flush itself (glibc does for
+        # ISO-2022-CN-EXT).  That must not be read as a substituted character:
+        # doing so discarded the whole output, ASCII included.
+        #
+        # Only the ASCII around the character is checked, not a full round-trip.
+        # An iconv that cannot represent the character either rejects it or
+        # substitutes for it silently, as macOS does for ISO-2022-CN.
         tested = False
         for enc, text in _ICONV_SHIFT_STATE:
             if not iconv_encoding_available(enc):
                 continue
-            tested = True
             with self.subTest(encoding=enc):
-                data = codecs.iconv_encode(enc, text)[0]
+                try:
+                    data = codecs.iconv_encode(enc, text)[0]
+                except UnicodeEncodeError:
+                    continue
+                tested = True
                 self.assertNotEqual(data, b'')
-                self.assertEqual(
-                    codecs.iconv_decode(enc, data, 'strict', True)[0], text)
+                decoded = codecs.iconv_decode(enc, data, 'strict', True)[0]
+                self.assertStartsWith(decoded, 'ABC')
+                self.assertEndsWith(decoded, 'DEF')
         if not tested:
             self.skipTest('no shift-state iconv encoding is available')
 

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -3679,6 +3679,10 @@ _ICONV_MULTIBYTE = ['EUC-JP', 'SHIFT_JIS', 'GBK', 'GB18030', 'BIG5']
 # Encodings iconv may provide but for which CPython has no built-in codec
 # (cp1047 is EBCDIC, i.e. not ASCII-compatible).
 _ICONV_ONLY = ['cp1047', 'cp1133', 'GEORGIAN-PS', 'ARMSCII-8']
+# Encodings that leave a shift state pending, so encoding ends with a flush.
+_ICONV_SHIFT_STATE = [('ISO-2022-CN-EXT', 'ABC\u4e2dDEF'),
+                      ('ISO-2022-CN', 'ABC\u4e2dDEF'),
+                      ('ISO-2022-JP', 'ABC\u65e5DEF')]
 
 
 @unittest.skipUnless(hasattr(codecs, 'iconv_encode'),
@@ -3811,6 +3815,25 @@ class IconvTest(unittest.TestCase):
         for text in ('Gr\xfc\xdfe', 'ĀāĂ', 'A\U0001f389B'):
             with self.subTest(text=text):
                 self.assertEqual(text.encode('iconv:' + enc), text.encode(enc))
+
+    def test_encode_shift_state_flush(self):
+        # Encoding ends with a flush that emits the pending shift sequence.  Its
+        # return value counts nonreversible conversions, which some iconv
+        # implementations make positive for the flush itself (glibc does for
+        # ISO-2022-CN-EXT); that must not be read as a substituted character,
+        # which used to discard the whole output.
+        tested = False
+        for enc, text in _ICONV_SHIFT_STATE:
+            if not iconv_encoding_available(enc):
+                continue
+            tested = True
+            with self.subTest(encoding=enc):
+                data = codecs.iconv_encode(enc, text)[0]
+                self.assertNotEqual(data, b'')
+                self.assertEqual(
+                    codecs.iconv_decode(enc, data, 'strict', True)[0], text)
+        if not tested:
+            self.skipTest('no shift-state iconv encoding is available')
 
     def test_encode_surrogateescape(self):
         # A lone surrogate lives in the 2-byte kind and round-trips.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -8462,6 +8462,9 @@ _PyUnicode_EncodeIconv(const char *encoding, PyObject *unicode,
         }
 
         if (ret != (size_t)-1) {
+            if (flushing) {
+                break;
+            }
             /* A positive result counts nonreversible conversions: iconv()
                substituted an unencodable character instead of failing with
                EILSEQ (musl and *BSD citrus do this).  Treat it as unencodable
@@ -8478,9 +8481,6 @@ _PyUnicode_EncodeIconv(const char *encoding, PyObject *unicode,
                 /* This code point was substituted; drop it and report it. */
                 out = out_before;
                 up -= unit;
-            }
-            else if (flushing) {
-                break;
             }
             else if (careful && up < uend) {
                 continue;


### PR DESCRIPTION
Encoding ends with an `iconv()` call on a NULL input to flush the pending shift sequence.
That call's return value counts nonreversible conversions, and glibc makes it 1 for
ISO-2022-CN-EXT. The loop read any positive count as "iconv substituted an unencodable
character" and restarted one code point at a time, but `flushing` was still set, so the
retry fed no input, returned 0 and broke out with the output buffer already reset to
empty.

Checking `flushing` before the count fixes it. The retry path cannot be reached while
flushing, so nothing else changes.

```
>>> 'ABC中DEF'.encode('iso-2022-cn-ext')
b'ABC\x1b$)A\x0eVP\x0fDEF\x0f'
```

I compared the codec against raw iconv for all 1180 encodings `iconv -l` lists here.
ISO-2022-CN-EXT and its alias were the only two that disagreed, and none do now. The test
also covers ISO-2022-CN and ISO-2022-JP, where the flush count is 0, so those pass either
way and act as controls. It fails without the change.

The `(b'', 1)` consumed count in the report is not a second bug. `iconv_encode()` always
consumes the whole string, so the length is correct.

The iconv codecs are new in 3.16, so there is no NEWS entry.


<!-- gh-issue-number: gh-154863 -->
* Issue: gh-154863
<!-- /gh-issue-number -->
