### PR TITLE
gh-154892: Fix PyLong_AsLong() error checks in _zoneinfo

### DIFF
--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -499,6 +499,37 @@ class CZoneInfoTest(ZoneInfoTest):
                 self.assertEqual(dt_fromutc.fold, 1)
                 self.assertEqual(dt.fold, 0)
 
+    def test_datetime_subclass_negative_components(self):
+        """Regression test for gh-154892.
+
+        Datetime subclasses may return -1 for time components. The C
+        accelerator should treat -1 as a valid PyLong_AsLong() result unless
+        an exception is set, matching the pure-Python implementation.
+        """
+        class MinusOneDateTime(datetime):
+            @property
+            def hour(self):
+                return -1
+
+            @property
+            def minute(self):
+                return -1
+
+            @property
+            def second(self):
+                return -1
+
+        zi = self.zone_from_key("UTC")
+        dt = MinusOneDateTime(2024, 1, 1, tzinfo=zi)
+
+        self.assertEqual(dt.utcoffset(), ZERO)
+        self.assertEqual(dt.dst(), ZERO)
+        self.assertEqual(dt.tzname(), "UTC")
+        self.assertEqual(
+            zi.fromutc(dt),
+            datetime(2024, 1, 1, tzinfo=zi),
+        )
+
 
 class ZoneInfoDatetimeSubclassTest(DatetimeSubclassMixin, ZoneInfoTest):
     pass

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -317,12 +317,7 @@ class ZoneInfoTest(TzPathUserMixin, ZoneInfoTestBase):
                 self.assertEqual(dt.dst(), offset.dst, dt)
 
     def test_datetime_subclass_negative_components(self):
-        """Regression test for gh-154892.
-
-        Datetime subclasses may return -1 for time components. The C
-        accelerator should treat -1 as a valid PyLong_AsLong() result unless
-        an exception is set, matching the pure-Python implementation.
-        """
+        # Regression test for gh-154892.
         class MinusOneDateTime(datetime):
             @property
             def hour(self):

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -317,19 +317,8 @@ class ZoneInfoTest(TzPathUserMixin, ZoneInfoTestBase):
                 self.assertEqual(dt.dst(), offset.dst, dt)
 
     def test_datetime_subclass_negative_components(self):
-        # Regression test for gh-154892.
         class MinusOneDateTime(datetime):
-            @property
-            def hour(self):
-                return -1
-
-            @property
-            def minute(self):
-                return -1
-
-            @property
-            def second(self):
-                return -1
+            hour = minute = second = -1
 
         zi = self.zone_from_key("UTC")
         dt = MinusOneDateTime(2024, 1, 1, tzinfo=zi)
@@ -337,10 +326,7 @@ class ZoneInfoTest(TzPathUserMixin, ZoneInfoTestBase):
         self.assertEqual(dt.utcoffset(), ZERO)
         self.assertEqual(dt.dst(), ZERO)
         self.assertEqual(dt.tzname(), "UTC")
-        self.assertEqual(
-            zi.fromutc(dt),
-            datetime(2024, 1, 1, tzinfo=zi),
-        )
+        self.assertEqual(zi.fromutc(dt), datetime(2024, 1, 1, tzinfo=zi))
 
     def test_folds_and_gaps(self):
         test_cases = []

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -316,6 +316,37 @@ class ZoneInfoTest(TzPathUserMixin, ZoneInfoTestBase):
                 self.assertEqual(dt.utcoffset(), offset.utcoffset, dt)
                 self.assertEqual(dt.dst(), offset.dst, dt)
 
+    def test_datetime_subclass_negative_components(self):
+        """Regression test for gh-154892.
+
+        Datetime subclasses may return -1 for time components. The C
+        accelerator should treat -1 as a valid PyLong_AsLong() result unless
+        an exception is set, matching the pure-Python implementation.
+        """
+        class MinusOneDateTime(datetime):
+            @property
+            def hour(self):
+                return -1
+
+            @property
+            def minute(self):
+                return -1
+
+            @property
+            def second(self):
+                return -1
+
+        zi = self.zone_from_key("UTC")
+        dt = MinusOneDateTime(2024, 1, 1, tzinfo=zi)
+
+        self.assertEqual(dt.utcoffset(), ZERO)
+        self.assertEqual(dt.dst(), ZERO)
+        self.assertEqual(dt.tzname(), "UTC")
+        self.assertEqual(
+            zi.fromutc(dt),
+            datetime(2024, 1, 1, tzinfo=zi),
+        )
+
     def test_folds_and_gaps(self):
         test_cases = []
         for key in self.zones():
@@ -498,37 +529,6 @@ class CZoneInfoTest(ZoneInfoTest):
 
                 self.assertEqual(dt_fromutc.fold, 1)
                 self.assertEqual(dt.fold, 0)
-
-    def test_datetime_subclass_negative_components(self):
-        """Regression test for gh-154892.
-
-        Datetime subclasses may return -1 for time components. The C
-        accelerator should treat -1 as a valid PyLong_AsLong() result unless
-        an exception is set, matching the pure-Python implementation.
-        """
-        class MinusOneDateTime(datetime):
-            @property
-            def hour(self):
-                return -1
-
-            @property
-            def minute(self):
-                return -1
-
-            @property
-            def second(self):
-                return -1
-
-        zi = self.zone_from_key("UTC")
-        dt = MinusOneDateTime(2024, 1, 1, tzinfo=zi)
-
-        self.assertEqual(dt.utcoffset(), ZERO)
-        self.assertEqual(dt.dst(), ZERO)
-        self.assertEqual(dt.tzname(), "UTC")
-        self.assertEqual(
-            zi.fromutc(dt),
-            datetime(2024, 1, 1, tzinfo=zi),
-        )
 
 
 class ZoneInfoDatetimeSubclassTest(DatetimeSubclassMixin, ZoneInfoTest):

--- a/Misc/NEWS.d/next/Library/2026-07-29-21-37-39.gh-issue-154892.eQyJ3Z.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-21-37-39.gh-issue-154892.eQyJ3Z.rst
@@ -1,0 +1,3 @@
+Fixed a bug in the C accelerator for :mod:`zoneinfo` where ``datetime``
+subclasses returning ``-1`` for ``hour``, ``minute``, or ``second`` could
+incorrectly raise an error due to ``PyLong_AsLong()`` sentinel handling.

--- a/Misc/NEWS.d/next/Library/2026-07-29-21-37-39.gh-issue-154892.eQyJ3Z.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-21-37-39.gh-issue-154892.eQyJ3Z.rst
@@ -1,4 +1,3 @@
-Fix a bug in the C accelerator for
-:mod:`zoneinfo` where :class:`datetime.datetime`
-subclasses returning ``-1`` for ``hour``, ``minute``, or ``second`` could
-incorrectly raise an error due to ``PyLong_AsLong()`` sentinel handling.
+Fix a bug in the C accelerator for :mod:`zoneinfo` where
+:class:`datetime.datetime` subclasses returning ``-1`` for ``hour``,
+``minute``, or ``second`` could incorrectly raise a :exc:`SystemError`.

--- a/Misc/NEWS.d/next/Library/2026-07-29-21-37-39.gh-issue-154892.eQyJ3Z.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-21-37-39.gh-issue-154892.eQyJ3Z.rst
@@ -1,3 +1,4 @@
-Fixed a bug in the C accelerator for :mod:`zoneinfo` where ``datetime``
+Fix a bug in the C accelerator for
+:mod:`zoneinfo` where :class:`datetime.datetime`
 subclasses returning ``-1`` for ``hour``, ``minute``, or ``second`` could
 incorrectly raise an error due to ``PyLong_AsLong()`` sentinel handling.

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -2311,7 +2311,7 @@ get_local_timestamp(PyObject *dt, int64_t *local_ts)
         }
         hour = PyLong_AsLong(num);
         Py_DECREF(num);
-        if (hour == -1) {
+        if (hour == -1 && PyErr_Occurred()) {
             return -1;
         }
 
@@ -2321,7 +2321,7 @@ get_local_timestamp(PyObject *dt, int64_t *local_ts)
         }
         minute = PyLong_AsLong(num);
         Py_DECREF(num);
-        if (minute == -1) {
+        if (minute == -1 && PyErr_Occurred()) {
             return -1;
         }
 
@@ -2331,7 +2331,7 @@ get_local_timestamp(PyObject *dt, int64_t *local_ts)
         }
         second = PyLong_AsLong(num);
         Py_DECREF(num);
-        if (second == -1) {
+        if (second == -1 && PyErr_Occurred()) {
             return -1;
         }
     }


### PR DESCRIPTION
## Summary

Fix `Modules/_zoneinfo.c:get_local_timestamp()` to correctly distinguish a legitimate `-1` result from `PyLong_AsLong()` from an actual conversion error by checking `PyErr_Occurred()`, matching the documented C API behavior and the pure-Python implementation.

The previous implementation treated any `-1` return value from `PyLong_AsLong()` as an error, even when no exception was set. This caused `datetime` subclasses overriding `hour`, `minute`, or `second` to return `-1` to incorrectly raise an exception in the C accelerator.

This PR also adds a regression test covering `datetime` subclasses whose `hour`, `minute`, and `second` properties return `-1`.

## Issue

Closes issue gh-154892