### PR TITLE
gh-154904: Speed up import of shutil by probing compression extensions

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -18,23 +18,28 @@ try:
 except ImportError:
     _ZLIB_SUPPORTED = False
 
+# bz2, lzma and compression.zstd are pure Python wrappers whose only
+# importable dependency that may be missing is the extension module they
+# wrap.  Probe those extensions directly instead: it gives the same answer
+# without executing the wrappers, which shutil only needs when an archive
+# is actually created or extracted.
 try:
-    import bz2
-    del bz2
+    import _bz2
+    del _bz2
     _BZ2_SUPPORTED = True
 except ImportError:
     _BZ2_SUPPORTED = False
 
 try:
-    import lzma
-    del lzma
+    import _lzma
+    del _lzma
     _LZMA_SUPPORTED = True
 except ImportError:
     _LZMA_SUPPORTED = False
 
 try:
-    from compression import zstd
-    del zstd
+    import _zstd
+    del _zstd
     _ZSTD_SUPPORTED = True
 except ImportError:
     _ZSTD_SUPPORTED = False

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -10,6 +10,7 @@ import os
 import os.path
 import errno
 import functools
+import importlib
 import socket
 import subprocess
 import random
@@ -32,6 +33,7 @@ except ImportError:
 from test import support
 from test.support import os_helper, socket_helper
 from test.support.os_helper import TESTFN, FakePath
+from test.support.script_helper import assert_python_ok
 
 TESTFN2 = TESTFN + "2"
 TESTFN_SRC = TESTFN + "_SRC"
@@ -2320,6 +2322,40 @@ class TestArchives(BaseTest, unittest.TestCase):
         # let's leave a clean state
         unregister_unpack_format('Boo2')
         self.assertEqual(get_unpack_formats(), formats)
+
+    def test_compression_supported_flags(self):
+        # shutil determines compression support by probing the extension
+        # modules (_bz2, _lzma, _zstd) rather than importing the pure Python
+        # wrappers.  The answer must match what importing the wrapper does,
+        # including on builds where the extension is missing or fails to load.
+        for wrapper, supported in (
+            ('zlib', shutil._ZLIB_SUPPORTED),
+            ('bz2', shutil._BZ2_SUPPORTED),
+            ('lzma', shutil._LZMA_SUPPORTED),
+            ('compression.zstd', shutil._ZSTD_SUPPORTED),
+        ):
+            with self.subTest(wrapper=wrapper):
+                try:
+                    importlib.import_module(wrapper)
+                except ImportError:
+                    importable = False
+                else:
+                    importable = True
+                self.assertEqual(supported, importable)
+
+    def test_compression_wrappers_not_imported_by_shutil(self):
+        # Importing shutil must not pull in the compression wrappers: they are
+        # only needed once an archive is actually created or extracted, and
+        # importing them measurably slows down every process that uses shutil.
+        wrappers = ('bz2', 'lzma', 'compression', 'compression.zstd')
+        script = (
+            'import sys, shutil; '
+            f'print([m for m in {wrappers!r} if m in sys.modules])'
+        )
+        # -I so that a sitecustomize/usercustomize importing one of these
+        # cannot make the test fail spuriously.
+        rc, stdout, stderr = assert_python_ok('-I', '-c', script)
+        self.assertEqual(stdout.decode().strip(), '[]', stderr)
 
 
 class TestMisc(BaseTest, unittest.TestCase):

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -10,7 +10,6 @@ import os
 import os.path
 import errno
 import functools
-import importlib
 import socket
 import subprocess
 import random
@@ -33,7 +32,7 @@ except ImportError:
 from test import support
 from test.support import os_helper, socket_helper
 from test.support.os_helper import TESTFN, FakePath
-from test.support.script_helper import assert_python_ok
+from test.support.import_helper import ensure_lazy_imports
 
 TESTFN2 = TESTFN + "2"
 TESTFN_SRC = TESTFN + "_SRC"
@@ -2323,39 +2322,13 @@ class TestArchives(BaseTest, unittest.TestCase):
         unregister_unpack_format('Boo2')
         self.assertEqual(get_unpack_formats(), formats)
 
-    def test_compression_supported_flags(self):
-        # shutil determines compression support by probing the extension
-        # modules (_bz2, _lzma, _zstd) rather than importing the pure Python
-        # wrappers.  The answer must match what importing the wrapper does,
-        # including on builds where the extension is missing or fails to load.
-        for wrapper, supported in (
-            ('zlib', shutil._ZLIB_SUPPORTED),
-            ('bz2', shutil._BZ2_SUPPORTED),
-            ('lzma', shutil._LZMA_SUPPORTED),
-            ('compression.zstd', shutil._ZSTD_SUPPORTED),
-        ):
-            with self.subTest(wrapper=wrapper):
-                try:
-                    importlib.import_module(wrapper)
-                except ImportError:
-                    importable = False
-                else:
-                    importable = True
-                self.assertEqual(supported, importable)
-
     def test_compression_wrappers_not_imported_by_shutil(self):
-        # Importing shutil must not pull in the compression wrappers: they are
-        # only needed once an archive is actually created or extracted, and
-        # importing them measurably slows down every process that uses shutil.
-        wrappers = ('bz2', 'lzma', 'compression', 'compression.zstd')
-        script = (
-            'import sys, shutil; '
-            f'print([m for m in {wrappers!r} if m in sys.modules])'
-        )
-        # -I so that a sitecustomize/usercustomize importing one of these
-        # cannot make the test fail spuriously.
-        rc, stdout, stderr = assert_python_ok('-I', '-c', script)
-        self.assertEqual(stdout.decode().strip(), '[]', stderr)
+        # gh-154904: Importing shutil must not pull in the compression
+        # wrappers: they are only needed once an archive is actually created
+        # or extracted, and importing them measurably slows down every
+        # process that uses shutil.
+        ensure_lazy_imports("shutil",
+                            {"bz2", "lzma", "compression", "compression.zstd"})
 
 
 class TestMisc(BaseTest, unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2026-07-30-02-15-00.gh-issue-154904.Kx9mAq.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-30-02-15-00.gh-issue-154904.Kx9mAq.rst
@@ -1,0 +1,4 @@
+Speed up :mod:`shutil` import by probing the ``_bz2``, ``_lzma`` and
+``_zstd`` extension modules instead of importing the :mod:`bz2`,
+:mod:`lzma` and :mod:`compression.zstd` wrappers, which are now only
+imported when an archive is actually created or extracted.


### PR DESCRIPTION
Speed up `import shutil` by probing compression extensions instead of importing the wrappers

`shutil` imports `bz2`, `lzma` and `compression.zstd` at module scope only to set the `_*_SUPPORTED` booleans, then discards them, also dragging in`compression._common[._streams]` and `compression.zstd._zstdfile`. Every program importing `shutil` pays for it even if it never touches an archive. They are pure Python wrappers whose only dependency that can be missing is the extension they wrap, so probe that directly:

```diff
-    import bz2
-    del bz2
+    import _bz2
+    del _bz2
```

Same for `lzma`→`_lzma`, `compression.zstd`→`_zstd`. `zlib` is left alone: it is the extension. `tarfile`/`zipfile` still import the wrappers when an archive is created or extracted.

Net import cost (median of 40 fresh interpreters, minus `-c pass`, one core):

| | before | after | delta |
|---|---|---|---|
| `import shutil` | 12.75 ms | 10.25 ms | **−2.50 ms (−19.6%)** |
| `import urllib.request` | 36.64 ms | 34.30 ms | **−2.34 ms (−6.4%)** |

`urllib.request` benefits via `tempfile`→`shutil`. Motivation is short-lived processes on constrained hardware (CLI tools, serverless cold starts).

No API change: flags, both registries and `get_{archive,unpack}_formats()` are unchanged, including on builds missing a compression library. The probe is a real `import`, so `ImportError` semantics are exact, unlike `find_spec('bz2')`, which resolves the always-present wrapper and reports success where `_bz2` failed to compile (the case on my machine). PEP 810 `lazy import` also won't do: the flags are read at module scope (`shutil.py:1145`, `:1354`), so must be final at import time.

### Tests

Added to `TestArchives`: `test_compression_supported_flags` pins the flags to real `import` semantics, `test_compression_wrappers_not_imported_by_shutil` prevents the eager imports returning. Existing `test_unpack_archive_*` coverage unchanged; `patchcheck` clean.

```
$ ./python -m test test_shutil -v -m "test_compression*"   ok, ok
$ ./python -m test test_shutil test_zipfile test_tarfile test_importlib \
    test_site test_venv test_zipimport test_bz2 test_lzma test_zstd \
    test_gzip test_urllib2 test_logging -j6
  SUCCESS — 14 OK, run=3,959 skipped=314 (test_bz2 skips on main too)

negative controls, each test fails without the half it covers:
  find_spec variant:  ..._supported_flags FAIL: True != False
  unpatched main:     ..._wrappers_not_imported FAIL:
                      "['lzma', 'compression', 'compression.zstd']" != '[]'
```

fixes: #154904 


<!-- gh-issue-number: gh-154904 -->
* Issue: gh-154904
<!-- /gh-issue-number -->
