### PR TITLE
gh-148286: Fix undefined behaviour in the ctypes bit field accessors

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-07-30-12-00-00.gh-issue-148286.Kx7Qm2.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-30-12-00-00.gh-issue-148286.Kx7Qm2.rst
@@ -1,7 +1,2 @@
-Fix undefined behaviour in the :mod:`ctypes` bit field accessors. The
-``BIT_MASK``, ``GET_BITFIELD`` and ``SET`` macros in
-``Modules/_ctypes/cfield.c`` shifted negative values left and shifted ones
-into the sign bit of a signed type. The bit manipulation is now done in
-``uint64_t`` and converted back to the field's own type, which removes the
-two ``Modules/_ctypes/cfield.c`` entries from
-``Tools/ubsan/suppressions.txt``.
+Fix undefined behaviour when reading and writing :mod:`ctypes` bit fields of
+a signed type.

--- a/Misc/NEWS.d/next/Library/2026-07-30-12-00-00.gh-issue-148286.Kx7Qm2.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-30-12-00-00.gh-issue-148286.Kx7Qm2.rst
@@ -1,0 +1,7 @@
+Fix undefined behaviour in the :mod:`ctypes` bit field accessors. The
+``BIT_MASK``, ``GET_BITFIELD`` and ``SET`` macros in
+``Modules/_ctypes/cfield.c`` shifted negative values left and shifted ones
+into the sign bit of a signed type. The bit manipulation is now done in
+``uint64_t`` and converted back to the field's own type, which removes the
+two ``Modules/_ctypes/cfield.c`` entries from
+``Tools/ubsan/suppressions.txt``.

--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -492,23 +492,50 @@ Py_ssize_t NUM_BITS(Py_ssize_t bitsize) {
     return bitsize >> 16;
 }
 
-/* Doesn't work if NUM_BITS(size) == 0, but it never happens in SET() call. */
-#define BIT_MASK(type, size) (((((type)1 << (NUM_BITS(size) - 1)) - 1) << 1) + 1)
+/* Bit fields are manipulated as uint64_t -- the widest type the accessors
+   below support -- and converted back to the field's own type at the end.
+   Doing the arithmetic in the field's type would be undefined behaviour
+   whenever that type is signed: shifting a negative value left, and shifting
+   a one into the sign bit, are both UB. */
 
-/* This macro CHANGES the first parameter IN PLACE. For proper sign handling,
-   we must first shift left, then right.
-*/
-#define GET_BITFIELD(v, size)                                           \
-    if (NUM_BITS(size)) {                                               \
-        v <<= (sizeof(v)*8 - LOW_BIT(size) - NUM_BITS(size));           \
-        v >>= (sizeof(v)*8 - NUM_BITS(size));                           \
-    }
+/* A mask with the low `num_bits` bits set.
+   Doesn't work if num_bits == 0, but that never happens here. */
+static inline
+uint64_t LOW_BITS_MASK(Py_ssize_t num_bits) {
+    assert(0 < num_bits);
+    assert(num_bits <= 64);
+    return (~(uint64_t)0) >> (64 - num_bits);
+}
 
-/* This macro RETURNS the first parameter with the bit field CHANGED. */
+/* True if `type` is signed. Spelled so that neither comparison is the
+   `unsigned < 0` pattern that compilers warn about. */
+#define IS_SIGNED_TYPE(type) (!((type)0 < (type)-1))
+
+/* This macro CHANGES the `v` parameter IN PLACE. */
+#define GET_BITFIELD(type, v, size)                                           \
+    do {                                                                      \
+        if (NUM_BITS(size)) {                                                 \
+            uint64_t bitfield_bits = ((uint64_t)(v) >> LOW_BIT(size))         \
+                                     & LOW_BITS_MASK(NUM_BITS(size));         \
+            if (IS_SIGNED_TYPE(type)) {                                       \
+                /* Sign-extend: flipping the field's sign bit and then        \
+                   subtracting it leaves the low bits alone and fills the     \
+                   high bits with copies of that sign bit. */                 \
+                uint64_t sign_bit = (uint64_t)1 << (NUM_BITS(size) - 1);      \
+                bitfield_bits = (bitfield_bits ^ sign_bit) - sign_bit;        \
+            }                                                                 \
+            (v) = (type)bitfield_bits;                                        \
+        }                                                                     \
+    } while (0)
+
+/* This macro RETURNS the `x` parameter with the bit field CHANGED. */
 #define SET(type, x, v, size)                                                 \
-    (NUM_BITS(size) ?                                                   \
-     ( ( (type)(x) & ~(BIT_MASK(type, size) << LOW_BIT(size)) ) | ( ((type)(v) & BIT_MASK(type, size)) << LOW_BIT(size) ) ) \
-     : (type)(v))
+    ((type)(NUM_BITS(size)                                                    \
+            ? (((uint64_t)(x)                                                 \
+                & ~(LOW_BITS_MASK(NUM_BITS(size)) << LOW_BIT(size)))          \
+               | (((uint64_t)(v) & LOW_BITS_MASK(NUM_BITS(size)))             \
+                  << LOW_BIT(size)))                                          \
+            : (uint64_t)(v)))
 
 /*****************************************************************
  * The setter methods return an object which must be kept alive, to keep the
@@ -571,7 +598,7 @@ Py_ssize_t NUM_BITS(Py_ssize_t bitsize) {
         assert(NUM_BITS(size_arg) || (size_arg == (NBITS) / 8));              \
         CTYPE val;                                                            \
         memcpy(&val, ptr, sizeof(val));                                       \
-        GET_BITFIELD(val, size_arg);                                          \
+        GET_BITFIELD(CTYPE, val, size_arg);                                   \
         return PYAPI_FROMFUNC(val);                                           \
     }                                                                         \
     ///////////////////////////////////////////////////////////////////////////
@@ -604,7 +631,7 @@ Py_ssize_t NUM_BITS(Py_ssize_t bitsize) {
         CTYPE val;                                                            \
         memcpy(&val, ptr, sizeof(val));                                       \
         val = PY_SWAPFUNC(val);                                               \
-        GET_BITFIELD(val, size_arg);                                          \
+        GET_BITFIELD(CTYPE, val, size_arg);                                   \
         return PYAPI_FROMFUNC(val);                                           \
     }                                                                         \
     ///////////////////////////////////////////////////////////////////////////

--- a/Tools/ubsan/suppressions.txt
+++ b/Tools/ubsan/suppressions.txt
@@ -9,11 +9,5 @@
 # Objects/object.c:97:5: runtime error: member access within null pointer of type 'PyThreadState' (aka 'struct _ts')
 null:Objects/object.c
 
-# Modules/_ctypes/cfield.c:644:1: runtime error: left shift of 1 by 63 places cannot be represented in type 'int64_t' (aka 'long')
-shift-base:Modules/_ctypes/cfield.c
-
-# Modules/_ctypes/cfield.c:640:1: runtime error: signed integer overflow: -2147483648 - 1 cannot be represented in type 'int'
-signed-integer-overflow:Modules/_ctypes/cfield.c
-
 # Modules/_io/stringio.c:350:24: runtime error: addition of unsigned offset to 0x7fd01ec25850 overflowed to 0x7fd01ec2584c
 pointer-overflow:Modules/_io/stringio.c


### PR DESCRIPTION
`BIT_MASK`, `GET_BITFIELD` and `SET` in `Modules/_ctypes/cfield.c` do their bit manipulation in the bit field's own type. When that type is signed, both shifting a negative value left and shifting a one into the sign bit are undefined behaviour, which is why `Tools/ubsan/suppressions.txt` carries two file-level entries for this file.

Removing those entries and running `test_ctypes` under `UBSAN_OPTIONS=halt_on_error=1` aborts immediately at `cfield.c:644` in `i64_set`. Collecting rather than halting shows diagnostics at three distinct lines, so the suppression was covering rather more than its comment documents:

```
cfield.c:644: left shift of 1 by 63 places cannot be represented in type 'int64_t'
cfield.c:644: left shift of negative value -9223372036854775793
cfield.c:640: signed integer overflow: -2147483648 - 1 cannot be represented in type 'int'
cfield.c:640: left shift of 1 by 31 places cannot be represented in type 'int32_t'
cfield.c:636: left shift of negative value -32768
```

This does the arithmetic in `uint64_t` — the widest type the accessors support — and converts back to the field's own type at the end. `BIT_MASK` becomes `LOW_BITS_MASK()`, which no longer needs a type argument now that the mask is always computed unsigned; `GET_BITFIELD` gains the field type so it can still sign-extend signed fields, and is wrapped in `do { } while (0)`.

Since this rewrites the arithmetic of every integer bit field getter and setter, I checked it exhaustively against the old macros rather than relying on review alone. For every fixed-width type from `int8_t` to `uint64_t`, every `num_bits`, every `low_bit`, ten storage bit patterns and twenty stored values — 1,167,600 cases — the old and new expressions produce identical results, under both gcc and clang. The same sweep under `-fsanitize=undefined -fno-sanitize-recover=all` is clean, where the old macros produce eleven distinct diagnostics.

With the two `Modules/_ctypes/cfield.c` entries removed from the suppressions file, `test_ctypes` passes under `UBSAN_OPTIONS=halt_on_error=1`.

### Provenance

This supersedes #96925, my 2022 attempt at the same bug, which I have now closed. That version worked around the undefined shifts with multiplication, and @mdickinson pushed back on it in review — both because the intent is to move bits rather than to do arithmetic, and because multiplication drags the usual arithmetic conversions in on top of the integer promotions, making the result harder to reason about. He proposed doing the bit manipulation in unsigned types and sign-extending afterwards, and sketched the `(v ^ sign_bit) - sign_bit` idiom used here.

So the approach in this PR is his rather than mine, four years late. It is also a more complete fix than the old one: #96925 only added an assertion to `BIT_MASK` and left `(type)1 << (NUM_BITS(size) - 1)` in place, which is itself undefined for a full-width signed field — that is the `left shift of 1 by 63 places` diagnostic currently recorded in the suppressions file, so the original patch would not have cleared its own suppression. Thanks, Mark.


<!-- gh-issue-number: gh-148286 -->
* Issue: gh-148286
<!-- /gh-issue-number -->
