### PR TITLE
gh-148286: Fix undefined behaviour in io.StringIO.read() after an overseek

### DIFF
--- a/Lib/test/test_io/test_memoryio.py
+++ b/Lib/test/test_io/test_memoryio.py
@@ -341,6 +341,23 @@ class MemoryTestMixin:
         memio.write(buf)
         self.assertEqual(memio.getvalue(), buf + self.buftype('\0') + buf)
 
+    def test_overseek_far_past_end(self):
+        # gh-148286: the existing test_overseek only seeks one past the
+        # end. StringIO.read() formed ``self->buf + self->pos`` before
+        # returning the empty string, which is undefined behaviour for
+        # any overseek -- and for a position above PY_SSIZE_T_MAX // 4
+        # the multiplication by sizeof(Py_UCS4) wrapped, yielding a
+        # pointer below the buffer. Only large offsets exercise that.
+        buf = self.buftype("1234567890")
+        for pos in (2 ** 31, 2 ** 62, sys.maxsize):
+            with self.subTest(pos=pos):
+                memio = self.ioclass(buf)
+                self.assertEqual(memio.seek(pos), pos)
+                self.assertEqual(memio.read(), self.EOF)
+                self.assertEqual(memio.read(10), self.EOF)
+                self.assertEqual(memio.tell(), pos)
+                self.assertEqual(memio.getvalue(), buf)
+
     def test_tell(self):
         buf = self.buftype("1234567890")
         memio = self.ioclass(buf)

--- a/Lib/test/test_io/test_memoryio.py
+++ b/Lib/test/test_io/test_memoryio.py
@@ -54,6 +54,9 @@ class MemorySeekTestMixin:
         self.assertEqual(buf[3:], bytesIo.read())
         self.assertRaises(TypeError, bytesIo.seek, 0.0)
 
+        # gh-148286: seeking this far past the end and then reading is
+        # what exercises the overseek path where the pointer arithmetic
+        # wraps. Under UBSan this is the case that reports, so keep it.
         self.assertEqual(sys.maxsize, bytesIo.seek(sys.maxsize))
         self.assertEqual(self.EOF, bytesIo.read(4))
 
@@ -340,23 +343,6 @@ class MemoryTestMixin:
         self.assertEqual(memio.getvalue(), buf)
         memio.write(buf)
         self.assertEqual(memio.getvalue(), buf + self.buftype('\0') + buf)
-
-    def test_overseek_far_past_end(self):
-        # gh-148286: the existing test_overseek only seeks one past the
-        # end. StringIO.read() formed ``self->buf + self->pos`` before
-        # returning the empty string, which is undefined behaviour for
-        # any overseek -- and for a position above PY_SSIZE_T_MAX // 4
-        # the multiplication by sizeof(Py_UCS4) wrapped, yielding a
-        # pointer below the buffer. Only large offsets exercise that.
-        buf = self.buftype("1234567890")
-        for pos in (2 ** 31, 2 ** 62, sys.maxsize):
-            with self.subTest(pos=pos):
-                memio = self.ioclass(buf)
-                self.assertEqual(memio.seek(pos), pos)
-                self.assertEqual(memio.read(), self.EOF)
-                self.assertEqual(memio.read(10), self.EOF)
-                self.assertEqual(memio.tell(), pos)
-                self.assertEqual(memio.getvalue(), buf)
 
     def test_tell(self):
         buf = self.buftype("1234567890")

--- a/Misc/NEWS.d/next/Library/2026-07-30-12-05-00.gh-issue-148286.Bv3Nq8.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-30-12-05-00.gh-issue-148286.Bv3Nq8.rst
@@ -1,2 +1,2 @@
-Fix undefined behaviour in :meth:`io.StringIO.read` when reading from a
+Fix undefined behaviour in :meth:`!io.StringIO.read` when reading from a
 position past the end of the buffer.

--- a/Misc/NEWS.d/next/Library/2026-07-30-12-05-00.gh-issue-148286.Bv3Nq8.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-30-12-05-00.gh-issue-148286.Bv3Nq8.rst
@@ -1,0 +1,7 @@
+Fix undefined behaviour in :meth:`!io.StringIO.read` after an overseek.
+Reading from a position past the end of the buffer formed the pointer
+``self->buf + self->pos`` before returning the empty string; for a large
+enough position the arithmetic wrapped and produced a pointer below the
+buffer. :class:`io.StringIO` now returns the empty string early, as
+``_stringio_readline()`` already did, which removes the
+``Modules/_io/stringio.c`` entry from ``Tools/ubsan/suppressions.txt``.

--- a/Misc/NEWS.d/next/Library/2026-07-30-12-05-00.gh-issue-148286.Bv3Nq8.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-30-12-05-00.gh-issue-148286.Bv3Nq8.rst
@@ -1,7 +1,2 @@
-Fix undefined behaviour in :meth:`!io.StringIO.read` after an overseek.
-Reading from a position past the end of the buffer formed the pointer
-``self->buf + self->pos`` before returning the empty string; for a large
-enough position the arithmetic wrapped and produced a pointer below the
-buffer. :class:`io.StringIO` now returns the empty string early, as
-``_stringio_readline()`` already did, which removes the
-``Modules/_io/stringio.c`` entry from ``Tools/ubsan/suppressions.txt``.
+Fix undefined behaviour in :meth:`io.StringIO.read` when reading from a
+position past the end of the buffer.

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -349,6 +349,17 @@ _io_StringIO_read_impl(stringio *self, Py_ssize_t size)
     }
 
     ENSURE_REALIZED(self);
+
+    /* In case of overseek, return the empty string, as _stringio_readline()
+       does. `size` is already clamped to 0 here, so nothing would be read
+       through the pointer -- but forming `self->buf + self->pos` when
+       `self->pos` is past the end of the buffer is undefined behaviour on
+       its own, and for a large enough `self->pos` the multiplication by
+       sizeof(Py_UCS4) wraps and yields a pointer below `self->buf`. */
+    if (self->pos >= self->string_size) {
+        return Py_GetConstant(Py_CONSTANT_EMPTY_STR);
+    }
+
     output = self->buf + self->pos;
     self->pos += size;
     return PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, output, size);

--- a/Tools/ubsan/suppressions.txt
+++ b/Tools/ubsan/suppressions.txt
@@ -14,6 +14,3 @@ shift-base:Modules/_ctypes/cfield.c
 
 # Modules/_ctypes/cfield.c:640:1: runtime error: signed integer overflow: -2147483648 - 1 cannot be represented in type 'int'
 signed-integer-overflow:Modules/_ctypes/cfield.c
-
-# Modules/_io/stringio.c:350:24: runtime error: addition of unsigned offset to 0x7fd01ec25850 overflowed to 0x7fd01ec2584c
-pointer-overflow:Modules/_io/stringio.c


### PR DESCRIPTION
`_io_StringIO_read_impl()` clamps the read size to zero when the position is past the end of the buffer, but still forms the pointer `self->buf + self->pos` before returning. Nothing is read through it, but forming it is undefined behaviour on its own, and since `self->buf` is a `Py_UCS4 *` the byte offset is `self->pos * 4` — so for `self->pos == 2**62 - 1` the multiplication wraps and yields a pointer four bytes *below* `self->buf`.

```python
io.StringIO("abc").seek(2**62 - 1)   # then .read()
```

```
stringio.c:352: addition of unsigned offset to 0x... overflowed to 0x...
```

`_stringio_readline()` already guards exactly this condition a few lines below, with the comment "In case of overseek, return the empty string", so this applies the same guard on the read path. `self->pos += size` is a no-op here because `size` is zero, and `ENSURE_REALIZED()` is deliberately left ahead of the guard so the state transition and its error path are unchanged.

The existing `test_io` suite already covers this path — that is how UBSan found it — so no new test is needed. With the `Modules/_io/stringio.c` entry removed from `Tools/ubsan/suppressions.txt`, `test_io` passes under `UBSAN_OPTIONS=halt_on_error=1`, where before it aborts at `stringio.c:352`.


<!-- gh-issue-number: gh-148286 -->
* Issue: gh-148286
<!-- /gh-issue-number -->
