### PR TITLE
gh-148286: Fix undefined behaviour in per-thread refcount merging

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-30-14-30-00.gh-issue-148286.Wn5Tz4.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-30-14-30-00.gh-issue-148286.Wn5Tz4.rst
@@ -1,0 +1,5 @@
+Fix undefined behaviour in ``_PyObject_MergePerThreadRefcounts()`` on the
+free-threaded build. The per-thread reference count delta being merged is
+routinely negative, and it was shifted left by ``_Py_REF_SHARED_SHIFT``,
+which is undefined behaviour for a negative value. The shift is now done in
+the unsigned domain.

--- a/Python/uniqueid.c
+++ b/Python/uniqueid.c
@@ -181,8 +181,12 @@ _PyObject_MergePerThreadRefcounts(_PyThreadStateImpl *tstate)
         Py_ssize_t refcnt = tstate->refcounts.values[i];
         if (refcnt != 0) {
             PyObject *obj = pool->table[i].obj;
+            /* `refcnt` is a per-thread delta, so it is routinely negative,
+               and shifting a negative value left is undefined behaviour.
+               Shift in the unsigned domain instead. */
             _Py_atomic_add_ssize(&obj->ob_ref_shared,
-                                 refcnt << _Py_REF_SHARED_SHIFT);
+                                 (Py_ssize_t)((size_t)refcnt
+                                              << _Py_REF_SHARED_SHIFT));
             tstate->refcounts.values[i] = 0;
         }
     }


### PR DESCRIPTION
`_PyObject_MergePerThreadRefcounts()` merges each thread's local reference count deltas into the shared count:

```c
_Py_atomic_add_ssize(&obj->ob_ref_shared, refcnt << _Py_REF_SHARED_SHIFT);
```

`refcnt` is a delta, so it is routinely negative — in practice almost always `-1` — and shifting a negative value left is undefined behaviour. This does the shift in the unsigned domain and converts back.

This is not reachable from the UBSan CI job today. The sanitizer matrix in `.github/workflows/build.yml` pairs UBSan only with `free-threading: false`, so `Python/uniqueid.c` is never built under UBSan at all. Building `--disable-gil` together with `--with-undefined-behavior-sanitizer` shows how load-bearing it is: the first line of output from `./python -c pass` is the UBSan report, raised during interpreter startup via `_PyImport_InitExternal`, and it recurs from `gc_collect_main` on every collection.

Measured over the full test suite on that configuration, with every entry in `Tools/ubsan/suppressions.txt` disabled:

|          | UB reports | test failures | failing files |
|----------|-----------:|--------------:|--------------:|
| before   |       1762 |           529 |            61 |
| after    |          0 |             0 |             0 |

Most of those failures are tests asserting that a subprocess produced no stderr, which the UBSan diagnostic breaks.

I have not touched the CI matrix here, since adding a job is a maintainer's call and this fix stands on its own. But the reason this went unnoticed is structural rather than accidental, and I would like to follow up separately with a proposal to add `free-threading: true` to the UBSan matrix — with this fix in, that configuration is green, so it would be a regression guard rather than a source of new work. The same appears to be true of `--enable-experimental-jit`, which CI builds but never sanitizes: I ran the full suite against a machine-code JIT build under UBSan and it is clean today, while gh-139269 (an unaligned `uint64_t` store in `Python/jit.c`, which segfaulted release builds) was originally found by exactly that combination. I will write that up with the measurements rather than expand the scope of this PR.


<!-- gh-issue-number: gh-148286 -->
* Issue: gh-148286
<!-- /gh-issue-number -->
