### PR TITLE
gh-152433: Windows: change ``winreg`` to conditional import for UWP compatibility

### DIFF
--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -33,7 +33,10 @@ import marshal
 _MS_WINDOWS = (sys.platform == 'win32')
 if _MS_WINDOWS:
     import nt as _os
-    import winreg
+    try:
+        import winreg
+    except ImportError:
+        winreg = None
 else:
     import posix as _os
 

--- a/Misc/NEWS.d/next/Windows/2026-07-31-18-40-43.gh-issue-152433.Pq3-U-.rst
+++ b/Misc/NEWS.d/next/Windows/2026-07-31-18-40-43.gh-issue-152433.Pq3-U-.rst
@@ -1,0 +1,2 @@
+Changed :mod:`!winreg` to conditional import for Universal Windows Platform
+compatibility.


### PR DESCRIPTION
In current code, `winreg` module is not build because code guards not include `MS_WINDOWS_APP`:

~Instead of add `MS_WINDOWS_APP` condition, guards removed when is:~

```C
#if defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM) || defined(MS_WINDOWS_GAMES)
```

~(as includes all Windows families)~

~Or replaced with `MS_WINDOWS` when code is for all platforms.~

~The clinic's code also regenerated, resulting in the removal of many redundant conditions.~

~Note that Windows Registry is not accessible from UWP Apps (or Games) but for consistency is necessary build module as is imported in many places at Python initialization. The same logic was already being applied with `MS_WINDOWS_GAMES` build.~

Windows Registry is not accessible from UWP Apps (or Games), since module is not build, changed the import to conditional to able initialize Python in UWP without `winreg` module.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152433 -->
* Issue: gh-152433
<!-- /gh-issue-number -->
