### PR TITLE
gh-127337: Fix importlib.resources for legacy ResourceReader loaders

### DIFF
--- a/Lib/importlib/resources/_adapters.py
+++ b/Lib/importlib/resources/_adapters.py
@@ -66,10 +66,14 @@ class CompatibilityFiles:
 
         is_dir = is_file
 
-        def joinpath(self, other):
+        def joinpath(self, *descendants):
+            if not descendants:
+                return self
             if not self._reader:
-                return CompatibilityFiles.OrphanPath(other)
-            return CompatibilityFiles.ChildPath(self._reader, other)
+                return CompatibilityFiles.OrphanPath(*descendants)
+            first, *rest = descendants
+            child = CompatibilityFiles.ChildPath(self._reader, first)
+            return child.joinpath(*rest)
 
         @property
         def name(self):
@@ -97,8 +101,10 @@ class CompatibilityFiles:
         def is_dir(self):
             return not self.is_file()
 
-        def joinpath(self, other):
-            return CompatibilityFiles.OrphanPath(self.name, other)
+        def joinpath(self, *descendants):
+            if not descendants:
+                return self
+            return CompatibilityFiles.OrphanPath(self.name, *descendants)
 
         @property
         def name(self):
@@ -128,8 +134,10 @@ class CompatibilityFiles:
 
         is_dir = is_file
 
-        def joinpath(self, other):
-            return CompatibilityFiles.OrphanPath(*self._path, other)
+        def joinpath(self, *descendants):
+            if not descendants:
+                return self
+            return CompatibilityFiles.OrphanPath(*self._path, *descendants)
 
         @property
         def name(self):

--- a/Lib/test/test_importlib/resources/test_compatibilty_files.py
+++ b/Lib/test/test_importlib/resources/test_compatibilty_files.py
@@ -6,6 +6,8 @@ from importlib.resources._adapters import (
     wrap_spec,
 )
 
+from test.support import warnings_helper
+
 from . import util
 
 
@@ -79,6 +81,37 @@ class CompatibilityFilesTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             CompatibilityFiles.OrphanPath()
 
+    def test_spec_path_joinpath_no_descendants(self):
+        files = self.files
+        assert files.joinpath() is files
+
+    def test_child_path_joinpath_no_descendants(self):
+        child = self.files / 'a'
+        assert child.joinpath() is child
+
+    def test_orphan_path_joinpath_no_descendants(self):
+        orphan = self.files / 'a' / 'b'
+        assert orphan.joinpath() is orphan
+
+    def test_joinpath_multiple_descendants(self):
+        # Several descendants at once give the same result as applying them
+        # one at a time, as documented for Traversable.joinpath().
+        files = self.files
+        for path, expected in (
+            (files.joinpath('a', 'b'), files / 'a' / 'b'),
+            ((files / 'a').joinpath('b', 'c'), files / 'a' / 'b' / 'c'),
+            ((files / 'a' / 'b').joinpath('c', 'd'), files / 'a' / 'b' / 'c' / 'd'),
+        ):
+            assert isinstance(path, CompatibilityFiles.OrphanPath)
+            assert path._path == expected._path
+
+    def test_functional_api_without_path_names(self):
+        # gh-127337: these call joinpath() with no descendants at all.
+        package = self.package
+        with warnings_helper.check_warnings((".*contents.*", DeprecationWarning)):
+            assert sorted(resources.contents(package)) == ['a', 'b', 'c']
+        assert not resources.is_resource(package)
+
     def test_wrap_spec(self):
         spec = wrap_spec(self.package)
         assert isinstance(spec.loader.get_resource_reader(None), CompatibilityFiles)
@@ -95,3 +128,14 @@ class CompatibilityFilesNoReaderTests(unittest.TestCase):
 
     def test_spec_path_joinpath(self):
         assert isinstance(self.files / 'a', CompatibilityFiles.OrphanPath)
+
+    def test_spec_path_joinpath_no_descendants(self):
+        # Returns self rather than an OrphanPath with no parts, which would
+        # be rejected by OrphanPath.__init__().
+        files = self.files
+        assert files.joinpath() is files
+
+    def test_spec_path_joinpath_multiple_descendants(self):
+        path = self.files.joinpath('a', 'b')
+        assert isinstance(path, CompatibilityFiles.OrphanPath)
+        assert path._path == (self.files / 'a' / 'b')._path

--- a/Misc/NEWS.d/next/Library/2026-07-30-13-36-06.gh-issue-127337.ahcvtH.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-30-13-36-06.gh-issue-127337.ahcvtH.rst
@@ -1,0 +1,9 @@
+Fix a regression in :mod:`importlib.resources` where functions such as
+:func:`~importlib.resources.is_resource` and
+:func:`~importlib.resources.contents` raised :exc:`TypeError` for a package
+whose loader provides only a legacy
+:class:`~importlib.resources.abc.ResourceReader`.  The internal
+``CompatibilityFiles`` traversables wrapping such a reader now accept the
+zero-or-more argument ``joinpath()`` signature specified by
+:meth:`importlib.resources.abc.Traversable.joinpath`.
+Patch by pikammmmm.


### PR DESCRIPTION
`CompatibilityFiles.SpecPath`, `.ChildPath` and `.OrphanPath` each defined `joinpath()` with a single required argument, but `importlib.resources.abc.Traversable` declares `joinpath(*descendants)` and documents that passing no descendants returns `self`.

Since 3.13 the functional API is implemented on top of `files(anchor).joinpath(*path_names)`, so any call that passes no path names reaches `joinpath()` with no arguments and raises `TypeError` for a package whose loader provides only a legacy `ResourceReader`:

| | 3.12.13 | 3.13.13 / 3.14.4 / 3.15.0b1 | this PR |
| --- | --- | --- | --- |
| `contents(FakeModule)` | `['NAME']` | `TypeError` | `['NAME']` |
| `is_resource(FakeModule)` | n/a — required a `name` | `TypeError` | `False` |

(measured with the reproducer from the issue; 3.12 predates `_functional.py`, whose one-name-per-call predecessor never routed through `joinpath()`)

This is the fix @jaraco sketched in the issue, extended to `ChildPath` and `OrphanPath` as he suggested it might need to be. It also fixes the latent multi-argument case, broken ever since the protocol gained `*descendants` in 3.11 without `_adapters.py` being updated — as @FFY00 diagnosed, *"the `CompatibilityFiles` implementation is bad, it can only ever take one argument, and now it needs to be able to take any number of arguments."*

One deviation from the sketch: it used `'/'.join(descendants)` for `SpecPath`, which would make `files.joinpath('a', 'b')` a single `ChildPath` named `a/b`, while `files / 'a' / 'b'` is an `OrphanPath('a', 'b')`. The `Traversable.joinpath` docs present the chained single-argument form as the compatibility equivalent of the multi-argument form for implementations that predate it, so this PR applies descendants one at a time and the two forms agree. That also avoids `'/'.join` raising `TypeError` on a `PathLike` segment which single-argument `joinpath()` accepts today.

`CompatibilityFiles` still does not meaningfully support `os.PathLike` segments; that is unchanged here and out of scope.

### Tests

Seven new tests in `test_compatibilty_files.py`: zero-argument `joinpath()` on all three path classes (with and without a reader), the multi-argument/chained equivalence, and `contents()`/`is_resource()` through the functional API.

- Negative control: with `_adapters.py` reverted, all seven new tests fail and the 16 pre-existing tests in the file still pass.
- All 221 tests in `test_importlib.resources` pass (1 skipped).
- I test without a local C build — checkout `Lib/` on a matching installed interpreter — which yields 88 unrelated pre-existing failures in `test_importlib.metadata`/`frozen`/`extension`. That set is identical with and without this patch, and none of them are in `resources`.

Sibling fix for the same protocol violation in `simple.py`: #145263.

@FFY00 — @jaraco assigned this to you in December 2024; happy to close this if you would rather take it yourself.


<!-- gh-issue-number: gh-127337 -->
* Issue: gh-127337
<!-- /gh-issue-number -->
