### PR TITLE
gh-115159: Add SOCK_RAW regression tests

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -115,6 +115,9 @@ resources to test.  Currently only the following are defined:
     network -        It is okay to run tests that use external network
                      resource, e.g. testing SSL support for sockets.
 
+    netraw -         It is okay to run tests that create raw sockets. These
+                     tests may require elevated privileges.
+
     decimal -        Test the decimal module against a large suite that
                      verifies compliance with standards.
 

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -48,10 +48,13 @@ ALL_RESOURCES = ('audio', 'console', 'curses', 'largefile', 'network',
 #
 # - extralagefile (ex: test_zipfile64): really too slow to be enabled
 #   "by default"
+# - netraw: raw sockets may require elevated privileges and can trigger
+#   behavior monitoring systems.
 # - tzdata: while needed to validate fully test_datetime, it makes
 #   test_datetime too slow (15-20 min on some buildbots) and so is disabled by
 #   default (see bpo-30822).
-RESOURCE_NAMES = ALL_RESOURCES + ('extralargefile', 'tzdata', 'xpickle', 'wantobjects')
+RESOURCE_NAMES = ALL_RESOURCES + (
+    'extralargefile', 'netraw', 'tzdata', 'xpickle', 'wantobjects')
 
 
 # Types for types hints

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -152,6 +152,13 @@ class MyDatagramProto(asyncio.DatagramProtocol):
             self.done.set_result(None)
 
 
+class FakeRawSocket(socket.socket):
+
+    @property
+    def type(self):
+        return socket.SOCK_RAW
+
+
 class MyReadPipeProto(asyncio.Protocol):
     done = None
 
@@ -1495,6 +1502,25 @@ class EventLoopTestsMixin:
         self.assertIsInstance(pr, MyDatagramProto)
         tr.close()
         self.loop.run_until_complete(pr.done)
+
+    def test_create_datagram_endpoint_sock_raw(self):
+        if support.is_resource_enabled('netraw'):
+            sock = socket.socket(
+                socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_ICMP)
+        else:
+            sock = FakeRawSocket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.bind(('127.0.0.1', 0))
+
+        self.assertEqual(sock.type, socket.SOCK_RAW)
+        with sock:
+            f = self.loop.create_datagram_endpoint(
+                lambda: MyDatagramProto(loop=self.loop), sock=sock)
+            tr, pr = self.loop.run_until_complete(f)
+            self.assertIsInstance(tr, asyncio.Transport)
+            self.assertIsInstance(pr, MyDatagramProto)
+            tr.close()
+            self.loop.run_until_complete(pr.done)
+            self.assertEqual(sock.fileno(), -1)
 
     def test_datagram_send_to_non_listening_address(self):
         # see:

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -311,6 +311,9 @@ class ParseArgsTestCase(unittest.TestCase):
                 # test another resource which is not part of "all"
                 ns = self.parse_args([opt, 'extralargefile'])
                 self.assertEqual(ns.use_resources, {'extralargefile': None})
+                ns = self.parse_args([opt, 'netraw'])
+                self.assertEqual(ns.use_resources, {'netraw': None})
+                self.assertNotIn('netraw', cmdline.ALL_RESOURCES)
 
                 # test resource with value
                 ns = self.parse_args([opt, 'xpickle=2.7'])

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -945,6 +945,13 @@ def requireSocket(*args):
 
 class GeneralModuleTests(unittest.TestCase):
 
+    def test_create_raw_socket(self):
+        support.requires('netraw')
+        sock = socket.socket(
+            socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_ICMP)
+        with sock:
+            self.assertEqual(sock.type, socket.SOCK_RAW)
+
     @unittest.skipUnless(_socket is not None, 'need _socket module')
     def test_socket_type(self):
         self.assertTrue(gc.is_tracked(_socket.socket))

--- a/Misc/NEWS.d/next/Tests/2026-08-08-14-51-47.gh-issue-115159.netraw.rst
+++ b/Misc/NEWS.d/next/Tests/2026-08-08-14-51-47.gh-issue-115159.netraw.rst
@@ -1,0 +1,1 @@
+Add a ``netraw`` test resource and regression coverage for ``SOCK_RAW`` sockets.


### PR DESCRIPTION
Closes #115159.

Add an explicit `netraw` test resource for tests that create raw sockets. The resource is excluded from `--use=all` so potentially privileged operations remain opt-in.

`test_socket` now covers raw-socket creation when `netraw` is enabled. The asyncio tests always cover raw datagram endpoints, using a datagram-backed `FakeRawSocket` when the resource is disabled.

Tests: `test_regrtest`, `test_socket`, and `test_asyncio`.

<!-- gh-issue-number: gh-115159 -->
* Issue: gh-115159
<!-- /gh-issue-number -->
