### PR TITLE
gh-154936: Fix JSON control character error position

### DIFF
--- a/Lib/json/decoder.py
+++ b/Lib/json/decoder.py
@@ -97,7 +97,7 @@ def py_scanstring(s, end, strict=True,
             if strict:
                 #msg = "Invalid control character %r at" % (terminator,)
                 msg = "Invalid control character {0!r} at".format(terminator)
-                raise JSONDecodeError(msg, s, end)
+                raise JSONDecodeError(msg, s, end - 1)
             else:
                 _append(terminator)
                 continue

--- a/Lib/test/test_json/test_unicode.py
+++ b/Lib/test/test_json/test_unicode.py
@@ -44,7 +44,13 @@ class TestUnicode:
                          '\b\t\n\f\r')
         s = ''.join(map(chr, range(32)))
         for c in s:
-            self.assertRaises(self.JSONDecodeError, self.loads, f'"{c}"')
+            with self.subTest(control_character=ord(c)):
+                with self.assertRaises(self.JSONDecodeError) as cm:
+                    self.loads(f'"a{c}b"')
+                error = cm.exception
+                self.assertEqual(error.pos, 2)
+                self.assertEqual(error.lineno, 1)
+                self.assertEqual(error.colno, 3)
         self.assertEqual(self.loads(f'"{s}"', strict=False), s)
         self.assertEqual(self.loads('"\x7f"'), '\x7f')
 

--- a/Misc/NEWS.d/next/Library/2026-07-30-23-29-56.gh-issue-154936.a90443.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-30-23-29-56.gh-issue-154936.a90443.rst
@@ -1,0 +1,2 @@
+Fix the pure Python :mod:`json` decoder to report the correct position for
+invalid literal control characters in JSON strings.


### PR DESCRIPTION
Closes #154936.

Report the actual position of invalid literal control characters in the pure Python JSON decoder. Previously, the scanner passed `Match.end()`, which points one character past the consumed control character, causing `JSONDecodeError.pos`, `lineno`, and `colno` to identify the following character instead.

Use `end - 1` only in the strict invalid-control-character branch and extend the existing ASCII control-character test to verify all three location attributes for U+0000 through U+001F. The shared JSON tests cover both the pure Python and C decoders.

## Tests

- `./python -m test test_json`
- `make patchcheck`


<!-- gh-issue-number: gh-154936 -->
* Issue: gh-154936
<!-- /gh-issue-number -->
