### PR TITLE
gh-154916: Fix data race in ga_iter_reduce under free-threading

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-30-15-10-00.gh-issue-154916.Kp3nQz.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-30-15-10-00.gh-issue-154916.Kp3nQz.rst
@@ -1,0 +1,3 @@
+Fix a data race in :meth:`!__reduce__` of a shared :class:`types.GenericAlias`
+iterator under the :term:`free-threaded build`. Follow-up to
+:gh:`154043`, which only covered iteration itself.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -997,8 +997,19 @@ ga_iter_reduce(PyObject *self, PyObject *Py_UNUSED(ignored))
      * call must be before access of iterator pointers.
      * see issue #101765 */
 
-    if (gi->obj)
-        return Py_BuildValue("N(O)", iter, gi->obj);
+    /* ga_iternext takes gi->obj out with an atomic exchange and then drops the
+     * reference, so a plain read here is not just a data race: the two reads of
+     * gi->obj below could straddle that exchange and hand Py_BuildValue a
+     * pointer whose last reference is already gone. Take a strong reference
+     * once instead. Racing with next() may legitimately observe either the
+     * object or the exhausted iterator; both reductions are correct. */
+#ifdef Py_GIL_DISABLED
+    PyObject *obj = _Py_XGetRef(&gi->obj);
+#else
+    PyObject *obj = Py_XNewRef(gi->obj);
+#endif
+    if (obj != NULL)
+        return Py_BuildValue("N(N)", iter, obj);
     else
         return Py_BuildValue("N(())", iter);
 }
@@ -1030,6 +1041,11 @@ ga_iter(PyObject *self) {
         return NULL;
     }
     gi->obj = Py_NewRef(self);
+#ifdef Py_GIL_DISABLED
+    /* _Py_XGetRef in ga_iter_reduce needs the stored object to be flagged, or
+     * its try-incref cannot succeed from another thread and it would spin. */
+    _PyObject_SetMaybeWeakref(self);
+#endif
     PyObject_GC_Track(gi);
     return (PyObject *)gi;
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Issue: #154916

`ga_iternext` takes `gi->obj` out with `_Py_atomic_exchange_ptr` and then drops the
reference, while `ga_iter_reduce` reads the same field twice without synchronisation:

```c
if (gi->obj)
    return Py_BuildValue("N(O)", iter, gi->obj);
```

The two reads can straddle that exchange, so the guard can observe a non-NULL
pointer that is then passed to `Py_BuildValue` after the owning thread has
already called `Py_DECREF` on it. That makes this a potential use-after-free
rather than only a torn read. ThreadSanitizer trips on the guard read first,
which is what the issue reports.

The fix takes a single strong reference instead:

* `_Py_XGetRef` in the free-threaded build, plain `Py_XNewRef` otherwise, with
  `"N(N)"` so `Py_BuildValue` consumes the reference we now own.
* `_Py_XGetRef` documents that the writer must set maybe-weakref on the stored
  object, otherwise its try-incref can never succeed from another thread and it
  spins. `ga_iter` stores with a plain `Py_NewRef`, so the writer side needs
  `_PyObject_SetMaybeWeakref`.

Racing with `next()` may legitimately observe either the object or the exhausted
iterator; both reductions are correct and that does not change here.

## Verification

Built on arm64 macOS with `--disable-gil --with-thread-sanitizer --with-pydebug`.
Reproducer: 4 threads calling `next()` and 4 calling `__reduce__()` on one shared
`iter(list[int])`.

|        | TSAN warnings                                                 | result  |
| ------ | ------------------------------------------------------------- | ------- |
| before | 2 — `ga_iternext:946` ↔ `ga_iter_reduce:1000`, both orderings  | SIGABRT |
| after  | 0                                                             | clean   |

* `test_genericalias`, `test_types`, `test_typing`: 913 tests pass.
* `test_genericalias test_types -R 3:3`: no leaks. The `O` → `N` change moves
  ownership of the reference, so this seemed worth checking explicitly.
* `__reduce__` output and pickle round-trip are unchanged for both a live and an
  exhausted iterator.

## One open question

I kept this lock-free to stay symmetric with `ga_iternext` as gh-154108 left it.
The alternative is the `list_item_impl` pattern — a critical section plus
`_Py_NewRefWithLock` — but that only synchronises if `ga_iternext` takes the lock
too, which would mean revising the design just merged in gh-154108.
`_Py_XGetRef` has no other call site in the tree, so if you would rather have the
critical-section version, I am happy to redo it that way.

<!-- gh-issue-number: gh-154916 -->
* Issue: gh-154916
<!-- /gh-issue-number -->
