### PR TITLE
Clarify Future.cancel() behavior

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -504,10 +504,9 @@ The :class:`Future` class encapsulates the asynchronous execution of a callable.
 
    .. method:: cancel()
 
-      Attempt to cancel the call.  If the call is currently being executed or
-      finished running and cannot be cancelled then the method will return
-      ``False``, otherwise the call will be cancelled and the method will
-      return ``True``.
+      Attempt to cancel the call. Return ``False`` if the call cannot be
+      cancelled because it is already running or has finished. Otherwise, cancel
+      the call and return ``True``.
 
    .. method:: cancelled()
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
The previous wording could be read as implying that a running call might still be cancellable. This change makes it explicit that `Future.cancel()` returns `False` once the call is already running or has finished.

This is a documentation-only change; no behavior is changed.

Discussed at:
https://discuss.python.org/t/docs-improvement-suggestion-an-ambiguity-in-the-future-cancel-for-non-native-english-speakers/108328