### PR TITLE
dbm.whichdb docstring shows outdated return-value example

### DIFF
--- a/Lib/dbm/__init__.py
+++ b/Lib/dbm/__init__.py
@@ -102,7 +102,7 @@ def whichdb(filename):
 
     - None if the database file can't be read;
     - empty string if the file can be read but can't be recognized
-    - the name of the dbm submodule (e.g. "ndbm" or "gnu") if recognized.
+    - the dotted submodule name, such as "dbm.ndbm" or "dbm.gnu" if recognized.
 
     Importing the given module may still fail, and opening the
     database using that module may still fail.


### PR DESCRIPTION
This PR fixes the documentation issue reported in #153305: corrects `the name of the dbm submodule (e.g. "ndbm" or "gnu") if recognized.` to `the dotted submodule name, such as "dbm.ndbm" or "dbm.gnu" if recognized.` in `Lib/dbm/__init__.py`.

Fixes #153305

Fixes #153305