### PR TITLE
gh-154985: Fix crash when hashing a code object with crafted instrumented bytecode

### DIFF
--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -631,6 +631,24 @@ class CodeTest(unittest.TestCase):
         self.assertNotEqual(hash(c), hash(c1))
 
     @cpython_only
+    def test_code_hash_with_crafted_instrumented_bytecode(self):
+        # gh-154985: hashing or comparing a code object with hand-crafted
+        # bytecode containing opcodes that are normally only written by the
+        # instrumentation machinery must not crash, even though the code
+        # object has no monitoring data attached to it.
+        code = (lambda x, y: x + y).__code__
+        opcodes = [op for name, op in opmap.items()
+                   if name.startswith('INSTRUMENTED_')]
+        opcodes.append(opmap['ENTER_EXECUTOR'])
+        for op in opcodes:
+            with self.subTest(opname[op]):
+                co_code = bytes([op, 0, opmap['RETURN_VALUE'], 0])
+                crafted = code.replace(co_code=co_code)
+                self.assertIsInstance(hash(crafted), int)
+                self.assertEqual(crafted, code.replace(co_code=co_code))
+                self.assertNotEqual(crafted, code)
+
+    @cpython_only
     def test_code_equal_with_instrumentation(self):
         """ GH-109052
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-07-31-09-34-18.gh-issue-154985.Kq3vTz.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-07-31-09-34-18.gh-issue-154985.Kq3vTz.rst
@@ -1,0 +1,5 @@
+Fix a crash when hashing or comparing a code object whose bytecode was
+hand-crafted to contain ``INSTRUMENTED_LINE``, ``INSTRUMENTED_INSTRUCTION``
+or ``ENTER_EXECUTOR``. Such a code object has no instrumentation or executor
+data attached to it, so the corresponding pointers were dereferenced while
+still ``NULL``.

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -646,7 +646,14 @@ _Py_GetBaseCodeUnit(PyCodeObject *code, int i)
         assert(inst.op.code < MIN_SPECIALIZED_OPCODE);
         return inst;
     }
+    /* The code object may have been created with hand-crafted bytecode
+     * containing opcodes that only the instrumentation machinery is supposed
+     * to write. In that case the data needed to recover the base code unit
+     * does not exist, so return the code unit as-is. */
     if (opcode == ENTER_EXECUTOR) {
+        if (code->co_executors == NULL || inst.op.arg >= code->co_executors->size) {
+            return inst;
+        }
         _PyExecutorObject *exec = code->co_executors->executors[inst.op.arg];
         opcode = _PyOpcode_Deopt[exec->vm_data.opcode];
         inst.op.code = opcode;
@@ -655,9 +662,17 @@ _Py_GetBaseCodeUnit(PyCodeObject *code, int i)
         return inst;
     }
     if (opcode == INSTRUMENTED_LINE) {
+        if (code->_co_monitoring == NULL || code->_co_monitoring->lines == NULL) {
+            return inst;
+        }
         opcode = _PyCode_GetOriginalOpcode(code->_co_monitoring->lines, i);
     }
     if (opcode == INSTRUMENTED_INSTRUCTION) {
+        if (code->_co_monitoring == NULL ||
+            code->_co_monitoring->per_instruction_opcodes == NULL)
+        {
+            return inst;
+        }
         opcode = code->_co_monitoring->per_instruction_opcodes[i];
     }
     CHECK(opcode != INSTRUMENTED_INSTRUCTION);


### PR DESCRIPTION
`_Py_GetBaseCodeUnit()` dereferences `code->_co_monitoring` for `INSTRUMENTED_LINE` and `INSTRUMENTED_INSTRUCTION`, and `code->co_executors` for `ENTER_EXECUTOR`. Both are NULL on a code object that was never instrumented nor optimized, which a code object built with hand-crafted bytecode can be. Walking the bytecode with that helper, as `hash()` and `==` on a code object do, then crashes the interpreter.

Return the code unit unchanged when the side table needed to recover the base opcode is absent, and bounds-check the executor index.

<!-- gh-issue-number: gh-154985 -->
* Issue: gh-154985
<!-- /gh-issue-number -->
