### PR TITLE
[3.13] GH-115869: Make jit_stencils.h reproducible (GH-127166)

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-11-22-08-46-46.gh-issue-115869.UVLSKd.rst
+++ b/Misc/NEWS.d/next/Build/2024-11-22-08-46-46.gh-issue-115869.UVLSKd.rst
@@ -1,0 +1,1 @@
+Make ``jit_stencils.h`` (which is produced during JIT builds) reproducible.

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -65,8 +65,10 @@ class _Target(typing.Generic[_S, _R]):
         args = ["--disassemble", "--reloc", f"{path}"]
         output = await _llvm.maybe_run("llvm-objdump", args, echo=self.verbose)
         if output is not None:
+            # Make sure that full paths don't leak out (for reproducibility):
+            long, short = str(path), str(path.name)
             group.code.disassembly.extend(
-                line.expandtabs().strip()
+                line.expandtabs().strip().replace(long, short)
                 for line in output.splitlines()
                 if not line.isspace()
             )


### PR DESCRIPTION
Keep the build tmpdir out of jit_stencils.h

llvm-objdump prints the path of the object file it disassembles, and the JIT builds every stencil in a fresh tempfile.TemporaryDirectory().  That random path ended up verbatim in the disassembly comments of the generated jit_stencils.h, so two builds of the same source never produced the same header:

     // /tmp/tmp164olvmi/_BINARY_OP.o:  file format elf64-x86-64
    +// /tmp/tmpmufvewt2/_BINARY_OP.o:  file format elf64-x86-64

Replace the full path with the bare file name.

Only the _parse() hunk of that commit is taken here; the rest of it depends on refactorings that are not in 3.13.

(cherry picked from commit 17c16aea66b606d66f71ae9af381bc34d0ef3f5f)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

I tested that it works.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).

<!-- gh-issue-number: gh-115869 -->
* Issue: gh-115869
<!-- /gh-issue-number -->
