### PR TITLE
gh-151728: Partially revert "Clear the typing caches at interpreter shutdown (GH-154858)"

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -19,7 +19,6 @@ that may be changed without notice. Use at your own risk!
 """
 
 from abc import abstractmethod, ABCMeta
-import atexit
 import collections
 from collections import defaultdict
 import collections.abc
@@ -396,11 +395,6 @@ _caches = {}
 def _clear_caches():
     for cleanup in _cleanups:
         cleanup()
-
-
-# Release the LRU caches at shutdown, they otherwise redistribute reference
-# leaks of one extension to types of unrelated ones. See GH-151728.
-atexit.register(_clear_caches)
 
 
 def _tp_cache(func=None, /, *, typed=False):

--- a/Misc/NEWS.d/next/Library/2026-07-29-11-05-00.gh-issue-151728.Kq3vTn.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-11-05-00.gh-issue-151728.Kq3vTn.rst
@@ -1,4 +1,0 @@
-Clear the internal :mod:`typing` caches from an exit handler. Previously, an
-extension module that leaked a reference to :mod:`typing` would also keep every
-subscripted type alive past interpreter shutdown, including types owned by
-unrelated extension modules.


### PR DESCRIPTION
Unfortunately, adding the `atexit` function causes reference leak tests to fail.
Broken Tier 1 buildbots, revert or fix immediatelly. I currently don't have time to investigate.

This only reverts the atexit registration: it leaves the `_clear_caches` function, to simplify the regrtest utils code a bit.

cc @wjakob 


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151728 -->
* Issue: gh-151728
<!-- /gh-issue-number -->
