### PR TITLE
gh-154987: Handle ValueError for drive-relative paths in tarfile filters

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -835,7 +835,13 @@ def _get_filtered_attrs(member, dest_path, for_data=True):
     # Ensure we stay in the destination
     target_path = os.path.realpath(os.path.join(dest_path, name),
                                    strict=os.path.ALLOW_MISSING)
-    if os.path.commonpath([target_path, dest_path]) != dest_path:
+    try:
+        outside_destination = (os.path.commonpath([target_path, dest_path])
+                               != dest_path)
+    except ValueError:
+        # commonpath() raises for paths on different drives on Windows.
+        outside_destination = True
+    if outside_destination:
         raise OutsideDestinationError(member, target_path)
     # Limit permissions (no high bits, and go-w)
     mode = member.mode
@@ -890,7 +896,13 @@ def _get_filtered_attrs(member, dest_path, for_data=True):
                 target_path = os.path.join(dest_path, normalized)
             target_path = os.path.realpath(target_path,
                                            strict=os.path.ALLOW_MISSING)
-            if os.path.commonpath([target_path, dest_path]) != dest_path:
+            try:
+                outside_destination = (
+                    os.path.commonpath([target_path, dest_path]) != dest_path)
+            except ValueError:
+                # commonpath() raises for paths on different drives on Windows.
+                outside_destination = True
+            if outside_destination:
                 raise LinkOutsideDestinationError(member, target_path)
     return new_attrs
 

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -3993,6 +3993,14 @@ class TestExtractionFilters(unittest.TestCase):
         self.reraise_exception = False
         return self.raised_exception
 
+    def _make_drive_relative_path(self, name):
+        dest_drive = os.path.splitdrive(os.path.realpath(
+            self.destdir, strict=os.path.ALLOW_MISSING))[0]
+        for drive in "ZYXWVUTSRQPONMLKJIHGFEDCBA":
+            if drive.upper() != dest_drive.rstrip(":").upper():
+                return f"{drive}:{name}"
+        raise AssertionError("could not find a different drive")
+
     def test_benign_file(self):
         with ArchiveMaker() as arc:
             arc.add('benign.txt')
@@ -4024,6 +4032,26 @@ class TestExtractionFilters(unittest.TestCase):
                     self.expect_exception(
                         tarfile.AbsolutePathError,
                         """['"].*escaped.evil['"] has an absolute path""")
+
+    @unittest.skipIf(os.name != 'nt', 'Windows-specific drive-relative path')
+    def test_drive_relative_member_path(self):
+        # Drive-relative paths such as "Z:evil" are not absolute, but
+        # ntpath.commonpath() raises ValueError for them.
+        member_name = self._make_drive_relative_path('evil')
+        with ArchiveMaker() as arc:
+            arc.add('before')
+            arc.add(member_name)
+            arc.add('after')
+
+        for filter in 'tar', 'data':
+            with self.subTest(filter=filter, errorlevel=1):
+                with self.check_context(arc.open(errorlevel=1), filter):
+                    self.expect_exception(tarfile.OutsideDestinationError)
+
+            with self.subTest(filter=filter, errorlevel=0):
+                with self.check_context(arc.open(errorlevel=0), filter):
+                    self.expect_file('before')
+                    self.expect_file('after')
 
     @symlink_test
     def test_parent_symlink(self):
@@ -4280,6 +4308,28 @@ class TestExtractionFilters(unittest.TestCase):
             self.expect_exception(
                 tarfile.AbsoluteLinkError,
                 "'parent' is a link to an absolute path")
+
+    @unittest.skipIf(os.name != 'nt', 'Windows-specific drive-relative path')
+    @support.subTests('link_type', (tarfile.SYMTYPE, tarfile.LNKTYPE))
+    def test_data_filter_drive_relative_link_path(self, link_type):
+        linkname = self._make_drive_relative_path('evil')
+        link_kwargs = {}
+        if link_type == tarfile.SYMTYPE:
+            link_kwargs['symlink_to'] = linkname
+        else:
+            link_kwargs['hardlink_to'] = linkname
+
+        with ArchiveMaker() as arc:
+            arc.add('before')
+            arc.add('link', **link_kwargs)
+            arc.add('after')
+
+        with self.check_context(arc.open(errorlevel=1), 'data'):
+            self.expect_exception(tarfile.LinkOutsideDestinationError)
+
+        with self.check_context(arc.open(errorlevel=0), 'data'):
+            self.expect_file('before')
+            self.expect_file('after')
 
     @symlink_test
     def test_sly_relative0(self):

--- a/Misc/NEWS.d/next/Library/2026-07-31-16-30-00.bpo-0.xz7oaj.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-31-16-30-00.bpo-0.xz7oaj.rst
@@ -1,0 +1,3 @@
+On Windows, :mod:`tarfile` extraction filters now report drive-relative
+member names and link targets using structured filter errors instead of
+allowing :exc:`ValueError` from :func:`os.path.commonpath` to escape.


### PR DESCRIPTION
## Summary

Fixes gh-154987.

On Windows, `tarfile` extraction filters use `os.path.commonpath()` to verify that extracted members remain inside the destination directory.

For drive-relative paths (for example `Z:evil`), `ntpath.commonpath()` raises `ValueError` because the paths are considered to be on different drives. That exception currently escapes instead of being translated into tarfile's existing structured extraction filter errors.

This PR catches that `ValueError` and treats those paths as outside the destination, preserving the existing extraction filter semantics.

## Changes

- Handle `ValueError` raised by `os.path.commonpath()` during destination containment checks.
- Raise the existing:
  - `OutsideDestinationError`
  - `LinkOutsideDestinationError`
  instead of allowing a raw `ValueError` to escape.
- Add regression tests covering:
  - drive-relative member paths
  - drive-relative symlink targets
  - drive-relative hardlink targets
  - `errorlevel=0` continuation behaviour

## Testing

Executed:

```bash
PCbuild\amd64\python.exe -m test test_tarfile -m "*drive_relative*" -v

PCbuild\amd64\python.exe -m test test_tarfile \
    -m "*drive_relative*" \
    -m test_absolute \
    -m test_absolute_symlink \
    -m test_absolute_hardlink \
    -m test_link_at_destination \
    -m test_normpath_realpath_mismatch \
    -m test_errorlevel -v
```

All targeted regression tests passed successfully.