### PR TITLE
gh-151728: Clear the typing caches at interpreter shutdown

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1,4 +1,5 @@
 import annotationlib
+import atexit
 import contextlib
 import collections
 import collections.abc
@@ -6550,6 +6551,14 @@ class NoTypeCheckTests(BaseTestCase):
 class InternalsTests(BaseTestCase):
     def test_collect_parameters(self):
         typing = import_helper.import_fresh_module("typing")
+        # Importing typing registers an internal function named _clear_caches
+        # with atexit. The throwaway module created here installs its own
+        # handler, which holds the module alive and keeps references until
+        # interpreter shutdown even after the test finishes. Each repetition
+        # of this test under -R would therefore leak another module copy. To
+        # avoid this, we unregister the handler once the test is done.
+        self.addCleanup(atexit.unregister, typing._clear_caches)
+
         with self.assertWarnsRegex(
             DeprecationWarning,
             "The private _collect_parameters function is deprecated"
@@ -7719,6 +7728,10 @@ class CollectionsAbcTests(BaseTestCase):
 
         with self.assertWarns(DeprecationWarning):
             from typing import ByteString
+        # Drop the exit handler of this throwaway copy, see the comment in
+        # InternalsTests.test_collect_parameters.
+        self.addCleanup(atexit.unregister, sys.modules["typing"]._clear_caches)
+
         with self.assertWarns(DeprecationWarning):
             self.assertIsInstance(b'', ByteString)
         with self.assertWarns(DeprecationWarning):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -19,6 +19,7 @@ that may be changed without notice. Use at your own risk!
 """
 
 from abc import abstractmethod, ABCMeta
+import atexit
 import collections
 from collections import defaultdict
 import collections.abc
@@ -395,6 +396,11 @@ _caches = {}
 def _clear_caches():
     for cleanup in _cleanups:
         cleanup()
+
+
+# Release the LRU caches at shutdown, they otherwise redistribute reference
+# leaks of one extension to types of unrelated ones. See GH-151728.
+atexit.register(_clear_caches)
 
 
 def _tp_cache(func=None, /, *, typed=False):

--- a/Misc/NEWS.d/next/Library/2026-07-29-11-05-00.gh-issue-151728.Kq3vTn.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-11-05-00.gh-issue-151728.Kq3vTn.rst
@@ -1,0 +1,4 @@
+Clear the internal :mod:`typing` caches from an exit handler. Previously, an
+extension module that leaked a reference to :mod:`typing` would also keep every
+subscripted type alive past interpreter shutdown, including types owned by
+unrelated extension modules.


### PR DESCRIPTION
`typing` caches every subscripted type in module-level `lru_cache`es. Those caches are only released when the `typing` module itself is torn down, which does not happen when some extension module leaks a reference to it. Since `typing` is nearly universal, a single such leak (e.g. via `torch`) keeps the cached types alive past interpreter shutdown, including types owned by unrelated, correctly written extensions. Those extensions then look like they are leaking: `valgrind` reports them, and nanobind prints warnings about types, functions, and instances that were never freed.

`typing._clear_caches()` already exists but nothing calls it at shutdown. This PR registers it with `atexit` so that the caches are dropped during finalization and the process terminates leak-free. This complements gh-98253, which broke a cycle inside `_tp_cache` but left the retention itself in place.

This re-lands GH-154858, which was reverted in GH-154992 because of reference leak failures. The problem there was that the handler runs on every import of `typing` and keeps the module alive through its `__globals__`. Two tests in `test_typing` import a throwaway copy of `typing`, which then leaks once per repetition under `-R`. Both now unregister the handler of the copy they made.

The PR adds no test because reproducing the problem requires an extension module that deliberately leaks a reference (i.e. one with a missing `tp_traverse`). A minimal one is at https://github.com/wjakob/typing-leak.

<!-- gh-issue-number: gh-151728 -->
* Issue: gh-151728
<!-- /gh-issue-number -->
