### PR TITLE
gh-155004: Fix iconv error handlers in a non-initial shift state

### DIFF
--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -3761,7 +3761,7 @@ class IconvTest(unittest.TestCase):
                     data = codecs.iconv_encode(enc, text, errors)[0]
                     self.assertEqual(
                         codecs.iconv_decode(enc, data, 'strict', True)[0],
-                        char + replacement + char, data)
+                        char + replacement + char, ascii(data))
         if not tested:
             self.skipTest('no stateful iconv encoding is available')
 

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -3761,7 +3761,7 @@ class IconvTest(unittest.TestCase):
                     data = codecs.iconv_encode(enc, text, errors)[0]
                     self.assertEqual(
                         codecs.iconv_decode(enc, data, 'strict', True)[0],
-                        char + replacement + char)
+                        char + replacement + char, data)
         if not tested:
             self.skipTest('no stateful iconv encoding is available')
 

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -3679,10 +3679,11 @@ _ICONV_MULTIBYTE = ['EUC-JP', 'SHIFT_JIS', 'GBK', 'GB18030', 'BIG5']
 # Encodings iconv may provide but for which CPython has no built-in codec
 # (cp1047 is EBCDIC, i.e. not ASCII-compatible).
 _ICONV_ONLY = ['cp1047', 'cp1133', 'GEORGIAN-PS', 'ARMSCII-8']
-# Encodings that leave a shift state pending, so encoding ends with a flush.
-_ICONV_SHIFT_STATE = [('ISO-2022-CN-EXT', 'ABC\u4e2dDEF'),
-                      ('ISO-2022-CN', 'ABC\u4e2dDEF'),
-                      ('ISO-2022-JP', 'ABC\u65e5DEF')]
+# Stateful encodings, with a character that leaves a shift state pending.
+_ICONV_SHIFT_STATE = [('ISO-2022-CN-EXT', '\u4e2d'),
+                      ('ISO-2022-CN', '\u4e2d'),
+                      ('ISO-2022-JP', '\u65e5'),
+                      ('ISO-2022-KR', '\ud55c')]
 
 
 @unittest.skipUnless(hasattr(codecs, 'iconv_encode'),
@@ -3734,6 +3735,31 @@ class IconvTest(unittest.TestCase):
                          b'a\\u20acb')
         self.assertEqual(codecs.iconv_encode(enc, 'a€b', 'xmlcharrefreplace')[0],
                          b'a&#8364;b')
+
+    def test_encode_errors_shift_state(self):
+        # A replacement must not land inside a shifted region.
+        cases = [('replace', '?'),
+                 ('ignore', ''),
+                 ('backslashreplace', '\\U0001f600'),
+                 ('xmlcharrefreplace', '&#128512;')]
+        tested = False
+        for enc, char in _ICONV_SHIFT_STATE:
+            if not iconv_encoding_available(enc):
+                continue
+            data = codecs.iconv_encode(enc, char)[0]
+            if codecs.iconv_decode(enc, data, 'strict', True)[0] != char:
+                # iconv substituted the character instead of encoding it.
+                continue
+            tested = True
+            text = char + '\U0001f600' + char
+            for errors, replacement in cases:
+                with self.subTest(encoding=enc, errors=errors):
+                    data = codecs.iconv_encode(enc, text, errors)[0]
+                    self.assertEqual(
+                        codecs.iconv_decode(enc, data, 'strict', True)[0],
+                        char + replacement + char)
+        if not tested:
+            self.skipTest('no stateful iconv encoding is available')
 
     def test_decode_errors(self):
         enc = self.require('ASCII')
@@ -3827,12 +3853,12 @@ class IconvTest(unittest.TestCase):
         # An iconv that cannot represent the character either rejects it or
         # substitutes for it silently, as macOS does for ISO-2022-CN.
         tested = False
-        for enc, text in _ICONV_SHIFT_STATE:
+        for enc, char in _ICONV_SHIFT_STATE:
             if not iconv_encoding_available(enc):
                 continue
             with self.subTest(encoding=enc):
                 try:
-                    data = codecs.iconv_encode(enc, text)[0]
+                    data = codecs.iconv_encode(enc, 'ABC' + char + 'DEF')[0]
                 except UnicodeEncodeError:
                     continue
                 tested = True

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -3746,7 +3746,11 @@ class IconvTest(unittest.TestCase):
         for enc, char in _ICONV_SHIFT_STATE:
             if not iconv_encoding_available(enc):
                 continue
-            data = codecs.iconv_encode(enc, char)[0]
+            try:
+                data = codecs.iconv_encode(enc, char)[0]
+            except UnicodeEncodeError:
+                # This iconv cannot represent the character.
+                continue
             if codecs.iconv_decode(enc, data, 'strict', True)[0] != char:
                 # iconv substituted the character instead of encoding it.
                 continue

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -8368,6 +8368,29 @@ iconv_grow_writer(PyBytesWriter *writer, char **pout, char **poutend)
     return 0;
 }
 
+/* Return the output and the conversion to the initial shift state; a stateless
+   encoding writes nothing.  Returns 0 on success, -1 on error. */
+static int
+iconv_reset_shift_state(iconv_t cd, PyBytesWriter *writer,
+                        char **pout, char **poutend)
+{
+    for (;;) {
+        size_t outleft = (size_t)(*poutend - *pout);
+        /* Only -1 is a failure; a positive result counts nonreversible
+           conversions. */
+        if (iconv(cd, NULL, NULL, pout, &outleft) != (size_t)-1) {
+            return 0;
+        }
+        if (errno != E2BIG) {
+            PyErr_SetFromErrno(PyExc_OSError);
+            return -1;
+        }
+        if (iconv_grow_writer(writer, pout, poutend) < 0) {
+            return -1;
+        }
+    }
+}
+
 /*
  * Encode a str to bytes with iconv().
  *
@@ -8531,28 +8554,27 @@ _PyUnicode_EncodeIconv(const char *encoding, PyObject *unicode,
             replen = PyBytes_GET_SIZE(repbytes);
         }
 
-        while (outend - out < replen) {
-            if (iconv_grow_writer(writer, &out, &outend) < 0) {
-                if (repbytes != NULL) {
-                    Py_DECREF(repbytes);
-                }
-                else {
-                    Py_DECREF(rep);
-                }
-                goto done;
-            }
+        /* The replacement is copied verbatim, so the output must return to the
+           initial shift state first, or it reads back as encoded data. */
+        int failed = replen > 0
+                     && iconv_reset_shift_state(cd, writer, &out, &outend) < 0;
+        while (!failed && outend - out < replen) {
+            failed = iconv_grow_writer(writer, &out, &outend) < 0;
         }
-        memcpy(out, repdata, replen);
-        out += replen;
+        if (!failed) {
+            memcpy(out, repdata, replen);
+            out += replen;
+        }
         if (repbytes != NULL) {
             Py_DECREF(repbytes);
         }
         else {
             Py_DECREF(rep);
         }
+        if (failed) {
+            goto done;
+        }
         up = ustart + (size_t)newpos * unit;
-        /* Reset the shift state after the injected replacement bytes. */
-        iconv(cd, NULL, NULL, NULL, NULL);
     }
 
     if (PyBytesWriter_Resize(writer, out - (char *)PyBytesWriter_GetData(writer)) < 0) {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -8526,25 +8526,15 @@ _PyUnicode_EncodeIconv(const char *encoding, PyObject *unicode,
             }
             /* A positive result counts nonreversible conversions: iconv()
                substituted an unencodable character instead of failing with
-               EILSEQ (musl and *BSD citrus do this).  Treat it as unencodable
-               and re-run one code point at a time to locate it. */
+               EILSEQ (musl and *BSD citrus do this). */
             if (ret > 0) {
-                if (!careful) {
-                    careful = 1;
-                    probe_cd = iconv_open_or_set_error(encoding, source,
-                                                       encoding);
-                    if (probe_cd == (iconv_t)-1) {
-                        goto done;
-                    }
-                    iconv(cd, NULL, NULL, NULL, NULL);
-                    out = PyBytesWriter_GetData(writer);
-                    outend = out + PyBytesWriter_GetSize(writer);
-                    up = ustart;
-                    continue;
+                if (careful) {
+                    /* The probe reported the code point as encodable, but it
+                       was substituted in the current shift state; drop it and
+                       report it. */
+                    out = out_before;
+                    up -= unit;
                 }
-                /* This code point was substituted; drop it and report it. */
-                out = out_before;
-                up -= unit;
             }
             else if (careful && up < uend) {
                 continue;
@@ -8564,6 +8554,23 @@ _PyUnicode_EncodeIconv(const char *encoding, PyObject *unicode,
         else if (errno != EILSEQ && errno != EINVAL) {
             PyErr_SetFromErrno(PyExc_OSError);
             goto done;
+        }
+
+        if (!careful) {
+            /* iconv() can reset the shift state of cd on an unencodable code
+               point, while the output written for the preceding code points
+               stays in the shifted state.  Re-run one code point at a time:
+               then nothing is written for the failed one. */
+            careful = 1;
+            probe_cd = iconv_open_or_set_error(encoding, source, encoding);
+            if (probe_cd == (iconv_t)-1) {
+                goto done;
+            }
+            iconv(cd, NULL, NULL, NULL, NULL);
+            out = PyBytesWriter_GetData(writer);
+            outend = out + PyBytesWriter_GetSize(writer);
+            up = ustart;
+            continue;
         }
 
         /* An unencodable code point at *up; one input unit is one code point. */

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -8375,10 +8375,13 @@ iconv_reset_shift_state(iconv_t cd, PyBytesWriter *writer,
                         char **pout, char **poutend)
 {
     for (;;) {
+        /* A NULL input buffer means the reset, but its size is passed as a
+           real pointer: some implementations do not accept a NULL there. */
+        size_t inleft = 0;
         size_t outleft = (size_t)(*poutend - *pout);
         /* Only -1 is a failure; a positive result counts nonreversible
            conversions. */
-        if (iconv(cd, NULL, NULL, pout, &outleft) != (size_t)-1) {
+        if (iconv(cd, NULL, &inleft, pout, &outleft) != (size_t)-1) {
             return 0;
         }
         if (errno != E2BIG) {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -8391,6 +8391,25 @@ iconv_reset_shift_state(iconv_t cd, PyBytesWriter *writer,
     }
 }
 
+/* Test whether one code point is encodable, on a descriptor separate from the
+   one which writes the output.  Substituting it (e.g. writing SI in
+   ISO-2022-KR) changes the shift state, and dropping such output would
+   desynchronize the descriptor from what is already written. */
+static int
+iconv_encodable(iconv_t cd, const char *cp, size_t unit)
+{
+    char buf[32];       /* enough for one code point with escape sequences */
+    char *inptr = (char *)cp;
+    size_t inleft = unit;
+    char *out = buf;
+    size_t outleft = sizeof(buf);
+
+    iconv(cd, NULL, NULL, NULL, NULL);      /* start in the initial state */
+    /* Only a zero result means that the code point was encoded. */
+    /* See the note above on the void* cast of the iconv() input buffer. */
+    return iconv(cd, (void *)&inptr, &inleft, &out, &outleft) == 0;
+}
+
 /*
  * Encode a str to bytes with iconv().
  *
@@ -8458,6 +8477,8 @@ _PyUnicode_EncodeIconv(const char *encoding, PyObject *unicode,
     const char *uend = data + (size_t)ulen * unit;
     int flushing = 0;
     int careful = 0;            /* feed one code point per iconv() call */
+    /* tests a code point in the careful mode */
+    iconv_t probe_cd = (iconv_t)-1;
 
     /* A generous initial estimate for the output size. */
     writer = PyBytesWriter_Create(ulen + (ulen >> 1) + 16);
@@ -8476,12 +8497,24 @@ _PyUnicode_EncodeIconv(const char *encoding, PyObject *unicode,
         }
         char *out_before = out;
         size_t outleft = (size_t)(outend - out);
-        /* When the whole string is converted, a final iconv() call with a
-           NULL input flushes any pending shift sequence (e.g. ISO-2022). */
-        /* See the note above on the void* cast of the iconv() input buffer. */
-        size_t ret = iconv(cd, flushing ? NULL : (void *)&inptr, &inleft, &out, &outleft);
-        if (!flushing) {
-            up = inptr;
+        size_t ret;
+        if (careful && !flushing
+            && !iconv_encodable(probe_cd, up, (size_t)unit))
+        {
+            /* Do not feed it to cd, whose shift state has to match
+               the written output. */
+            ret = (size_t)-1;
+            errno = EILSEQ;
+        }
+        else {
+            /* When the whole string is converted, a final iconv() call with
+               a NULL input flushes any pending shift sequence (ISO-2022). */
+            /* See the note above on the void* cast of the iconv() input. */
+            ret = iconv(cd, flushing ? NULL : (void *)&inptr, &inleft,
+                        &out, &outleft);
+            if (!flushing) {
+                up = inptr;
+            }
         }
 
         if (ret != (size_t)-1) {
@@ -8495,6 +8528,11 @@ _PyUnicode_EncodeIconv(const char *encoding, PyObject *unicode,
             if (ret > 0) {
                 if (!careful) {
                     careful = 1;
+                    probe_cd = iconv_open_or_set_error(encoding, source,
+                                                       encoding);
+                    if (probe_cd == (iconv_t)-1) {
+                        goto done;
+                    }
                     iconv(cd, NULL, NULL, NULL, NULL);
                     out = PyBytesWriter_GetData(writer);
                     outend = out + PyBytesWriter_GetSize(writer);
@@ -8588,6 +8626,9 @@ done:
         PyBytesWriter_Discard(writer);
     }
     iconv_close(cd);
+    if (probe_cd != (iconv_t)-1) {
+        iconv_close(probe_cd);
+    }
     PyMem_Free(widened);
     Py_XDECREF(errorHandler);
     Py_XDECREF(exc);


### PR DESCRIPTION
The bytes an error handler returns are copied to the output as they are, so the output has to be back in the initial shift state first. It was reset only after the replacement, and with a NULL output buffer, so the closing sequence was never written and the replacement was read back as encoded data.

`iconv_reset_shift_state()` flushes into the output before the replacement is copied, and only when there is something to copy. `iconv:ISO-2022-JP` now matches `iso2022_jp` byte for byte with all four error handlers.

Encoding `<char>😀<char>` and decoding it back was broken for 146 (encoding, handler) pairs of the 1180 encodings `iconv -l` lists here, and for none now. The test fails without the change.

The iconv codecs are new in 3.16, so there is no NEWS entry.

<!-- gh-issue-number: gh-155004 -->
* Issue: gh-155004
<!-- /gh-issue-number -->
