### PR TITLE
gh-155006: Encode an error handler's replacement strictly

### DIFF
--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1,3 +1,4 @@
+import _codecs
 import codecs
 import contextlib
 import copy
@@ -3734,6 +3735,17 @@ class IconvTest(unittest.TestCase):
                          b'a\\u20acb')
         self.assertEqual(codecs.iconv_encode(enc, 'a€b', 'xmlcharrefreplace')[0],
                          b'a&#8364;b')
+
+    def test_encode_errors_unencodable_replacement(self):
+        # Encoding the replacement must not call the error handler again.
+        enc = self.require('ASCII')
+        codecs.register_error('test.iconv', lambda exc: ('€', exc.end))
+        self.addCleanup(_codecs._unregister_error, 'test.iconv')
+        with self.assertRaises(UnicodeEncodeError) as cm:
+            codecs.iconv_encode(enc, 'a€b', 'test.iconv')
+        self.assertEqual((cm.exception.start, cm.exception.end), (1, 2))
+        self.assertEqual(cm.exception.reason,
+                         'unable to encode error handler result')
 
     def test_decode_errors(self):
         enc = self.require('ASCII')

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -8520,11 +8520,19 @@ _PyUnicode_EncodeIconv(const char *encoding, PyObject *unicode,
             replen = PyBytes_GET_SIZE(rep);
         }
         else {
-            /* A str replacement is encoded through the same codec. */
+            /* A str replacement is encoded through the same codec, but
+               strictly: handling its errors in turn could never terminate. */
             assert(PyUnicode_Check(rep));
-            repbytes = _PyUnicode_EncodeIconv(encoding, rep, errors);
+            repbytes = _PyUnicode_EncodeIconv(encoding, rep, NULL);
             Py_DECREF(rep);
             if (repbytes == NULL) {
+                if (PyErr_ExceptionMatches(PyExc_UnicodeEncodeError)) {
+                    /* Report the input the caller knows about, not the
+                       replacement. */
+                    PyErr_Clear();
+                    raise_encode_exception(&exc, encoding, unicode, pos, pos + 1,
+                            "unable to encode error handler result");
+                }
                 goto done;
             }
             repdata = PyBytes_AS_STRING(repbytes);


### PR DESCRIPTION
A `str` replacement was re-encoded with the same error handler, so a replacement that is itself unencodable called the handler again, without end. It is encoded strictly now, and one that does not fit is reported against the input character.

`replace` therefore raises where it used to recurse, which includes the charsets with no `'?'` at all, 38 of the names here: E13B, Braille, the INIS subsets and others. `ignore` is unaffected.

Encoding `a😀b` with the four handlers recursed for 274 encodings and for none now. The test fails without the change.

The iconv codecs are new in 3.16, so there is no NEWS entry.

<!-- gh-issue-number: gh-155006 -->
* Issue: gh-155006
<!-- /gh-issue-number -->
