### PR TITLE
Update Android Gradle plugin to version 9.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -338,7 +338,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build and test
-        run: JAVA_HOME="${JAVA_HOME_21_X64:-$JAVA_HOME_21_arm64}" python3 Platforms/Android ci --fast-ci ${{ matrix.arch }}-linux-android
+        run: python3 Platforms/Android ci --fast-ci ${{ matrix.arch }}-linux-android
 
   build-ios:
     name: iOS

--- a/Platforms/Android/README.md
+++ b/Platforms/Android/README.md
@@ -31,7 +31,7 @@ The script also requires the following commands to be on the `PATH`:
 
 * `curl`
 * `java` (or set the `JAVA_HOME` environment variable).
-  Java versions 17 and 21 are supported.
+  Java versions 17, 21 and 25 are supported.
 
 ## Building
 

--- a/Platforms/Android/__main__.py
+++ b/Platforms/Android/__main__.py
@@ -393,10 +393,10 @@ def setup_testbed():
     if all((TESTBED_DIR / path).exists() for path in paths):
         return
 
-    # The wrapper version isn't important, as any version of the wrapper can
-    # download any version of Gradle. The Gradle version actually used for the
-    # build is specified in testbed/gradle/wrapper/gradle-wrapper.properties.
-    version = "8.9.0"
+    # Any version of the wrapper can run any reasonably close version of Gradle, so this
+    # doesn't need to match the Gradle version used for the build, which is specified in
+    # testbed/gradle/wrapper/gradle-wrapper.properties.
+    version = "9.5.0"
 
     for path in paths:
         out_path = TESTBED_DIR / path

--- a/Platforms/Android/testbed/app/build.gradle.kts
+++ b/Platforms/Android/testbed/app/build.gradle.kts
@@ -3,7 +3,6 @@ import kotlin.math.max
 
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
 }
 
 val ANDROID_DIR = file("../..")
@@ -144,17 +143,9 @@ android {
         path("src/main/c/CMakeLists.txt")
     }
 
-    // Set this property to something nonexistent but non-empty. Otherwise it'll use the
-    // default list, which ignores asset directories beginning with an underscore, and
-    // maybe also other files required by tests.
-    aaptOptions.ignoreAssetsPattern = "android-testbed-dont-ignore-anything"
-
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
     }
 
     testOptions {
@@ -191,6 +182,12 @@ android {
                 }
             }
         }
+    }
+    androidResources {
+        // Set this property to something nonexistent but non-empty. Otherwise it'll use
+        // the default list, which ignores asset directories beginning with an
+        // underscore, and maybe also other files required by tests.
+        ignoreAssetsPattern = "android-testbed-dont-ignore-anything"
     }
 }
 

--- a/Platforms/Android/testbed/build.gradle.kts
+++ b/Platforms/Android/testbed/build.gradle.kts
@@ -1,5 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.10.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+    id("com.android.application") version "9.3.1" apply false
 }

--- a/Platforms/Android/testbed/gradle.properties
+++ b/Platforms/Android/testbed/gradle.properties
@@ -11,16 +11,8 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app's APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
-android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true
 
 # By default, the app will be uninstalled after the tests finish (apparently
 # after 10 seconds in case of an unclean shutdown). We disable this, because

--- a/Platforms/Android/testbed/gradle/wrapper/gradle-wrapper.properties
+++ b/Platforms/Android/testbed/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Feb 19 20:29:06 GMT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This makes the testbed compatible with Java 25, allowing it to run on GitHub Actions on Ubuntu 26.04 without overriding the Java version (https://github.com/pypa/cibuildwheel/issues/2950).

The supported Java versions are now covered by:
* 17 on the x86_64 buildbot
* 21 on the aarch64 buildbot
* 25 on the x86_64 GitHub Actions