### PR TITLE
gh-122826: Document exec closure name resolution

### DIFF
--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -331,15 +331,16 @@ This means that the following code will print 42::
 .. XXX from * also invalid with relative imports (at least currently)
 
 The :func:`eval` and :func:`exec` functions do not have access to the full
-environment for resolving names.  Names may be resolved in the local and global
-namespaces of the caller.  Free variables are not resolved in the nearest
-enclosing namespace, but in the global namespace.  [#]_ The :func:`exec` and
-:func:`eval` functions have optional arguments to override the global and local
-namespace.  If only one namespace is specified, it is used for both.
+environment for resolving names.  When their *source* argument is a string,
+names may be resolved in the local and global namespaces of the caller.  Free
+variables are not resolved in the nearest enclosing namespace, but in the
+global namespace.  [#]_ The :func:`exec` and :func:`eval` functions have
+optional arguments to override the global and local namespace.  If only one
+namespace is specified, it is used for both.
 
-.. XXX(ncoghlan) above is only accurate for string execution. When executing code objects,
-   closure cells may now be passed explicitly to resolve co_freevars references.
-   Docs issue: https://github.com/python/cpython/issues/122826
+When :func:`exec` is passed a code object containing free variables, the
+*closure* argument may be used to explicitly supply the required closure
+cells.
 
 .. _exceptions:
 


### PR DESCRIPTION
Fixes #122826.

The execution model documentation previously described name resolution for eval() and exec() without distinguishing string source from code objects. This change limits the existing explanation to string source and documents that exec() can explicitly receive closure cells for a code object containing free variables.

Checks:

- Doc\make.bat check
- Doc\make.bat html reference/executionmodel.rst with warnings treated as errors

<!-- gh-issue-number: gh-122826 -->
* Issue: gh-122826
<!-- /gh-issue-number -->
