### PR TITLE
gh-154945: add regression test for NormalDist.quantiles(n < 1)

### DIFF
--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -3105,6 +3105,12 @@ class TestNormalDist:
             self.assertTrue(all(math.isclose(e, a, abs_tol=0.0001)
                             for e, a in zip(expected, actual)))
 
+    def test_quantiles_invalid_n(self):
+        Z = self.module.NormalDist()
+        with self.assertRaises(self.module.StatisticsError) as cm:
+            Z.quantiles(0)
+        self.assertEqual(str(cm.exception), 'n must be at least 1')
+
     def test_overlap(self):
         NormalDist = self.module.NormalDist
 


### PR DESCRIPTION
<!-- gh-issue-number: gh-154945 -->
* Issue: gh-154945
<!-- /gh-issue-number -->

Adds a regression test for the inconsistency reported in gh-154945: `NormalDist.quantiles(n)` accepts `n < 1` and silently returns `[]`, whereas the module-level `statistics.quantiles(data, n)` rejects it with `StatisticsError('n must be at least 1')`.

```pycon
>>> from statistics import NormalDist, quantiles
>>> NormalDist().quantiles(0)
[]                                   # NormalDist: silently wrong
>>> quantiles([1, 2, 3, 4], n=0)
StatisticsError: n must be at least 1   # module-level: validated
```

`NormalDist.quantiles` computes `[self.inv_cdf(i / n) for i in range(1, n)]`; with `n=0` the range is empty, so the invalid request produces an empty list instead of an error, and the two sibling APIs disagree.

This PR is the failing test only, so CI shows it red against `main` — that's the reproduction. It goes green with a two-line guard at the top of `NormalDist.quantiles`, mirroring the module-level validation so both APIs behave identically:

```diff
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -1293,6 +1293,8 @@ def quantiles(self, n=4):
         Set *n* to 100 for percentiles which gives the 99 cuts points that
         separate the normal distribution in to 100 equal sized groups.
         """
+        if n < 1:
+            raise StatisticsError('n must be at least 1')
         return [self.inv_cdf(i / n) for i in range(1, n)]
```

Notes on the choice:
- **Message and exception type are copied verbatim** from the existing check in the module-level `quantiles()` (`Lib/statistics.py`), so the two entry points raise identically — that consistency is the whole point of the report.
- **Only `n < 1` is guarded.** `n == 1` correctly returns `[]` (one interval ⇒ zero cut points), matching the module-level function, so it is intentionally left unchanged.
- The issue also observes that `inv_cdf` re-checks `p <= 0 or p >= 1` every loop iteration even though `i / n` is always in `(0, 1)`. That's a separate micro-optimization and is deliberately **not** included here to keep this change to the reported correctness fix.

@ayishaatwork — you asked to work on this on the issue; the guard above is the whole fix, so please feel free to send it as the source-side change and this test will turn green. I've verified both states locally on a built interpreter (`./python -m test test_statistics`): the test fails on `main` and passes with the guard, for both the pure-Python and the C-accelerated `NormalDist`.
