### PR TITLE
gh-155016: Fix encoding to Windows code pages which require dwFlags=0

### DIFF
--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -3562,6 +3562,49 @@ class CodePageTest(unittest.TestCase):
             (b'[\xff]', 'strict', '[\xff]'),
         ))
 
+    def test_cp50220(self):
+        # ISO-2022-JP, a code page which only supports conversion with flags=0
+        self.check_encode(50220, (
+            ('abc', 'strict', b'abc'),
+            ('\u3042', 'strict', b'\x1b$B$"\x1b(B'),
+            ('\u3042abc', 'strict', b'\x1b$B$"\x1b(Babc'),
+            # test error handlers
+            ('[\u20ac]', 'strict', None),
+            ('[\u20ac]', 'ignore', b'[]'),
+            ('[\u20ac]', 'replace', b'[?]'),
+            ('[\u20ac]', 'backslashreplace', b'[\\u20ac]'),
+            ('[\u20ac]', 'xmlcharrefreplace', b'[&#8364;]'),
+            ('\u3042[\u20ac]\u3042', 'ignore',
+             b'\x1b$B$"\x1b(B[]\x1b$B$"\x1b(B'),
+            ('[\udc80]', 'strict', None),
+            ('[\udc80]', 'ignore', b'[]'),
+        ))
+        self.check_decode(50220, (
+            (b'abc', 'strict', 'abc'),
+            (b'\x1b$B$"\x1b(B', 'strict', '\u3042'),
+            (b'\x1b$B$"\x1b(Babc', 'strict', '\u3042abc'),
+        ))
+
+    def test_cp54936(self):
+        # GB18030, a code page which only supports conversion with flags=0
+        self.check_encode(54936, (
+            ('abc', 'strict', b'abc'),
+            ('\u4e2d', 'strict', b'\xd6\xd0'),
+            ('\u20ac', 'strict', b'\xa2\xe3'),
+            ('\U00020000', 'strict', b'\x952\x826'),
+            # test error handlers
+            ('[\udc80]', 'strict', None),
+            ('[\udc80]', 'ignore', b'[]'),
+            ('[\udc80]', 'replace', b'[?]'),
+            ('[\udc80]', 'backslashreplace', b'[\\udc80]'),
+            ('[\udc80]', 'surrogateescape', b'[\x80]'),
+        ))
+        self.check_decode(54936, (
+            (b'abc', 'strict', 'abc'),
+            (b'\xd6\xd0', 'strict', '\u4e2d'),
+            (b'\x952\x826', 'strict', '\U00020000'),
+        ))
+
     def test_multibyte_encoding(self):
         self.check_decode(932, (
             (b'\x84\xe9\x80', 'ignore', '\u9a3e'),

--- a/Misc/NEWS.d/next/Windows/2026-08-01-12-00-00.gh-issue-155016.Wc4Fl9.rst
+++ b/Misc/NEWS.d/next/Windows/2026-08-01-12-00-00.gh-issue-155016.Wc4Fl9.rst
@@ -1,0 +1,4 @@
+Fix encoding to Windows code pages which only support conversion with
+``dwFlags`` set to 0: ISO-2022 (50220, 50221, 50222, 50225, 50227 and 50229),
+HZ-GB2312 (52936), GB18030 (54936) and ISCII (57002--57011).  Previously
+encoding to them always failed with :exc:`OSError`.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -7829,14 +7829,34 @@ PyUnicode_DecodeMBCS(const char *s,
     return PyUnicode_DecodeMBCSStateful(s, size, errors, NULL);
 }
 
+/* WideCharToMultiByte() only supports some code pages with flags=0 and
+   lpUsedDefaultChar=NULL, see its documentation.  Unencodable characters
+   are silently replaced then, so they are detected by decoding the result
+   back (see encode_code_page_lossy()). */
+static int
+encode_code_page_zero_flags(UINT code_page)
+{
+    switch (code_page) {
+    case 42:                            /* Symbol */
+    case 50220: case 50221: case 50222: /* ISO-2022-JP */
+    case 50225:                         /* ISO-2022-KR */
+    case 50227: case 50229:             /* ISO-2022-CN */
+    case 52936:                         /* HZ-GB2312 */
+    case 54936:                         /* GB18030 */
+    case CP_UTF7:
+        return 1;
+    default:
+        return 57002 <= code_page && code_page <= 57011;  /* ISCII */
+    }
+}
+
 static DWORD
 encode_code_page_flags(UINT code_page, const char *errors)
 {
     if (code_page == CP_UTF8) {
         return WC_ERR_INVALID_CHARS;
     }
-    else if (code_page == CP_UTF7) {
-        /* CP_UTF7 only supports flags=0 */
+    else if (encode_code_page_zero_flags(code_page)) {
         return 0;
     }
     else {
@@ -7845,6 +7865,56 @@ encode_code_page_flags(UINT code_page, const char *errors)
         else
             return WC_NO_BEST_FIT_CHARS;
     }
+}
+
+/* Code pages encoded without WC_NO_BEST_FIT_CHARS and lpUsedDefaultChar
+   need the result to be decoded back to detect replaced characters.
+   UTF-7 encodes every character, so it is exempted. */
+static int
+encode_code_page_check_lossy(UINT code_page)
+{
+    return code_page != CP_UTF7 && encode_code_page_zero_flags(code_page);
+}
+
+/*
+ * Check whether some characters were replaced when encoding, i.e. whether
+ * the encoded string is not decoded back into the original string.
+ *
+ * Returns 1 if some characters were replaced, 0 if not, or raise an OSError
+ * and returns -1 on error.
+ */
+static int
+encode_code_page_lossy(UINT code_page,
+                       const wchar_t *p, int size,
+                       const char *out, int outsize)
+{
+    wchar_t *decoded;
+    int n, lossy;
+
+    n = MultiByteToWideChar(code_page, 0, out, outsize, NULL, 0);
+    if (n <= 0) {
+        PyErr_SetFromWindowsErr(0);
+        return -1;
+    }
+    if (n != size) {
+        return 1;
+    }
+
+    decoded = PyMem_New(wchar_t, n);
+    if (decoded == NULL) {
+        PyErr_NoMemory();
+        return -1;
+    }
+    n = MultiByteToWideChar(code_page, 0, out, outsize, decoded, n);
+    if (n <= 0) {
+        PyErr_SetFromWindowsErr(0);
+        lossy = -1;
+    }
+    else {
+        lossy = (memcmp(decoded, p, (size_t)size * sizeof(wchar_t)) != 0);
+    }
+    PyMem_Free(decoded);
+    return lossy;
 }
 
 /*
@@ -7866,6 +7936,7 @@ encode_code_page_strict(UINT code_page, PyBytesWriter **writer,
     Py_ssize_t size;
     const DWORD flags = encode_code_page_flags(code_page, NULL);
     char *out;
+    Py_ssize_t start;
     /* Create a substring so that we can get the UTF-16 representation
        of just the slice under consideration. */
     PyObject *substring;
@@ -7873,7 +7944,7 @@ encode_code_page_strict(UINT code_page, PyBytesWriter **writer,
 
     assert(len > 0);
 
-    if (code_page != CP_UTF8 && code_page != CP_UTF7)
+    if (code_page != CP_UTF8 && !encode_code_page_zero_flags(code_page))
         pusedDefaultChar = &usedDefaultChar;
     else
         pusedDefaultChar = NULL;
@@ -7903,6 +7974,7 @@ encode_code_page_strict(UINT code_page, PyBytesWriter **writer,
 
     if (*writer == NULL) {
         /* Create string object */
+        start = 0;
         *writer = PyBytesWriter_Create(outsize);
         if (*writer == NULL) {
             goto done;
@@ -7911,11 +7983,11 @@ encode_code_page_strict(UINT code_page, PyBytesWriter **writer,
     }
     else {
         /* Extend string object */
-        Py_ssize_t n = PyBytesWriter_GetSize(*writer);
+        start = PyBytesWriter_GetSize(*writer);
         if (PyBytesWriter_Grow(*writer, outsize) < 0) {
             goto done;
         }
-        out = (char*)PyBytesWriter_GetData(*writer) + n;
+        out = (char*)PyBytesWriter_GetData(*writer) + start;
     }
 
     /* Do the conversion */
@@ -7928,6 +8000,22 @@ encode_code_page_strict(UINT code_page, PyBytesWriter **writer,
     if (pusedDefaultChar && *pusedDefaultChar) {
         ret = -2;
         goto done;
+    }
+    if (encode_code_page_check_lossy(code_page)) {
+        int lossy = encode_code_page_lossy(code_page, p, (int)size,
+                                           out, outsize);
+        if (lossy < 0) {
+            goto done;
+        }
+        if (lossy) {
+            /* Drop the lossy result, it will be re-encoded with an error
+               handler. */
+            if (PyBytesWriter_Resize(*writer, start) < 0) {
+                goto done;
+            }
+            ret = -2;
+            goto done;
+        }
     }
     ret = 0;
 
@@ -7962,8 +8050,10 @@ encode_code_page_errors(UINT code_page, PyBytesWriter **writer,
     /* Ideally, we should get reason from FormatMessage. This is the Windows
        2000 English version of the message. */
     const char *reason = "invalid character";
-    /* 4=maximum length of a UTF-8 sequence */
-    char buffer[4];
+    /* 4=maximum length of a UTF-8 sequence, 16 is enough for a character
+       encoded together with escape sequences (e.g. in ISO-2022) */
+    char buffer[16];
+    int maxcharsize;
     BOOL usedDefaultChar = FALSE, *pusedDefaultChar;
     Py_ssize_t outsize;
     char *out;
@@ -7993,16 +8083,21 @@ encode_code_page_errors(UINT code_page, PyBytesWriter **writer,
         return -1;
     }
 
-    if (code_page != CP_UTF8 && code_page != CP_UTF7)
+    if (code_page != CP_UTF8 && !encode_code_page_zero_flags(code_page))
         pusedDefaultChar = &usedDefaultChar;
     else
         pusedDefaultChar = NULL;
 
-    if (Py_ARRAY_LENGTH(buffer) > PY_SSIZE_T_MAX / insize) {
+    /* Only code pages encoded with flags=0 can need more than 4 bytes
+       per character. */
+    maxcharsize = encode_code_page_zero_flags(code_page)
+                  ? (int)Py_ARRAY_LENGTH(buffer) : 4;
+
+    if (maxcharsize > PY_SSIZE_T_MAX / insize) {
         PyErr_NoMemory();
         goto error;
     }
-    outsize = insize * Py_ARRAY_LENGTH(buffer);
+    outsize = insize * maxcharsize;
 
     if (*writer == NULL) {
         /* Create string object */
@@ -8039,10 +8134,18 @@ encode_code_page_errors(UINT code_page, PyBytesWriter **writer,
 
         outsize = WideCharToMultiByte(code_page, flags,
                                       chars, charsize,
-                                      buffer, Py_ARRAY_LENGTH(buffer),
+                                      buffer, maxcharsize,
                                       NULL, pusedDefaultChar);
         if (outsize > 0) {
-            if (pusedDefaultChar == NULL || !(*pusedDefaultChar))
+            int lossy = (pusedDefaultChar != NULL && *pusedDefaultChar);
+            if (!lossy && encode_code_page_check_lossy(code_page)) {
+                lossy = encode_code_page_lossy(code_page, chars, charsize,
+                                               buffer, (int)outsize);
+                if (lossy < 0) {
+                    goto error;
+                }
+            }
+            if (!lossy)
             {
                 pos++;
                 memcpy(out, buffer, outsize);


### PR DESCRIPTION
Encode with `dwFlags = 0` and `lpUsedDefaultChar = NULL` to the code pages which only support this: 42 (Symbol), 50220, 50221, 50222, 50225, 50227, 50229 (ISO-2022), 52936 (HZ-GB2312), 54936 (GB18030) and 57002-57011 (ISCII). UTF-7 was already special cased, now it shares the same code.

Since `lpUsedDefaultChar` is no longer available for these code pages, replaced characters are detected by decoding the encoded string back and comparing it with the original string. This also detects best fit characters, which `dwFlags = 0` re-enables.

The per-character buffer in `encode_code_page_errors()` is enlarged from 4 to 16 bytes, because a single character encoded together with escape sequences is longer than that (up to 9 bytes in cp50220). Only code pages encoded with `dwFlags = 0` use more than 4 bytes per character.

```pycon
>>> codecs.code_page_encode(50220, 'あ')
(b'\x1b$B$"\x1b(B', 1)
>>> '[€]'.encode('cp50220', 'backslashreplace')
b'[\\u20ac]'
```


<!-- gh-issue-number: gh-155016 -->
* Issue: gh-155016
<!-- /gh-issue-number -->
