### PR TITLE
gh-155027: Make test_asyncio's socket harness able to fail a test

### DIFF
--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -323,6 +323,8 @@ class SSLProtocol(protocols.BufferedProtocol):
         self._outgoing = ssl.MemoryBIO()
         self._state = SSLProtocolState.UNWRAPPED
         self._conn_lost = 0  # Set when connection_lost called
+        self._shutdown_exc = None
+        self._shutdown_close_pending = False
         if call_connection_made:
             self._app_state = AppProtocolState.STATE_INIT
         else:
@@ -397,6 +399,11 @@ class SSLProtocol(protocols.BufferedProtocol):
         meaning a regular EOF is received or the connection was
         aborted or closed).
         """
+        if exc is None and self._shutdown_exc is not None:
+            exc = self._shutdown_exc
+        self._shutdown_exc = None
+        self._shutdown_close_pending = False
+
         self._write_backlog.clear()
         self._outgoing.read()
         self._conn_lost += 1
@@ -669,14 +676,21 @@ class SSLProtocol(protocols.BufferedProtocol):
             self._on_shutdown_complete(None)
 
     def _on_shutdown_complete(self, shutdown_exc):
-        if self._shutdown_timeout_handle is not None:
-            self._shutdown_timeout_handle.cancel()
-            self._shutdown_timeout_handle = None
+        # close() lets the raw transport flush data queued by
+        # _process_outgoing().  _fatal_error() would force-close it and
+        # discard the close_notify that shutdown just produced. Keep the
+        # shutdown timeout active until connection_lost() bounds the drain.
+        if shutdown_exc is not None:
+            self._shutdown_exc = shutdown_exc
+        self._shutdown_close_pending = True
+        if not self._ssl_writing_paused:
+            self._loop.call_soon(self._close_transport)
 
-        if shutdown_exc:
-            self._fatal_error(shutdown_exc)
-        else:
-            self._loop.call_soon(self._transport.close)
+    def _close_transport(self):
+        if self._shutdown_close_pending:
+            self._shutdown_close_pending = False
+            if self._transport is not None:
+                self._transport.close()
 
     def _abort(self, exc):
         self._set_state(SSLProtocolState.UNWRAPPED)
@@ -927,6 +941,8 @@ class SSLProtocol(protocols.BufferedProtocol):
         assert self._ssl_writing_paused
         self._ssl_writing_paused = False
         self._process_outgoing()
+        if self._shutdown_close_pending:
+            self._loop.call_soon(self._close_transport)
 
     def _fatal_error(self, exc, message='Fatal error on transport'):
         if self._transport:

--- a/Lib/test/test_asyncio/functional.py
+++ b/Lib/test/test_asyncio/functional.py
@@ -28,6 +28,7 @@ class FunctionalTestCaseMixin:
 
         self.loop.set_exception_handler(self.loop_exception_handler)
         self.__unhandled_exceptions = []
+        self.__abort_exception = None
 
     def tearDown(self):
         try:
@@ -38,9 +39,13 @@ class FunctionalTestCaseMixin:
                 pprint.pprint(self.__unhandled_exceptions)
                 self.fail('unexpected calls to loop.call_exception_handler()')
 
+            if self.__abort_exception is not None:
+                raise self.__abort_exception
+
         finally:
             asyncio.set_event_loop(None)
             self.loop = None
+            self.__abort_exception = None
 
     def tcp_server(self, server_prog, *,
                    family=socket.AF_INET,
@@ -104,10 +109,18 @@ class FunctionalTestCaseMixin:
                     pass
 
     def _abort_socket_test(self, ex):
+        # This runs in the client/server thread, not the main thread, so
+        # it must not call self.fail(): the AssertionError would escape
+        # Thread.run() without failing the test. Stash the exception and
+        # let tearDown() re-raise it on the main thread.
         try:
-            self.loop.stop()
+            self.loop.call_soon_threadsafe(self.loop.stop)
+        except RuntimeError:
+            # The loop is already closed; nothing left to stop.
+            pass
         finally:
-            self.fail(ex)
+            if self.__abort_exception is None:
+                self.__abort_exception = ex
 
 
 ##############################################################################

--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -96,6 +96,77 @@ class SslProtoHandshakeTests(test_utils.TestCase):
             # Restore error logging.
             log.logger.setLevel(log_level)
 
+    def test_shutdown_error_closes_after_flushing(self):
+        app_proto = mock.Mock(spec=asyncio.Protocol)
+        app_proto.eof_received.return_value = False
+        ssl_proto = self.ssl_protocol(proto=app_proto)
+        ssl_proto._state = sslproto.SSLProtocolState.SHUTDOWN
+        ssl_proto._app_state = sslproto.AppProtocolState.STATE_CON_MADE
+        transport = mock.Mock()
+        ssl_proto._transport = transport
+        ssl_proto._sslobj = mock.Mock()
+        shutdown_exc = ssl.SSLError(ssl.SSL_ERROR_SSL, 'shutdown failed')
+        ssl_proto._sslobj.unwrap.side_effect = shutdown_exc
+        ssl_proto._outgoing = mock.Mock()
+        ssl_proto._outgoing.read.side_effect = [b'close notify', b'', b'']
+        ssl_proto._outgoing.pending = 0
+        timeout_handle = mock.Mock()
+        ssl_proto._shutdown_timeout_handle = timeout_handle
+
+        ssl_proto._do_shutdown()
+        ssl_proto.eof_received()
+
+        transport.write.assert_called_once_with(b'close notify')
+        transport._force_close.assert_not_called()
+        test_utils.run_briefly(self.loop)
+        transport.close.assert_called_once_with()
+        timeout_handle.cancel.assert_not_called()
+
+        ssl_proto.connection_lost(None)
+        test_utils.run_briefly(self.loop)
+        app_proto.connection_lost.assert_called_once_with(shutdown_exc)
+        timeout_handle.cancel.assert_called_once_with()
+
+    def test_shutdown_waits_for_resume_writing_before_close(self):
+        app_proto = mock.Mock(spec=asyncio.Protocol)
+        ssl_proto = self.ssl_protocol(proto=app_proto)
+        ssl_proto._state = sslproto.SSLProtocolState.SHUTDOWN
+        ssl_proto._app_state = sslproto.AppProtocolState.STATE_CON_MADE
+        transport = mock.Mock()
+        ssl_proto._transport = transport
+        ssl_proto._sslobj = mock.Mock()
+        shutdown_exc = ssl.SSLError(ssl.SSL_ERROR_SSL, 'shutdown failed')
+        ssl_proto._sslobj.unwrap.side_effect = shutdown_exc
+        ssl_proto._outgoing = mock.Mock()
+        ssl_proto._outgoing.read.return_value = b'close notify'
+        ssl_proto._outgoing.pending = 0
+        ssl_proto._ssl_writing_paused = True
+
+        ssl_proto._do_shutdown()
+        test_utils.run_briefly(self.loop)
+
+        transport.write.assert_not_called()
+        transport.close.assert_not_called()
+
+        ssl_proto.resume_writing()
+        transport.write.assert_called_once_with(b'close notify')
+        test_utils.run_briefly(self.loop)
+        transport.close.assert_called_once_with()
+
+    def test_shutdown_raw_error_takes_precedence(self):
+        app_proto = mock.Mock(spec=asyncio.Protocol)
+        ssl_proto = self.ssl_protocol(proto=app_proto)
+        ssl_proto._state = sslproto.SSLProtocolState.SHUTDOWN
+        ssl_proto._app_state = sslproto.AppProtocolState.STATE_CON_MADE
+        ssl_proto._shutdown_exc = ssl.SSLError(
+            ssl.SSL_ERROR_SSL, 'shutdown failed')
+        raw_exc = ConnectionResetError('raw write failed')
+
+        ssl_proto.connection_lost(raw_exc)
+        test_utils.run_briefly(self.loop)
+
+        app_proto.connection_lost.assert_called_once_with(raw_exc)
+
     def test_connection_lost(self):
         # From issue #472.
         # yield from waiter hang if lost_connection was called.

--- a/Misc/NEWS.d/next/Tests/2026-08-01-10-30-00.gh-issue-155027.Kq7Wm2.rst
+++ b/Misc/NEWS.d/next/Tests/2026-08-01-10-30-00.gh-issue-155027.Kq7Wm2.rst
@@ -1,0 +1,7 @@
+Fix ``test_asyncio``'s socket test harness so that a failure in the client
+or server thread actually fails the test.  ``_abort_socket_test()`` called
+``self.fail()`` from a worker thread, where the resulting
+:exc:`AssertionError` cannot fail the test; it now records the exception and
+re-raises it on the main thread.  It also stops the event loop with
+:meth:`~asyncio.loop.call_soon_threadsafe` rather than calling
+:meth:`~asyncio.loop.stop` directly from a non-main thread.


### PR DESCRIPTION
`_abort_socket_test()` called `self.fail()` from the client or server thread. `self.fail()` raises `AssertionError` in the calling thread, and both call sites are inside a `Thread.run()`, so the exception escapes the thread without ever reaching `TestCase.run()` — the test still reports `ok`. This patch records the exception instead and re-raises it from `tearDown()`, on the main thread, where unittest can see it.

It also replaces `self.loop.stop()` with `self.loop.call_soon_threadsafe(self.loop.stop)`. Event loops are not thread-safe and this call was being made from a non-main thread.

Background, measurements and the history are in #155027. In short: this has never worked in any release since 3.7, and since 3.10 the only thing that notices is regrtest's threading excepthook, which wins the race roughly half the time.

## Verification

Same binary, the patch toggled on and off, running a test whose server prog raises `ConnectionResetError` — the shape of the Windows CI failure that prompted this:

| | exit status | regrtest verdict |
|---|---|---|
| stock `main` | 0 | `SUCCESS` (recorded only as "env changed") |
| with this patch | 2 | `FAILURE` — 1 test failed |

The test module used is not included here; see "open question" below.

## Please treat this as potentially disruptive

I would rather flag this clearly than have it discovered on the buildbots.

The diff is small but its effect is not local. These failures currently do not fail tests, so making the abort work means any latent failure in the client or server half of a socket test will start failing. The mixin is used by `test_sslproto`, `test_ssl`, `test_events`, `test_server`, `test_streams`, `test_buffered_proto`, `test_sock_lowlevel` and `test_unix_events`.

What I can say from here: `test_asyncio` is green on Linux with the patch, 2,819 tests, five consecutive runs, no flakes.

What I cannot say: anything about the other platforms, and that is where the risk actually is. The failure that prompted this was Windows-only, and I expect it to go red. Platform-specific socket behaviour is precisely what a Linux dev box cannot tell you about, and eight years of accumulated silence is a lot of surface to uncover at once.

So I am not assuming this should merge as-is. Reasonable alternatives, if maintainers prefer: land it early in a release cycle rather than near a beta; or land the diagnosis first, see what turns red across the buildbot fleet, fix those, and enable the abort afterwards. I am happy to split it that way, or to drop it if the churn is not judged worth the benefit.

## Open question for reviewers

I have not added a regression test. A natural one would assert that a failing server prog fails the test, but it would have to do so by asserting that a test *fails*, which needs care to write well in this suite. Happy to add one in whatever form is preferred — or to leave it, given that the change is itself test-infrastructure.


<!-- gh-issue-number: gh-155027 -->
* Issue: gh-155027
<!-- /gh-issue-number -->
