### PR TITLE
gh-151138: Correct documented `tempfile` Windows temp directory search order

### DIFF
--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -348,8 +348,9 @@ The module defines the following user-callable items:
 
    #. A platform-specific location:
 
-      * On Windows, the directories :file:`C:\\TEMP`, :file:`C:\\TMP`,
-        :file:`\\TEMP`, and :file:`\\TMP`, in that order.
+      * On Windows, the directories :file:`{USERPROFILE}\\AppData\\Local\\Temp`,
+        :file:`{SYSTEMROOT}\\Temp`, :file:`c:\\temp`, :file:`c:\\tmp`,
+        :file:`\\temp`, and :file:`\\tmp`, in that order.
 
       * On all other platforms, the directories :file:`/tmp`, :file:`/var/tmp`, and
         :file:`/usr/tmp`, in that order.


### PR DESCRIPTION
## Problem

The `tempfile.gettempdir()` docs incorrectly document the Windows temp directory search order.

Current docs claim:
```
C:\TEMP, C:\TMP, \TEMP, \TMP
```

Actual implementation (`Lib/tempfile.py` lines 192-194):
```python
for envname in 'TMPDIR', 'TEMP', 'TMP':
    dirname = os.getenv(envname)
    if dirname: return dirname
```

On Windows, `TEMP` and `TMP` env vars point to `%USERPROFILE%\AppData\Local\Temp` (user temp) and `%SYSTEMROOT%\Temp` (system temp), not the hardcoded paths the docs claim.

Fixes #151138.

## Fix

Update `Doc/library/tempfile.rst` to document the correct search order:
```
{USERPROFILE}\AppData\Local\Temp
{SYSTEMROOT}\Temp
c:	emp, c:	mp, 	emp, 	mp
```

This reflects actual runtime behavior: environment variables first, then hardcoded fallback paths.

## Test

Documentation-only change. Verified docs build with `make html`.