### PR TITLE
gh-84291: Clarify Pool.imap documentation

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2538,7 +2538,7 @@ with the :class:`Pool` class.
 
    .. method:: imap(func, iterable, chunksize=1, *, buffersize=None)
 
-      A lazier version of :meth:`.map`.
+      An iterator-based version of :meth:`.map`.
 
       The *chunksize* argument is the same as the one used by the :meth:`.map`
       method.  For very long iterables using a large value for *chunksize* can


### PR DESCRIPTION
Clarify that `Pool.imap()` is an iterator-based version of `Pool.map()`, rather than describing it as unconditionally lazy.

Without an explicit `buffersize`, `imap()` can consume its input eagerly; `buffersize` controls how far input consumption proceeds ahead of yielded results.

Closes #84291.

<!-- gh-issue-number: gh-84291 -->
* Issue: gh-84291
<!-- /gh-issue-number -->
