### PR TITLE
gh-155031: repass permission errors on subprocesses to parent / user

### DIFF
--- a/Lib/profiling/sampling/__main__.py
+++ b/Lib/profiling/sampling/__main__.py
@@ -58,13 +58,13 @@ def handle_permission_error():
         print(WINDOWS_PERMISSION_ERROR, file=sys.stderr)
     else:
         print(GENERIC_PERMISSION_ERROR, file=sys.stderr)
-    sys.exit(1)
 
 if __name__ == '__main__':
     try:
         main()
     except PermissionError:
         handle_permission_error()
+        sys.exit(1)
     except SamplingUnknownProcessError as err:
         print(f"Tachyon cannot find the process: {err}", file=sys.stderr)
         sys.exit(1)

--- a/Lib/profiling/sampling/_child_monitor.py
+++ b/Lib/profiling/sampling/_child_monitor.py
@@ -237,7 +237,6 @@ class ChildProcessMonitor:
                 cmd,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
             )
             with self._lock:
                 if self._stop_event.is_set():

--- a/Misc/NEWS.d/next/Library/2026-08-01-10-54-39.gh-issue-155031.sTB_n8.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-01-10-54-39.gh-issue-155031.sTB_n8.rst
@@ -1,0 +1,2 @@
+Propagate to user any permission errors from subprocess attach commands in
+Tachyon


### PR DESCRIPTION
These changes enable issues with permissions that happen while using the `--subprocesses` option on the 'run' method to propagate back, giving the user an indication of what went wrong. Previously, it would just silently fail, not giving the user a hint of what happened wrong.


<!-- gh-issue-number: gh-155031 -->
* Issue: gh-155031
<!-- /gh-issue-number -->
