### PR TITLE
gh-154942: Refresh statistics.kde cache after same-length data changes

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -1060,24 +1060,27 @@ def kde(data, h, kernel='normal', *, cumulative=False):
 
     else:
 
-        sample = sorted(data)
+        data_snapshot = tuple(data)
+        sample = sorted(data_snapshot)
         bandwidth = h * support
 
+        def refresh():
+            nonlocal n, data_snapshot, sample
+            updated_data = tuple(data)
+            if updated_data != data_snapshot:
+                data_snapshot = updated_data
+                sample = sorted(updated_data)
+                n = len(updated_data)
+
         def pdf(x):
-            nonlocal n, sample
-            if len(data) != n:
-                sample = sorted(data)
-                n = len(data)
+            refresh()
             i = bisect_left(sample, x - bandwidth)
             j = bisect_right(sample, x + bandwidth)
             supported = sample[i : j]
             return sum(K((x - x_i) / h) for x_i in supported) / (n * h)
 
         def cdf(x):
-            nonlocal n, sample
-            if len(data) != n:
-                sample = sorted(data)
-                n = len(data)
+            refresh()
             i = bisect_left(sample, x - bandwidth)
             j = bisect_right(sample, x + bandwidth)
             supported = sample[i : j]

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -2428,6 +2428,14 @@ class TestKDE(unittest.TestCase):
         data.append(100)
         self.assertGreater(f_hat(100), 0.0)
 
+        for cumulative in (False, True):
+            with self.subTest(cumulative=cumulative):
+                data = [1, 2, 3]
+                estimate = kde(data, 1.0, 'triangular', cumulative=cumulative)
+                data[0] = 5
+                expected = kde(data, 1.0, 'triangular', cumulative=cumulative)
+                self.assertEqual(estimate(1.5), expected(1.5))
+
     def test_kde_kernel_specs(self):
         # White-box test for the kernel formulas in isolation from
         # their downstream use in kde() and kde_random()

--- a/Misc/NEWS.d/next/Library/2026-08-01-23-30-00.gh-issue-154942.mF8QvS.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-01-23-30-00.gh-issue-154942.mF8QvS.rst
@@ -1,0 +1,2 @@
+Fix :func:`statistics.kde` with a bounded-support kernel to refresh its cached
+sample when the contents of the input data change without changing its length.


### PR DESCRIPTION
Fixes #154942.

`statistics.kde()` now detects changes to the contents of mutable data sequences for bounded-support kernels. Previously, its sorted sample cache was refreshed only when the sequence length changed, so replacing a value without changing the length could produce a stale estimate.

The bounded-support path now compares the current data with a tuple snapshot and rebuilds the sorted sample only when the contents change. This preserves online updates while keeping bounded- and unbounded-support kernels consistent.

The statistics test suite passes, including new regression coverage for PDF and CDF estimates after a same-length value replacement.


<!-- gh-issue-number: gh-154942 -->
* Issue: gh-154942
<!-- /gh-issue-number -->
