### PR TITLE
gh-155013: Reword a reference to `partial object` in functools

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -386,9 +386,9 @@ The :mod:`!functools` module defines the following functions:
    only one positional argument is provided, but there are two placeholders
    that must be filled in.
 
-   If :func:`!partial` is applied to an existing :func:`!partial` object,
-   :data:`!Placeholder` sentinels of the input object are filled in with
-   new positional arguments.
+   If :func:`!partial` is applied to an existing
+   :ref:`partial object<partial-objects>`, :data:`!Placeholder` sentinels of the
+   input object are filled in with new positional arguments.
    A placeholder can be retained by inserting a new
    :data:`!Placeholder` sentinel to the place held by a previous :data:`!Placeholder`:
 

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -387,7 +387,7 @@ The :mod:`!functools` module defines the following functions:
    that must be filled in.
 
    If :func:`!partial` is applied to an existing
-   :ref:`partial object<partial-objects>`, :data:`!Placeholder` sentinels of the
+   :ref:`partial object <partial-objects>`, :data:`!Placeholder` sentinels of the
    input object are filled in with new positional arguments.
    A placeholder can be retained by inserting a new
    :data:`!Placeholder` sentinel to the place held by a previous :data:`!Placeholder`:


### PR DESCRIPTION
Rather than referring to a `` :func:`!partial` object``, use a reference to the definition of a "partial object", provided as a part of the functools docs.

This results in two linked references from `functools.partial` docs to `partial object`, as there is another one at the top of the docstring.
However, the doc is sufficiently long that this second link is likely to be beneficial to a reader.


<!-- gh-issue-number: gh-155013 -->
* Issue: gh-155013
<!-- /gh-issue-number -->
