### PR TITLE
[3.15] gh-110128: Ignore a truncated final row in csv.Sniffer

### DIFF
--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -368,7 +368,11 @@ class Sniffer:
         """
         from collections import Counter, defaultdict
 
-        data = list(filter(None, data.split('\n')))
+        lines = data.split('\n')
+        if len(lines) > 1 and not data.endswith(('\r', '\n')):
+            # The sample may have been cut off in the middle of the last row.
+            lines.pop()
+        data = list(filter(None, lines))
 
         # build frequency tables
         chunkLength = min(10, len(data))

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1563,6 +1563,22 @@ ghi\0jkl
         with self.assertRaisesRegex(csv.Error, "Could not determine delimiter"):
             sniffer.sniff(sample)
 
+    def test_sniff_truncated_sample(self):
+        sniffer = csv.Sniffer()
+        # A single row without a line terminator is complete enough to sniff.
+        self.assertEqual(sniffer.sniff("a,b").delimiter, ",")
+
+        # The last row may have been cut off in the middle of the sample.
+        for lineterminator in ("\n", "\r\n"):
+            with self.subTest(lineterminator=lineterminator):
+                sample = lineterminator.join((
+                    "a,b,c",
+                    "d,e,f",
+                    "g,h,i",
+                    "j,k",
+                ))
+                self.assertEqual(sniffer.sniff(sample).delimiter, ",")
+
 
 class NUL:
     def write(s, *args):

--- a/Misc/NEWS.d/next/Library/2026-07-31-20-00-00.gh-issue-110128.tRuNc8.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-31-20-00-00.gh-issue-110128.tRuNc8.rst
@@ -1,0 +1,2 @@
+Fix :meth:`csv.Sniffer.sniff` failing to detect the delimiter when a sample
+is truncated in the middle of its final row.


### PR DESCRIPTION
Fixes #110128.

When a sample is truncated in the middle of its final row, the incomplete row can distort the character-frequency table used by `_guess_delimiter()` and cause `Sniffer.sniff()` to raise `csv.Error`.

This change excludes the final physical row from delimiter detection when the sample contains multiple rows and does not end with `\r` or `\n`. A single unterminated row remains usable.

The handling is intentionally kept within the existing `_guess_delimiter()` row preparation, making this a targeted maintenance-branch fix without changing the delimiter-detection algorithm. It mirrors the `cut and len(rows) > 1` behavior of the rewritten Sniffer in Python 3.16. If maintainers would prefer the truncation handling at a different level, I’m happy to adjust the implementation.

Tests cover:

- single-row samples without a trailing newline;
- truncated samples with LF line endings;
- truncated samples with CRLF line endings.

<!-- gh-issue-number: gh-110128 -->
* Issue: gh-110128
<!-- /gh-issue-number -->
