### PR TITLE
gh-155040: Support copy.replace() for tarfile.TarInfo

### DIFF
--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -966,7 +966,7 @@ A ``TarInfo`` object has the following public data attributes:
    This method is also used by :func:`copy.replace`.
 
    .. versionchanged:: next
-      Added support of :func:`copy.replace`.
+      Added support for :func:`copy.replace`.
 
 A :class:`TarInfo` object also provides some convenient query methods:
 

--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -963,6 +963,11 @@ A ``TarInfo`` object has the following public data attributes:
    If *deep* is false, the copy is shallow, i.e. ``pax_headers``
    and any custom attributes are shared with the original ``TarInfo`` object.
 
+   This method is also used by :func:`copy.replace`.
+
+   .. versionchanged:: next
+      Added support of :func:`copy.replace`.
+
 A :class:`TarInfo` object also provides some convenient query methods:
 
 

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1036,6 +1036,8 @@ class TarInfo(object):
             result.gname = gname
         return result
 
+    __replace__ = replace
+
     def get_info(self):
         """Return the TarInfo's attributes as a dictionary.
         """

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1,3 +1,4 @@
+import copy
 import errno
 import sys
 import os
@@ -3523,6 +3524,16 @@ class ReplaceTests(ReadTest, unittest.TestCase):
         member = self.tar.getmember('ustar/regtype')
         with self.assertRaises(TypeError):
             member.replace(offset=123456789)
+
+    def test_copy_replace(self):
+        member = self.tar.getmember('ustar/regtype')
+        replaced = copy.replace(member, name='misc/other', mode=0o644)
+        self.assertEqual(replaced.name, 'misc/other')
+        self.assertEqual(replaced.mode, 0o644)
+        self.assertEqual(replaced.size, member.size)
+        self.assertEqual(member.name, 'ustar/regtype')
+        with self.assertRaises(TypeError):
+            copy.replace(member, offset=123456789)
 
 
 class NoneInfoExtractTests(ReadTest):

--- a/Misc/NEWS.d/next/Library/2026-08-01-19-01-00.gh-issue-155040.Tr1nFo.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-01-19-01-00.gh-issue-155040.Tr1nFo.rst
@@ -1,0 +1,1 @@
+:class:`tarfile.TarInfo` objects now support :func:`copy.replace`.


### PR DESCRIPTION
Add `TarInfo.__replace__` as an alias of the existing `TarInfo.replace()`.

<!-- gh-issue-number: gh-155040 -->
* Issue: gh-155040
<!-- /gh-issue-number -->
