### PR TITLE
gh-155042: Support copy.replace() for email.policy.Policy

### DIFF
--- a/Doc/library/email.policy.rst
+++ b/Doc/library/email.policy.rst
@@ -257,7 +257,7 @@ added matters.  To illustrate::
       This method is also used by :func:`copy.replace`.
 
       .. versionchanged:: next
-         Added support of :func:`copy.replace`.
+         Added support for :func:`copy.replace`.
 
 
    The remaining :class:`Policy` methods are called by the email package code,

--- a/Doc/library/email.policy.rst
+++ b/Doc/library/email.policy.rst
@@ -254,6 +254,11 @@ added matters.  To illustrate::
       values as the current instance, except where those attributes are
       given new values by the keyword arguments.
 
+      This method is also used by :func:`copy.replace`.
+
+      .. versionchanged:: next
+         Added support of :func:`copy.replace`.
+
 
    The remaining :class:`Policy` methods are called by the email package code,
    and are not intended to be called by an application using the email package.

--- a/Lib/email/_policybase.py
+++ b/Lib/email/_policybase.py
@@ -84,6 +84,8 @@ class _PolicyBase:
             object.__setattr__(newpolicy, attr, value)
         return newpolicy
 
+    __replace__ = clone
+
     def __setattr__(self, name, value):
         if hasattr(self, name):
             msg = "{!r} object attribute {!r} is read-only"

--- a/Lib/test/test_email/test_policy.py
+++ b/Lib/test/test_email/test_policy.py
@@ -1,3 +1,4 @@
+import copy
 import io
 import types
 import textwrap
@@ -253,6 +254,16 @@ class PolicyAPITests(unittest.TestCase):
         self.assertIsInstance(h, self.Foo)
         h = policy2.header_factory('foo', 'test')
         self.assertIsInstance(h, self.Foo)
+
+    def test_copy_replace(self):
+        policy = email.policy.default
+        new = copy.replace(policy, max_line_length=100)
+        self.assertIsInstance(new, type(policy))
+        self.assertEqual(new.max_line_length, 100)
+        self.assertEqual(new.linesep, policy.linesep)
+        self.assertEqual(policy.max_line_length, 78)
+        with self.assertRaises(TypeError):
+            copy.replace(policy, no_such_attribute=1)
 
     def test_new_factory_overrides_default(self):
         mypolicy = email.policy.EmailPolicy()

--- a/Misc/NEWS.d/next/Library/2026-08-01-19-03-00.gh-issue-155042.Em1Pol.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-01-19-03-00.gh-issue-155042.Em1Pol.rst
@@ -1,0 +1,1 @@
+:class:`email.policy.Policy` objects now support :func:`copy.replace`.


### PR DESCRIPTION
Add `Policy.__replace__` as an alias of the existing `Policy.clone()`.

<!-- gh-issue-number: gh-155042 -->
* Issue: gh-155042
<!-- /gh-issue-number -->
