### PR TITLE
gh-155044: Support copy.replace() for optparse.Values

### DIFF
--- a/Doc/library/optparse.rst
+++ b/Doc/library/optparse.rst
@@ -1077,7 +1077,7 @@ As you can see, most actions involve storing or updating a value somewhere.
    which returns a copy of the object with the specified attributes replaced.
 
    .. versionchanged:: next
-      Added support of :func:`copy.replace`.
+      Added support for :func:`copy.replace`.
 
 Option
 arguments (and various other values) are stored as attributes of this object,

--- a/Doc/library/optparse.rst
+++ b/Doc/library/optparse.rst
@@ -1073,6 +1073,12 @@ As you can see, most actions involve storing or updating a value somewhere.
    and can be overridden by a custom subclass passed to the *values* argument of
    :meth:`OptionParser.parse_args` (as described in :ref:`optparse-parsing-arguments`).
 
+   :class:`!Values` objects support :func:`copy.replace`,
+   which returns a copy of the object with the specified attributes replaced.
+
+   .. versionchanged:: next
+      Added support of :func:`copy.replace`.
+
 Option
 arguments (and various other values) are stored as attributes of this object,
 according to the :attr:`~Option.dest` (destination) option attribute.

--- a/Lib/optparse.py
+++ b/Lib/optparse.py
@@ -830,6 +830,12 @@ class Values:
         else:
             return NotImplemented
 
+    def __replace__(self, /, **changes):
+        new = self.__class__()
+        new.__dict__.update(self.__dict__)
+        new.__dict__.update(changes)
+        return new
+
     def _update_careful(self, dict):
         """
         Update the option values from an arbitrary dictionary, but only

--- a/Lib/test/test_optparse.py
+++ b/Lib/test/test_optparse.py
@@ -434,6 +434,13 @@ class TestOptionValues(BaseTest):
         self.assertNotEqual(values, "")
         self.assertNotEqual(values, [])
 
+    def test_replace(self):
+        values = Values(defaults={"foo": "bar", "baz": 42})
+        new = copy.replace(values, baz=43, spam="eggs")
+        self.assertIsInstance(new, Values)
+        self.assertEqual(vars(new), {"foo": "bar", "baz": 43, "spam": "eggs"})
+        self.assertEqual(vars(values), {"foo": "bar", "baz": 42})
+
 
 class TestTypeAliases(BaseTest):
     def setUp(self):

--- a/Misc/NEWS.d/next/Library/2026-08-01-19-05-00.gh-issue-155044.Op1Val.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-01-19-05-00.gh-issue-155044.Op1Val.rst
@@ -1,0 +1,1 @@
+:class:`optparse.Values` objects now support :func:`copy.replace`.


### PR DESCRIPTION
Add `Values.__replace__()`, with the same semantics as `types.SimpleNamespace.__replace__()`.

<!-- gh-issue-number: gh-155044 -->
* Issue: gh-155044
<!-- /gh-issue-number -->
