### PR TITLE
gh-155053: Fix GenericAlias crash on OOM

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -97,6 +97,7 @@ _UNPACKED_TUPLES = [
     tuple[*tuple[Unpack[tuple[int, ...]]]],
 ]
 
+
 class BaseTest(unittest.TestCase):
     """Test basics."""
     generic_types = [type, tuple, list, dict, frozendict,

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -1,6 +1,8 @@
 """Tests for C-implemented GenericAlias."""
 
 import unittest
+from test import support
+from test.support import import_helper
 import pickle
 from array import array
 import copy
@@ -62,10 +64,11 @@ except ImportError:
 from string.templatelib import Template, Interpolation
 
 import typing
-from typing import TypeVar, Unpack
+from typing import TypeVar, TypeVarTuple, Unpack
 T = TypeVar('T')
 K = TypeVar('K')
 V = TypeVar('V')
+Ts = TypeVarTuple("Ts")
 
 _UNPACKED_TUPLES = [
     # Unpacked tuple using `*`
@@ -97,6 +100,7 @@ _UNPACKED_TUPLES = [
     tuple[*tuple[Unpack[tuple[int, ...]]]],
 ]
 
+_testcapi = import_helper.import_module("_testcapi")
 
 class BaseTest(unittest.TestCase):
     """Test basics."""
@@ -627,6 +631,29 @@ class BaseTest(unittest.TestCase):
                 x = container[TypeVar("")]
                 with self.assertRaises(TypeError):
                     x[*typing.Mapping[..., ...]]
+
+    @support.nomemtest
+    def test_subs_tvars_nomemory(self):
+        alias = dict[str, tuple[*Ts]]
+        key = (int, str)
+
+        # Warm the code path to stabilize the allocation window.
+        # This injection point was determined experimentally for this build.
+        try:
+            dict[str, tuple[int, str]]
+        except Exception:
+            pass
+
+        _testcapi.set_nomemory(24, 25)
+        raised = False
+        try:
+            alias[key]
+        except MemoryError:
+            raised = True
+        finally:
+            _testcapi.remove_mem_hooks()
+
+        self.assertTrue(raised, "MemoryError not raised")
 
 
 class TypeIterationTests(unittest.TestCase):

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -1,8 +1,6 @@
 """Tests for C-implemented GenericAlias."""
 
 import unittest
-from test import support
-from test.support import import_helper
 import pickle
 from array import array
 import copy
@@ -64,11 +62,10 @@ except ImportError:
 from string.templatelib import Template, Interpolation
 
 import typing
-from typing import TypeVar, TypeVarTuple, Unpack
+from typing import TypeVar, Unpack
 T = TypeVar('T')
 K = TypeVar('K')
 V = TypeVar('V')
-Ts = TypeVarTuple("Ts")
 
 _UNPACKED_TUPLES = [
     # Unpacked tuple using `*`
@@ -99,8 +96,6 @@ _UNPACKED_TUPLES = [
     tuple[Unpack[tuple[*tuple[int, ...]]]],
     tuple[*tuple[Unpack[tuple[int, ...]]]],
 ]
-
-_testcapi = import_helper.import_module("_testcapi")
 
 class BaseTest(unittest.TestCase):
     """Test basics."""
@@ -631,29 +626,6 @@ class BaseTest(unittest.TestCase):
                 x = container[TypeVar("")]
                 with self.assertRaises(TypeError):
                     x[*typing.Mapping[..., ...]]
-
-    @support.nomemtest
-    def test_subs_tvars_nomemory(self):
-        alias = dict[str, tuple[*Ts]]
-        key = (int, str)
-
-        # Warm the code path to stabilize the allocation window.
-        # This injection point was determined experimentally for this build.
-        try:
-            dict[str, tuple[int, str]]
-        except Exception:
-            pass
-
-        _testcapi.set_nomemory(24, 25)
-        raised = False
-        try:
-            alias[key]
-        except MemoryError:
-            raised = True
-        finally:
-            _testcapi.remove_mem_hooks()
-
-        self.assertTrue(raised, "MemoryError not raised")
 
 
 class TypeIterationTests(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-01-19-17-56.gh-issue-155053.sxmlTO.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-01-19-17-56.gh-issue-155053.sxmlTO.rst
@@ -1,2 +1,2 @@
-Fix a crash in :class:`types.GenericAlias` when ``tuple_extend()`` fails
-during substitution of a ``TypeVarTuple`` under allocation failure.
+Fix a crash in :class:`types.GenericAlias` during substitution of a
+``TypeVarTuple`` under allocation failure.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-01-19-17-56.gh-issue-155053.sxmlTO.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-01-19-17-56.gh-issue-155053.sxmlTO.rst
@@ -1,0 +1,2 @@
+Fix a crash in :class:`types.GenericAlias` when ``tuple_extend()`` fails
+during substitution of a ``TypeVarTuple`` under allocation failure.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -302,8 +302,8 @@ subs_tvars(PyObject *obj, PyObject *params,
                                     PyTuple_GET_SIZE(arg));
                     if (j < 0) {
                         Py_DECREF(subparams);
-                        /* tuple_extend() clears subargs on failure, so there is no
-                           reference left to decref here. */
+                        assert(subargs == NULL);
+                        /* tuple_extend() clears subargs on failure. */
                         return NULL;
                     }
                     continue;

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -302,8 +302,8 @@ subs_tvars(PyObject *obj, PyObject *params,
                                     PyTuple_GET_SIZE(arg));
                     if (j < 0) {
                         Py_DECREF(subparams);
-                        assert(subargs == NULL);
                         /* tuple_extend() clears subargs on failure. */
+                        assert(subargs == NULL);
                         return NULL;
                     }
                     continue;

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -302,6 +302,8 @@ subs_tvars(PyObject *obj, PyObject *params,
                                     PyTuple_GET_SIZE(arg));
                     if (j < 0) {
                         Py_DECREF(subparams);
+                        /* tuple_extend() clears subargs on failure, so there is no
+                           reference left to decref here. */
                         return NULL;
                     }
                     continue;

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -302,7 +302,6 @@ subs_tvars(PyObject *obj, PyObject *params,
                                     PyTuple_GET_SIZE(arg));
                     if (j < 0) {
                         Py_DECREF(subparams);
-                        Py_DECREF(subargs);
                         return NULL;
                     }
                     continue;


### PR DESCRIPTION
## Summary

Fix a NULL dereference in `Objects/genericaliasobject.c` when `tuple_extend()`
fails during `TypeVarTuple` substitution under allocation failure.

When `_PyTuple_Resize()` fails, it clears its out-parameter, so `subargs`
becomes `NULL`. The error path in `subs_tvars()` must not call
`Py_DECREF(subargs)` and should instead propagate the `MemoryError`.

Also add a regression test covering the allocation-failure path using
`_testcapi.set_nomemory()` to ensure a `MemoryError` is raised instead of
crashing the interpreter.

Issue: gh-155053