### PR TITLE
gh-155052: Fix docstring of decimal.Context.copy

### DIFF
--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -1696,12 +1696,12 @@ _decimal.Context.copy
 
     cls: defining_class
 
-Return a duplicate of the context with all flags cleared.
+Return a duplicate of the context.
 [clinic start generated code]*/
 
 static PyObject *
 _decimal_Context_copy_impl(PyObject *self, PyTypeObject *cls)
-/*[clinic end generated code: output=31c9c8eeb0c0cf77 input=aef1c0bddabdf8f0]*/
+/*[clinic end generated code: output=31c9c8eeb0c0cf77 input=87f8b92b1c7462a5]*/
 {
     decimal_state *state = PyType_GetModuleState(cls);
 

--- a/Modules/_decimal/clinic/_decimal.c.h
+++ b/Modules/_decimal/clinic/_decimal.c.h
@@ -7100,4 +7100,4 @@ exit:
 #ifndef _DECIMAL_CONTEXT_APPLY_METHODDEF
     #define _DECIMAL_CONTEXT_APPLY_METHODDEF
 #endif /* !defined(_DECIMAL_CONTEXT_APPLY_METHODDEF) */
-/*[clinic end generated code: output=07ec694c7fd6b048 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=718b1f6c20412350 input=a9049054013a1b77]*/

--- a/Modules/_decimal/clinic/_decimal.c.h
+++ b/Modules/_decimal/clinic/_decimal.c.h
@@ -371,7 +371,7 @@ PyDoc_STRVAR(_decimal_Context_copy__doc__,
 "copy($self, /)\n"
 "--\n"
 "\n"
-"Return a duplicate of the context with all flags cleared.");
+"Return a duplicate of the context.");
 
 #define _DECIMAL_CONTEXT_COPY_METHODDEF    \
     {"copy", _PyCFunction_CAST(_decimal_Context_copy), METH_METHOD|METH_FASTCALL|METH_KEYWORDS, _decimal_Context_copy__doc__},


### PR DESCRIPTION
## Summary

Update the Argument Clinic docstring for `decimal.Context.copy()` to match its actual behavior and the existing library documentation.

The previous docstring incorrectly stated that flags are cleared, while `Context.copy()` preserves them. Since `__copy__()` and `__reduce__()` share the same Argument Clinic input, their docstrings are updated as well.

Closes issue gh-155052
