### PR TITLE
gh-89024: Document the 3.10 change in escaping the csv escapechar

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -481,6 +481,10 @@ Dialects support the following attributes:
    On reading, the *escapechar* removes any special meaning from
    the following character. It defaults to :const:`None`, which disables escaping.
 
+   .. versionchanged:: 3.10
+      Previously the *escapechar* itself was not escaped,
+      which lost it on reading.
+
    .. versionchanged:: 3.11
       An empty *escapechar* is not allowed.
 


### PR DESCRIPTION
Since 3.10 (bpo-12178) the writer escapes the *escapechar* occurring in a field instead of quoting the field. The current rule is already documented as the third bullet of `Dialect.escapechar`; this only dates it and says what it replaced.

<!-- gh-issue-number: gh-89024 -->
* Issue: gh-89024
<!-- /gh-issue-number -->
