### PR TITLE
gh-80678: Document the preferred attribute of csv.Sniffer

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -324,8 +324,8 @@ The :mod:`!csv` module defines the following classes:
 
       If several combinations fit the sample equally well ---
       for example if both ``','`` and ``';'`` split every row consistently ---
-      the delimiters ``','``, ``'\t'``, ``';'``, ``' '`` and ``':'``
-      are preferred, in this order,
+      the delimiters listed in the :attr:`~Sniffer.preferred` attribute
+      are preferred, in that order,
       no matter how many times each of them occurs.
 
       .. versionchanged:: next
@@ -353,6 +353,15 @@ The :mod:`!csv` module defines the following classes:
 
       This method is a rough heuristic and may produce both false positives and
       negatives.
+
+   The :class:`Sniffer` class has the following attribute:
+
+   .. attribute:: preferred
+
+      The list of the delimiters preferred for breaking ties,
+      in the order of preference.
+      It can be modified.
+      Its initial value is ``[',', '\t', ';', ' ', ':']``.
 
 An example for :class:`Sniffer` use::
 


### PR DESCRIPTION
The `preferred` attribute is public, and assigning to it changes the order in which the delimiters are preferred for breaking ties. `sniff()` now refers to it instead of repeating the list of characters.

<!-- gh-issue-number: gh-80678 -->
* Issue: gh-80678
<!-- /gh-issue-number -->
