### PR TITLE
gh-155003: Don't try to close mmap in SharedMemory.__del__

### DIFF
--- a/Lib/multiprocessing/shared_memory.py
+++ b/Lib/multiprocessing/shared_memory.py
@@ -186,7 +186,7 @@ class SharedMemory:
 
     def __del__(self):
         try:
-            self.close()
+            self._closefd()
         except OSError:
             pass
 
@@ -222,6 +222,11 @@ class SharedMemory:
         "Size in bytes."
         return self._size
 
+    def _closefd(self):
+        if _USE_POSIX and self._fd >= 0:
+            os.close(self._fd)
+            self._fd = -1
+
     def close(self):
         """Closes access to the shared memory from this instance but does
         not destroy the shared memory block."""
@@ -231,9 +236,7 @@ class SharedMemory:
         if self._mmap is not None:
             self._mmap.close()
             self._mmap = None
-        if _USE_POSIX and self._fd >= 0:
-            os.close(self._fd)
-            self._fd = -1
+        self._closefd()
 
     def unlink(self):
         """Requests that the underlying shared memory block be destroyed.

--- a/Misc/NEWS.d/next/Library/2026-08-02-08-43-20.gh-issue-155003.VVy9Z_.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-02-08-43-20.gh-issue-155003.VVy9Z_.rst
@@ -1,0 +1,2 @@
+Fix an error in the finalizer of :class:`multiprocessing.shared_memory.SharedMemory`
+which could leak a file descriptor.


### PR DESCRIPTION
This is an alternative to #155007, keeping the file descriptor in the object and fixing the `__del__` method to close it without trying to close the mmap or memoryview, which was my original idea in #155003.

I could add, in this PR or separately:

- The same `posix_fallocate()` change as in #155007 - but with this option it's orthogonal.
- A public API to access the fd, probably a `.fileno()` method, which is a convention for higher level objects which wrap an fd.
- Use `mmap(..., trackfd=False)` to skip the duplicate fd within mmap (at a cost of breaking potential workarounds using `sm._mmap.resize()` & `.size()`)

<!-- gh-issue-number: gh-155003 -->
* Issue: gh-155003
<!-- /gh-issue-number -->
