### PR TITLE
[3.14] gh-154902: Type-check the SET_ADD operand

### DIFF
--- a/Lib/test/test_type_annotations.py
+++ b/Lib/test/test_type_annotations.py
@@ -1,5 +1,6 @@
 import annotationlib
 import inspect
+import itertools
 import textwrap
 import types
 import unittest
@@ -896,3 +897,18 @@ class RegressionTests(unittest.TestCase):
                 mod = build_module(code)
                 annos = mod.__annotations__
                 self.assertEqual(annos, {"annotated_name": 0})
+
+    # gh-154902
+    def test_conditional_annotations_rebound(self):
+        # user code can rebind __conditional_annotations__ to any object
+        lefts = ("__conditional_annotations__",
+                 'globals()["__conditional_annotations__"]')
+        values = ("0", "{}", "[]", "''", "object()", "frozenset()")
+        for left, value in itertools.product(lefts, values):
+            with self.subTest(left=left, value=value):
+                code = f"""
+                    {left} = {value}
+                    x: int
+                """
+                with self.assertRaises(TypeError):
+                    run_code(code)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-02-11-47-15.gh-issue-154902.DIi6sf.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-02-11-47-15.gh-issue-154902.DIi6sf.rst
@@ -1,0 +1,2 @@
+Fix a crash when ``__conditional_annotations__`` is rebound to a non-set
+object.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1056,7 +1056,16 @@ dummy_func(
         }
 
         inst(SET_ADD, (set, unused[oparg-1], v -- set, unused[oparg-1])) {
-            int err = _PySet_AddTakeRef((PySetObject *)PyStackRef_AsPyObjectBorrow(set),
+            PyObject *set_o = PyStackRef_AsPyObjectBorrow(set);
+            // gh-154902: user code can rebind __conditional_annotations__
+            if (!PySet_Check(set_o)) {
+                _PyErr_Format(tstate, PyExc_TypeError,
+                              "__conditional_annotations__ must be a set, not %T",
+                              set_o);
+                PyStackRef_CLOSE(v);
+                ERROR_IF(true);
+            }
+            int err = _PySet_AddTakeRef((PySetObject *)set_o,
                                         PyStackRef_AsPyObjectSteal(v));
             ERROR_IF(err);
         }

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1058,10 +1058,9 @@ dummy_func(
         inst(SET_ADD, (set, unused[oparg-1], v -- set, unused[oparg-1])) {
             PyObject *set_o = PyStackRef_AsPyObjectBorrow(set);
             // gh-154902: user code can rebind __conditional_annotations__
-            if (!PySet_Check(set_o)) {
+            if (!PySet_CheckExact(set_o)) {
                 _PyErr_Format(tstate, PyExc_TypeError,
-                              "__conditional_annotations__ must be a set, not %T",
-                              set_o);
+                              "'%T' object is not a set", set_o);
                 PyStackRef_CLOSE(v);
                 ERROR_IF(true);
             }

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1610,11 +1610,10 @@
             v = stack_pointer[-1];
             set = stack_pointer[-2 - (oparg-1)];
             PyObject *set_o = PyStackRef_AsPyObjectBorrow(set);
-            if (!PySet_Check(set_o)) {
+            if (!PySet_CheckExact(set_o)) {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 _PyErr_Format(tstate, PyExc_TypeError,
-                              "__conditional_annotations__ must be a set, not %T",
-                              set_o);
+                              "'%T' object is not a set", set_o);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -1;
                 assert(WITHIN_STACK_BOUNDS());

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1609,8 +1609,22 @@
             oparg = CURRENT_OPARG();
             v = stack_pointer[-1];
             set = stack_pointer[-2 - (oparg-1)];
+            PyObject *set_o = PyStackRef_AsPyObjectBorrow(set);
+            if (!PySet_Check(set_o)) {
+                _PyFrame_SetStackPointer(frame, stack_pointer);
+                _PyErr_Format(tstate, PyExc_TypeError,
+                              "__conditional_annotations__ must be a set, not %T",
+                              set_o);
+                stack_pointer = _PyFrame_GetStackPointer(frame);
+                stack_pointer += -1;
+                assert(WITHIN_STACK_BOUNDS());
+                _PyFrame_SetStackPointer(frame, stack_pointer);
+                PyStackRef_CLOSE(v);
+                stack_pointer = _PyFrame_GetStackPointer(frame);
+                JUMP_TO_ERROR();
+            }
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            int err = _PySet_AddTakeRef((PySetObject *)PyStackRef_AsPyObjectBorrow(set),
+            int err = _PySet_AddTakeRef((PySetObject *)set_o,
                                         PyStackRef_AsPyObjectSteal(v));
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err) {

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -10859,8 +10859,22 @@
             _PyStackRef v;
             v = stack_pointer[-1];
             set = stack_pointer[-2 - (oparg-1)];
+            PyObject *set_o = PyStackRef_AsPyObjectBorrow(set);
+            if (!PySet_Check(set_o)) {
+                _PyFrame_SetStackPointer(frame, stack_pointer);
+                _PyErr_Format(tstate, PyExc_TypeError,
+                              "__conditional_annotations__ must be a set, not %T",
+                              set_o);
+                stack_pointer = _PyFrame_GetStackPointer(frame);
+                stack_pointer += -1;
+                assert(WITHIN_STACK_BOUNDS());
+                _PyFrame_SetStackPointer(frame, stack_pointer);
+                PyStackRef_CLOSE(v);
+                stack_pointer = _PyFrame_GetStackPointer(frame);
+                JUMP_TO_LABEL(error);
+            }
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            int err = _PySet_AddTakeRef((PySetObject *)PyStackRef_AsPyObjectBorrow(set),
+            int err = _PySet_AddTakeRef((PySetObject *)set_o,
                                         PyStackRef_AsPyObjectSteal(v));
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err) {

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -10860,11 +10860,10 @@
             v = stack_pointer[-1];
             set = stack_pointer[-2 - (oparg-1)];
             PyObject *set_o = PyStackRef_AsPyObjectBorrow(set);
-            if (!PySet_Check(set_o)) {
+            if (!PySet_CheckExact(set_o)) {
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 _PyErr_Format(tstate, PyExc_TypeError,
-                              "__conditional_annotations__ must be a set, not %T",
-                              set_o);
+                              "'%T' object is not a set", set_o);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -1;
                 assert(WITHIN_STACK_BOUNDS());


### PR DESCRIPTION
Type-check the SET_ADD operand

This is an alternative version of fix for https://github.com/python/cpython/issues/154902, but dedicated to 3.15 and 3.14 only, because we cant change bytecode here


<!-- gh-issue-number: gh-154902 -->
* Issue: gh-154902
<!-- /gh-issue-number -->
