### PR TITLE
gh-105116: Document that an escaped csv quotechar does not cause quoting

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -377,6 +377,8 @@ The :mod:`!csv` module defines the following constants:
    Instructs :class:`writer` objects to only quote those fields which contain
    special characters such as *delimiter*, *quotechar*, ``'\r'``, ``'\n'``
    or any of the characters in *lineterminator*.
+   If *doublequote* is :const:`False` and *escapechar* is set,
+   the *quotechar* is escaped instead of causing the field to be quoted.
 
 
 .. data:: QUOTE_NONNUMERIC


### PR DESCRIPTION
Under `QUOTE_MINIMAL`, a field containing the *quotechar* is not quoted if *doublequote* is false and *escapechar* is set -- the *quotechar* is escaped instead. This is already implied by the second bullet of `Dialect.escapechar`; this states it where the quoting rule itself is described.

<!-- gh-issue-number: gh-105116 -->
* Issue: gh-105116
<!-- /gh-issue-number -->