### PR TITLE
gh-155074: Fix remaining-space calculation in `_pyio.BufferedReader.readinto()`

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1198,7 +1198,8 @@ class BufferedReader(_BufferedIOMixin):
             while written < len(buf):
 
                 # First try to read from internal buffer
-                avail = min(len(self._read_buf) - self._read_pos, len(buf))
+                avail = min(len(self._read_buf) - self._read_pos,
+                            len(buf) - written)
                 if avail:
                     buf[written:written+avail] = \
                         self._read_buf[self._read_pos:self._read_pos+avail]

--- a/Lib/test/test_io/test_bufferedio.py
+++ b/Lib/test/test_io/test_bufferedio.py
@@ -313,6 +313,14 @@ class BufferedReaderTest(CommonBufferedTests):
         self.assertEqual(bufio.readinto(b), 1)
         self.assertEqual(b, b"cb")
 
+    def test_readinto_with_remaining_buffered_data(self):
+        bufio = self.tp(self.BytesIO(b"abcd"), buffer_size=2)
+        self.assertEqual(bufio.read(1), b"a")
+        b = bytearray(2)
+        self.assertEqual(bufio.readinto(b), 2)
+        self.assertEqual(b, b"bc")
+        self.assertEqual(bufio.read(), b"d")
+
     def test_readinto1(self):
         buffer_size = 10
         rawio = self.MockRawIO((b"abc", b"de", b"fgh", b"jkl"))

--- a/Misc/NEWS.d/next/Library/2026-08-02-19-08-17.gh-issue-155074.Vj8qL2.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-02-19-08-17.gh-issue-155074.Vj8qL2.rst
@@ -1,0 +1,2 @@
+Fix the pure Python implementation of ``BufferedReader.readinto()`` raising
+:exc:`ValueError` after partially filling the destination buffer.


### PR DESCRIPTION
Closes #155074.

This PR fixes `_pyio.BufferedReader.readinto()` when data from the internal buffer only partially fills the destination before a refill.

The pure Python implementation limited each buffered copy by the destination's original length. After earlier bytes had been copied, this could make the next copy exceed the remaining memoryview slice and raise `ValueError`. The copy is now limited by the remaining destination space, `len(buf) - written`.

The regression test is shared by the C and pure Python implementations and verifies the returned byte count, destination contents, and unread data.

<!-- gh-issue-number: gh-155074 -->
* Issue: gh-155074
<!-- /gh-issue-number -->
