### PR TITLE
[3.15] gh-155052: Fix docstring of decimal.Context.copy (GH-155062)

### DIFF
--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -1690,12 +1690,12 @@ _decimal.Context.copy
 
     cls: defining_class
 
-Return a duplicate of the context with all flags cleared.
+Return a duplicate of the context.
 [clinic start generated code]*/
 
 static PyObject *
 _decimal_Context_copy_impl(PyObject *self, PyTypeObject *cls)
-/*[clinic end generated code: output=31c9c8eeb0c0cf77 input=aef1c0bddabdf8f0]*/
+/*[clinic end generated code: output=31c9c8eeb0c0cf77 input=87f8b92b1c7462a5]*/
 {
     decimal_state *state = PyType_GetModuleState(cls);
 

--- a/Modules/_decimal/clinic/_decimal.c.h
+++ b/Modules/_decimal/clinic/_decimal.c.h
@@ -371,7 +371,7 @@ PyDoc_STRVAR(_decimal_Context_copy__doc__,
 "copy($self, /)\n"
 "--\n"
 "\n"
-"Return a duplicate of the context with all flags cleared.");
+"Return a duplicate of the context.");
 
 #define _DECIMAL_CONTEXT_COPY_METHODDEF    \
     {"copy", _PyCFunction_CAST(_decimal_Context_copy), METH_METHOD|METH_FASTCALL|METH_KEYWORDS, _decimal_Context_copy__doc__},
@@ -6984,4 +6984,4 @@ exit:
 #ifndef _DECIMAL_CONTEXT_APPLY_METHODDEF
     #define _DECIMAL_CONTEXT_APPLY_METHODDEF
 #endif /* !defined(_DECIMAL_CONTEXT_APPLY_METHODDEF) */
-/*[clinic end generated code: output=0eb835634388294e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=72f619bdb52660d6 input=a9049054013a1b77]*/


### PR DESCRIPTION
(cherry picked from commit 04a1fcfdabb3a9d61cc247dfec13d601ce3398e9)

## Summary

Backport GH-155062 to the 3.15 branch.

This backport updates the Argument Clinic docstring for `decimal.Context.copy()` to match its actual behavior by changing:

> Return a duplicate of the context with all flags cleared.

to:

> Return a duplicate of the context.

The generated Argument Clinic files were regenerated for the 3.15 branch as part of the backport.

<!-- gh-issue-number: gh-155052 -->
* Issue: gh-155052
<!-- /gh-issue-number -->
