### PR TITLE
[3.14] gh-155052: Fix docstring of decimal.Context.copy (GH-155062)

### DIFF
--- a/Modules/_decimal/docstrings.h
+++ b/Modules/_decimal/docstrings.h
@@ -541,7 +541,7 @@ Set all traps to False.\n\
 
 PyDoc_STRVAR(doc_ctx_copy,
 "copy($self, /)\n--\n\n\
-Return a duplicate of the context with all flags cleared.\n\
+Return a duplicate of the context.\n\
 \n");
 
 PyDoc_STRVAR(doc_ctx_copy_decimal,


### PR DESCRIPTION
(cherry picked from commit 04a1fcfdabb3a9d61cc247dfec13d601ce3398e9)

## Summary

Backport GH-155062 to the 3.14 branch.

The 3.14 branch still uses the legacy `Modules/_decimal/docstrings.h` file instead of the Argument Clinic-generated docstrings used on `main`. Therefore, this backport applies the equivalent docstring fix in the branch-specific implementation by updating the `decimal.Context.copy()` docstring from:

> Return a duplicate of the context with all flags cleared.

to:

> Return a duplicate of the context.

<!-- gh-issue-number: gh-155052 -->
* Issue: gh-155052
<!-- /gh-issue-number -->
