### PR TITLE
Add soft-deprecated to site-packages

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -606,3 +606,14 @@ if 'create-social-cards' not in tags:  # noqa: F821
         '<meta property="og:image:width" content="200">',
         '<meta property="og:image:height" content="200">',
     )
+
+def setup(app):
+    try:
+        import sphinx.builders.changes
+        # We are reaching into the installed library and forcing the
+        # missing key into the class-level typemap.
+        if hasattr(sphinx.builders.changes, 'ChangesBuilder'):
+            if hasattr(sphinx.builders.changes.ChangesBuilder, 'typemap'):
+                sphinx.builders.changes.ChangesBuilder.typemap['soft-deprecated'] = 'soft-deprecated'
+    except ImportError:
+        pass


### PR DESCRIPTION
Fixes #155095

make -C Doc changes

File "/home/cbot/.local/lib/python3.14/site-packages/sphinx/builders/changes.py", line 61, in write_documents
        ttext = self.typemap[changeset.type]
                ~~~~~~~~~~~~^^^^^^^^^^^^^^^^
    KeyError: 'soft-deprecated'

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Fixes #155095