### PR TITLE
gh-155102: Preserve TypeError raised during set discard/remove comparison

### DIFF
--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -471,6 +471,29 @@ class TestSet(TestJointOps, unittest.TestCase):
         self.assertNotIn(self.thetype(self.word), s)
         s.discard(self.thetype(self.word))
 
+    def test_discard_remove_hashable_set_subclass_eq_typeerror(self):
+        class Bad:
+            def __hash__(self):
+                return 1
+
+            def __eq__(self, other):
+                raise TypeError("boom from __eq__")
+
+        class HashableSet(set):
+            def __hash__(self):
+                return 1
+
+        probe = HashableSet()
+
+        with self.assertRaisesRegex(TypeError, "boom from __eq__"):
+            probe in {Bad()}
+
+        with self.assertRaisesRegex(TypeError, "boom from __eq__"):
+            {Bad()}.discard(probe)
+
+        with self.assertRaisesRegex(TypeError, "boom from __eq__"):
+            {Bad()}.remove(probe)
+
     def test_pop(self):
         for i in range(len(self.s)):
             elem = self.s.pop()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-02-22-07-48.gh-issue-155102.wYmQcU.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-02-22-07-48.gh-issue-155102.wYmQcU.rst
@@ -1,0 +1,3 @@
+Preserve TypeError exceptions raised during equality comparison in
+set.discard() and set.remove() when using hashable set subclasses as lookup
+keys.

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -2653,19 +2653,21 @@ set_remove_impl(PySetObject *so, PyObject *key)
 {
     int rv;
 
-    rv = set_discard_key(so, key);
-    if (rv < 0) {
-        if (!PySet_Check(key) || !PyErr_ExceptionMatches(PyExc_TypeError))
+    Py_hash_t hash = PyObject_Hash(key);
+    if (hash == -1) {
+        if (!PySet_Check(key) || !PyErr_ExceptionMatches(PyExc_TypeError)) {
+            set_unhashable_type(key);
             return NULL;
+        }
         PyErr_Clear();
-        Py_hash_t hash;
         Py_BEGIN_CRITICAL_SECTION(key);
         hash = frozenset_hash_impl(key);
         Py_END_CRITICAL_SECTION();
-        rv = set_discard_entry(so, key, hash);
-        if (rv < 0)
-            return NULL;
     }
+
+    rv = set_discard_entry(so, key, hash);
+    if (rv < 0)
+        return NULL;
 
     if (rv == DISCARD_NOTFOUND) {
         _PyErr_SetKeyError(key);
@@ -2693,19 +2695,21 @@ set_discard_impl(PySetObject *so, PyObject *key)
 {
     int rv;
 
-    rv = set_discard_key(so, key);
-    if (rv < 0) {
-        if (!PySet_Check(key) || !PyErr_ExceptionMatches(PyExc_TypeError))
+    Py_hash_t hash = PyObject_Hash(key);
+    if (hash == -1) {
+        if (!PySet_Check(key) || !PyErr_ExceptionMatches(PyExc_TypeError)) {
+            set_unhashable_type(key);
             return NULL;
+        }
         PyErr_Clear();
-        Py_hash_t hash;
         Py_BEGIN_CRITICAL_SECTION(key);
         hash = frozenset_hash_impl(key);
         Py_END_CRITICAL_SECTION();
-        rv = set_discard_entry(so, key, hash);
-        if (rv < 0)
-            return NULL;
     }
+
+    rv = set_discard_entry(so, key, hash);
+    if (rv < 0)
+        return NULL;
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
Fixes issue gh-155102.

`set.discard()` and `set.remove()` could incorrectly suppress or replace
exceptions raised during equality comparison when the lookup key was a
hashable subclass of `set`.

The issue was caused by the special set/frozenset fallback path treating
all `TypeError` cases from hashing as unhashable-key handling. This could
clear an exception raised by `__eq__` and retry the lookup, resulting in
different behavior compared to normal membership testing.

This change separates the hash failure path from comparison errors:

- Preserve the existing fallback behavior for unhashable `set`/`frozenset`
  keys.
- Propagate exceptions raised during equality comparison consistently from
  `set.discard()` and `set.remove()`.

A regression test has been added to cover a hashable `set` subclass whose
`__eq__` raises `TypeError`.

Tests:
- `./python -m test test_set`