### PR TITLE
gh-152105: Remove docs snippet that uses internal C API

### DIFF
--- a/Doc/c-api/frame.rst
+++ b/Doc/c-api/frame.rst
@@ -269,29 +269,8 @@ Unless using :pep:`523`, you will not need this.
       * - .. c:macro:: PyUnstable_EXECUTABLE_KIND_METHOD_DESCRIPTOR
         - The frame corresponds to a method on a class instance.
 
-   However, Python's C API lacks a function to read the executable kind from
-   a frame. Instead, use this recipe:
-
-   .. code-block:: c
-
-      int
-      get_executable_kind(PyFrameObject *frame)
-      {
-         _PyInterpreterFrame *f = frame->f_frame;
-         PyObject *exec = PyStackRef_AsPyObjectBorrow(f->f_executable);
-
-         if (PyCode_Check(exec)) {
-            return PyUnstable_EXECUTABLE_KIND_PY_FUNCTION;
-         }
-         if (PyMethod_Check(exec)) {
-            return PyUnstable_EXECUTABLE_KIND_BUILTIN_FUNCTION;
-         }
-         if (Py_IS_TYPE(exec, &PyMethodDescr_Type)) {
-            return PyUnstable_EXECUTABLE_KIND_METHOD_DESCRIPTOR;
-         }
-
-         return PyUnstable_EXECUTABLE_KIND_SKIP;
-      }
+   Note that reading the executable kind from a frame is currently only
+   possible with undocumented internal API.
 
    .. versionadded:: 3.13
 

--- a/Doc/c-api/frame.rst
+++ b/Doc/c-api/frame.rst
@@ -270,7 +270,7 @@ Unless using :pep:`523`, you will not need this.
         - The frame corresponds to a method on a class instance.
 
    Note that reading the executable kind from a frame is currently only
-   possible with undocumented internal API.
+   possible with undocumented internal APIs.
 
    .. versionadded:: 3.13
 


### PR DESCRIPTION
Follow-up to GH-143490 (see [this comment](https://github.com/python/cpython/pull/143490#issuecomment-5133058680)).

`_PyInterpreterFrame.f_executable` and `PyStackRef_AsPyObjectBorrow` are undocumented and only available in the internal API. Docs should not suggest using them, even if `PyUnstable_ExecutableKinds` is unusable without them.

This is a backportable docs PR; for 3.16 let's [remove the API](https://github.com/python/cpython/compare/main...encukou:cpython:remove-PyUnstable_ExecutableKinds?expand=1) unless someone explains things. (I'll send the PR after this is merged.)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152105 -->
* Issue: gh-152105
<!-- /gh-issue-number -->
