### PR TITLE
gh-155143: Fix asyncio.shield leaking tasks via await-graph.

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -997,6 +997,9 @@ def shield(arg):
             # Keep only one callback to log on cancel
             inner.remove_done_callback(_log_on_exception)
             inner.add_done_callback(_log_on_exception)
+            if cur_task is not None:
+                inner.remove_done_callback(_clear_awaited_by_callback)
+                futures.future_discard_from_awaited_by(inner, cur_task)
 
     if cur_task is not None:
         inner.add_done_callback(_clear_awaited_by_callback)

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -2148,7 +2148,7 @@ class BaseTaskTests:
 
         task = self.new_task(self.loop, coro())
         self.loop.run_until_complete(task)
-        self.assertEqual(0, 0 if inner._asyncio_awaited_by is None else len(inner._asyncio_awaited_by))
+        self.assertFalse(inner._asyncio_awaited_by)
         self.assertTrue({f for f, _ctx in inner._callbacks or []} <= {asyncio.tasks._log_on_exception})
 
     def test_shield_duplicate_log_once(self):

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -2109,7 +2109,7 @@ class BaseTaskTests:
         test_utils.run_briefly(self.loop)
         self.assertTrue(outer.cancelled())
         self.assertEqual(0, 0 if outer._callbacks is None else len(outer._callbacks))
-        self.assertEqual(0, 0 if inner._asyncio_awaited_by is None else len(inner._asyncio_awaited_by))
+        self.assertFalse(inner._asyncio_awaited_by)
         self.assertTrue({f for f, _ctx in inner._callbacks or []} <= {asyncio.tasks._log_on_exception})
 
     def test_shield_cancel_outer_result(self):

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -2109,6 +2109,8 @@ class BaseTaskTests:
         test_utils.run_briefly(self.loop)
         self.assertTrue(outer.cancelled())
         self.assertEqual(0, 0 if outer._callbacks is None else len(outer._callbacks))
+        self.assertEqual(0, 0 if inner._asyncio_awaited_by is None else len(inner._asyncio_awaited_by))
+        self.assertTrue({f for f, _ctx in inner._callbacks or []} <= {asyncio.tasks._log_on_exception})
 
     def test_shield_cancel_outer_result(self):
         mock_handler = mock.Mock()
@@ -2133,6 +2135,21 @@ class BaseTaskTests:
         inner.set_exception(Exception('foo'))
         test_utils.run_briefly(self.loop)
         mock_handler.assert_called_once()
+
+    def test_shield_cancel_outer_in_task(self):
+        inner = self.new_future(self.loop)
+
+        async def coro():
+            outer = asyncio.shield(inner)
+            self.assertNotEqual(0, len(inner._callbacks))
+            outer.cancel()
+            await asyncio.sleep(0)
+            self.assertTrue(outer.cancelled())
+
+        task = self.new_task(self.loop, coro())
+        self.loop.run_until_complete(task)
+        self.assertEqual(0, 0 if inner._asyncio_awaited_by is None else len(inner._asyncio_awaited_by))
+        self.assertTrue({f for f, _ctx in inner._callbacks or []} <= {asyncio.tasks._log_on_exception})
 
     def test_shield_duplicate_log_once(self):
         mock_handler = mock.Mock()

--- a/Misc/NEWS.d/next/Library/2026-08-03-22-46-07.gh-issue-155143.9-byZp.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-03-22-46-07.gh-issue-155143.9-byZp.rst
@@ -1,0 +1,2 @@
+Fix :func:`asyncio.shield` leaking the calling task via the await-graph and
+callbacks when called on a future that never resolves.


### PR DESCRIPTION
see issue #155143 

<!-- gh-issue-number: gh-155143 -->
* Issue: gh-155143
<!-- /gh-issue-number -->
