### PR TITLE
[3.12] gh-98820: Fix quadratic time in csv.Sniffer for quoted fields (GH-154867)

### DIFF
--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -222,12 +222,16 @@ class Sniffer:
         this way.
         """
 
+        # The body of a quoted field ends at the first quote which is
+        # not doubled, as it does for a reader.  A lazy ".*?" scans to
+        # the end of the sample instead, from every start: quadratically.
+        body = r'(?:(?P=quote){2}|(?!(?P=quote)).)*+'
         matches = []
-        for restr in (r'(?P<delim>[^\w\n"\'])(?P<space> ?)(?P<quote>["\']).*?(?P=quote)(?P=delim)', # ,".*?",
-                      r'(?:^|\n)(?P<quote>["\']).*?(?P=quote)(?P<delim>[^\w\n"\'])(?P<space> ?)',   #  ".*?",
-                      r'(?P<delim>[^\w\n"\'])(?P<space> ?)(?P<quote>["\']).*?(?P=quote)(?:$|\n)',   # ,".*?"
-                      r'(?:^|\n)(?P<quote>["\']).*?(?P=quote)(?:$|\n)'):                            #  ".*?" (no delim, no space)
-            regexp = re.compile(restr, re.DOTALL | re.MULTILINE)
+        for restr in (r'(?P<delim>[^\w\n"\'])(?P<space> ?)(?P<quote>["\'])%s(?P=quote)(?P=delim)',   # ,"...",
+                      r'(?:^|\n)(?P<quote>["\'])%s(?P=quote)(?P<delim>[^\w\n"\'])(?P<space> ?)',     #  "...",
+                      r'(?P<delim>[^\w\n"\'])(?P<space> ?)(?P<quote>["\'])%s(?P=quote)(?:$|\n)',  # ,"..."
+                      r'(?:^|\n)(?P<quote>["\'])%s(?P=quote)(?:$|\n)'):                           #  "..." (no delim, no space)
+            regexp = re.compile(restr % body, re.DOTALL | re.MULTILINE)
             matches = regexp.findall(data)
             if matches:
                 break

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1415,6 +1415,13 @@ ghi\0jkl
         self.assertEqual(dialect.delimiter, ' ')
         self.assertIs(dialect.doublequote, False)
 
+    def test_sniff_quoted_single_column(self):
+        # gh-98820: this sample used to take minutes.
+        sniffer = csv.Sniffer()
+        sample = '"abcdefghijklmnopqrstuvwxyz"\n' * 10000
+        with self.assertRaisesRegex(csv.Error, "Could not determine delimiter"):
+            sniffer.sniff(sample, delimiters=',:|\t')
+
 
 class NUL:
     def write(s, *args):

--- a/Misc/NEWS.d/next/Library/2026-07-29-11-20-00.gh-issue-98820.Qm7Hs4.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-11-20-00.gh-issue-98820.Qm7Hs4.rst
@@ -1,0 +1,2 @@
+Fix quadratic time in :meth:`csv.Sniffer.sniff` for a sample which contains
+quoted fields, in particular for a single column of quoted fields.


### PR DESCRIPTION
Manual backport of #154867 to the security branch, cherry-picked from the 3.13 backport (commit b30c7fa9edd921a118f286e9f90f560777fa693b).

The only conflict was in `Lib/csv.py`: 3.12 does not have gh-103925, so its patterns end with `(?:$|\n)` where the 3.13 pre-image had `(?:$|\r|\n)`.  After the resolution `_guess_quote_and_delimiter()` is identical to the 3.13 one.

Sniffing `'"abcdefghijklmnopqrstuvwxyz"\n' * n` with `delimiters=',:|\t'` takes 0.248, 0.977, 3.891 and 15.316 s for n = 1250, 2500, 5000 and 10000 before the change, and 0.026, 0.055, 0.109 and 0.216 s after it.

<!-- gh-issue-number: gh-98820 -->
* Issue: gh-98820
<!-- /gh-issue-number -->
