### PR TITLE
gh-150942: Speed up BytesIO.readlines() using reference-stealing append

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-08-04-19-50-52.gh-issue-150942.B8ytes.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-04-19-50-52.gh-issue-150942.B8ytes.rst
@@ -1,0 +1,2 @@
+Improve the performance of :meth:`io.BytesIO.readlines`, particularly in
+free-threaded builds.

--- a/Misc/NEWS.d/next/Library/2026-08-04-19-50-52.gh-issue-150942.B8ytes.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-04-19-50-52.gh-issue-150942.B8ytes.rst
@@ -1,2 +1,2 @@
 Improve the performance of :meth:`~io.IOBase.readlines` for
-:class:`io.BytesIO`, particularly in free-threaded builds.
+:class:`io.BytesIO`.

--- a/Misc/NEWS.d/next/Library/2026-08-04-19-50-52.gh-issue-150942.B8ytes.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-04-19-50-52.gh-issue-150942.B8ytes.rst
@@ -1,2 +1,2 @@
-Improve the performance of :meth:`io.BytesIO.readlines`, particularly in
-free-threaded builds.
+Improve the performance of :meth:`~io.IOBase.readlines` for
+:class:`io.BytesIO`, particularly in free-threaded builds.

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -1,5 +1,6 @@
 #include "Python.h"
 #include "pycore_critical_section.h"  // Py_BEGIN_CRITICAL_SECTION()
+#include "pycore_list.h"              // _PyList_AppendTakeRef()
 #include "pycore_object.h"
 #include "pycore_pyatomic_ft_wrappers.h"
 #include "pycore_sysmodule.h"         // _PySys_GetSizeOf()
@@ -663,11 +664,9 @@ _io_BytesIO_readlines_impl(bytesio *self, PyObject *arg)
         line = PyBytes_FromStringAndSize(output, n);
         if (!line)
             goto on_error;
-        if (PyList_Append(result, line) == -1) {
-            Py_DECREF(line);
+        if (_PyList_AppendTakeRef((PyListObject *)result, line) < 0) {
             goto on_error;
         }
-        Py_DECREF(line);
         size += n;
         if (maxsize > 0 && size >= maxsize)
             break;


### PR DESCRIPTION
## Summary

Use `_PyList_AppendTakeRef()` while building the private result list in
`BytesIO.readlines()`.

The new bytes object is transferred directly to the result list, avoiding the
incref/decref pair performed by `PyList_Append()`. The result list is freshly
allocated, remains local for the complete loop, and is protected by the
`BytesIO` critical section until it is returned.

Partially fixes gh-150942.

## Benchmark

Author-run `pyperf` comparisons used five `BytesIO.readlines()` workloads on a
free-threaded Clang 21 PGO+ThinLTO build. Two balanced baseline/patch comparison
pairs reported improvements of 8.64% to 36.18% across the workloads, with
19.27% and 20.43% equal-weight geometric-mean improvements. Earlier regular-GIL
PGO+LTO comparisons reported 7.64% and 8.68% geometric-mean improvements.

Several individual suites produced `pyperf check` stability warnings. The raw
benchmark script and result files are not attached to this PR, so these figures
are author-reported results and are not independently reproducible from the
public PR artifacts.

## Verification

All required GitHub checks pass on the current head, including regular and
free-threaded builds and tests, sanitizer jobs, and generated-file checks.
`git diff --check` also passes for the complete two-file diff.
