### PR TITLE
gh-155175: Reject fractional seconds without a decimal mark in C fromisoformat

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3762,6 +3762,11 @@ class TestDateTime(TestDate):
             '2009-04-19T12:30:45.-05:00',   # Empty fraction before offset
             '2009-04-19T12:30:45.Z',        # Empty fraction before Z
             '2009-04-19T12:30:45,+05:00',   # Empty fraction (comma) before offset
+            '2009-04-19T12304578',          # Fraction without a decimal mark
+            '2009-04-19T123045789',         # Fraction without a decimal mark
+            '2009-04-19T123045123456789',   # Fraction without a decimal mark
+            '2009-04-19T123045+00000000',   # Offset fraction without decimal mark
+            '2009-04-19T12:30:45+00000000', # Offset fraction without decimal mark
         ]
 
         for bad_str in bad_strs:
@@ -5042,6 +5047,11 @@ class TestTimeTZ(TestTime, TZInfoBase, unittest.TestCase):
             '12:30:45.-05:00',          # Empty fraction before offset
             '12:30:45.Z',               # Empty fraction before Z
             '12:30:45,+05:00',          # Empty fraction (comma) before offset
+            '12304578',                 # Fraction without a decimal mark
+            '123045789',                # Fraction without a decimal mark
+            '123045123456789',          # Fraction without a decimal mark
+            '123045+00000000',          # Offset fraction without decimal mark
+            '12:30:45+00000000',        # Offset fraction without decimal mark
         ]
 
         for bad_str in bad_strs:

--- a/Misc/NEWS.d/next/Library/2026-08-04-19-40-00.gh-issue-155175.Kf3xQ1.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-04-19-40-00.gh-issue-155175.Kf3xQ1.rst
@@ -1,0 +1,5 @@
+Fix :meth:`datetime.time.fromisoformat` and
+:meth:`datetime.datetime.fromisoformat` in the C implementation accepting a
+fractional seconds component that is not introduced by a decimal mark, such
+as ``'12345678'`` (previously parsed as ``12:34:56.780000``).  Such strings
+are now rejected, matching the pure-Python implementation.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1021,6 +1021,7 @@ parse_hh_mm_ss_ff(const char *tstr, const char *tstr_end, int *hour,
     int *vals[3] = {hour, minute, second};
     // This is initialized to satisfy an erroneous compiler warning.
     unsigned char has_separator = 1;
+    unsigned char has_fraction = 0;
 
     // Parse [HH[:?MM[:?SS]]]
     for (size_t i = 0; i < 3; ++i) {
@@ -1041,6 +1042,7 @@ parse_hh_mm_ss_ff(const char *tstr, const char *tstr_end, int *hour,
             if (p >= p_end) {
                 return -3;  // Decimal mark not followed by any digit
             }
+            has_fraction = 1;
             break;
         }
         else if (p >= p_end) {
@@ -1058,6 +1060,14 @@ parse_hh_mm_ss_ff(const char *tstr, const char *tstr_end, int *hour,
         else {
             return -4;  // Malformed time separator
         }
+    }
+
+    // A fractional component must be introduced by a decimal mark.  Falling
+    // out of the loop above without having seen one means the basic format
+    // left unconsumed characters after SS (e.g. "12345678"), which would
+    // otherwise be silently parsed as a fraction.
+    if (!has_fraction) {
+        return -4;  // Malformed microsecond separator
     }
 
     // Parse fractional components


### PR DESCRIPTION
`parse_hh_mm_ss_ff()` in `Modules/_datetimemodule.c` parsed any characters left
over after `HHMMSS` in the ISO 8601 basic format as a fractional seconds
component, without requiring the decimal mark that ISO 8601 mandates:

```python
>>> time.fromisoformat('12345678')
datetime.time(12, 34, 56, 780000)          # now raises ValueError
>>> datetime.fromisoformat('2020-01-01T12345678')
datetime.datetime(2020, 1, 1, 12, 34, 56, 780000)   # now raises ValueError
```

The `HH`/`MM`/`SS` loop only `break`s into the fraction-parsing code when it
sees `.` or `,`. In the basic format it can also fall out of the loop normally
with input still unconsumed, the `else if (!has_separator) { --p; }` branch
un-consumes the character and the loop ends, after which the code below
parses whatever remains as a fraction, never checking that a decimal mark
introduced it.

This tracks whether a decimal mark was actually seen and rejects the string
otherwise, matching `_pydatetime._parse_hh_mm_ss_ff()`, which performs the
check explicitly:

```python
if pos < len_str:
    if tstr[pos] not in '.,':
        raise ValueError("Invalid microsecond separator")
```

Because the same helper also parses the UTC offset, this fixes malformed
offsets being accepted with the trailing digits silently discarded:

```python
>>> time.fromisoformat('12:34:56+00000000')
datetime.time(12, 34, 56, tzinfo=datetime.timezone.utc)   # now raises ValueError
```

Valid inputs are unaffected, `'123456'`, `'123456.78'`, `'123456,78'`,
`'123456.123456789'`, `'12:34:56.123456'`, `'1234'`, `'12'`, `'123456+0000'`,
`'123456Z'`, `'12:34:56+00:00:00.123456'`, `'20200101T123456.789'` and
`'20200101T123456+0530'` all parse exactly as before, and identically to the
pure-Python implementation.

This is the same class of C/pure-Python divergence as gh-152157 (empty fraction
before a timezone designator) and gh-152079.

### Tests

Five cases added to each of the `time` and `datetime` `bad_strs` lists in
`Lib/test/datetimetester.py`, covering the fraction and the UTC offset paths.
They run under both the `_Fast` (C) and `_Pure` (pure Python) test classes.

`test_datetime` passes (1160 tests), and the full suite passes
(`run=48,806`, `Result: SUCCESS`).


<!-- gh-issue-number: gh-155175 -->
* Issue: gh-155175
<!-- /gh-issue-number -->
