### PR TITLE
gh-155194: Fix not raising on non-module import

### DIFF
--- a/Lib/test/test_lazy_import/__init__.py
+++ b/Lib/test/test_lazy_import/__init__.py
@@ -706,6 +706,14 @@ class ErrorHandlingTests(LazyImportTestCase):
         """)
         assert_python_ok("-c", code)
 
+    def test_non_package_lazily_imported_as(self):
+        """Doing a dotted lazy import as still works"""
+        code = textwrap.dedent("""
+            lazy import math.pi as pi
+            pi
+        """)
+        assert_python_ok("-c", code)
+
     def test_missing_attribute_raises_import_error(self):
         """Accessing a nonexistent lazy name via from import raises ImportError."""
         code = textwrap.dedent("""

--- a/Lib/test/test_lazy_import/__init__.py
+++ b/Lib/test/test_lazy_import/__init__.py
@@ -693,7 +693,7 @@ class ErrorHandlingTests(LazyImportTestCase):
         assert_python_ok("-c", code)
 
     def test_non_package_lazily_imported(self):
-        """Accessing a nonexistent lazy submodule via parent attr raises AttributeError."""
+        """Accessing a nonexistent lazy submodule via parent attr raises ModuleNotFoundError."""
         code = textwrap.dedent("""
             lazy import math.pi
 
@@ -703,6 +703,20 @@ class ErrorHandlingTests(LazyImportTestCase):
                 pass
             else:
                 raise AssertionError("ModuleNotFoundError was not raised")
+        """)
+        assert_python_ok("-c", code)
+
+    def test_missing_attribute_raises_import_error(self):
+        """Accessing a nonexistent lazy submodule via from import raises ImportError."""
+        code = textwrap.dedent("""
+            lazy from sys import doesnotexist
+
+            try:
+                _ = doesnotexist
+            except ImportError:
+                pass
+            else:
+                raise AssertionError("ImportError was not raised")
         """)
         assert_python_ok("-c", code)
 

--- a/Lib/test/test_lazy_import/__init__.py
+++ b/Lib/test/test_lazy_import/__init__.py
@@ -679,7 +679,7 @@ class ErrorHandlingTests(LazyImportTestCase):
     """Tests for error handling during lazy import reification."""
 
     def test_missing_lazy_submodule_raises_module_not_found_error(self):
-        """Accessing a nonexistent lazy submodule via parent attr raises AttributeError."""
+        """Accessing a nonexistent lazy submodule via parent attr raises ModuleNotFoundError."""
         code = textwrap.dedent("""
             lazy import test.test_lazy_import.data.nonexistent_module
 
@@ -693,7 +693,7 @@ class ErrorHandlingTests(LazyImportTestCase):
         assert_python_ok("-c", code)
 
     def test_non_package_lazily_imported(self):
-        """Accessing a nonexistent lazy submodule via parent attr raises ModuleNotFoundError."""
+        """Accessing a nonexistent lazy name via parent attr raises ModuleNotFoundError."""
         code = textwrap.dedent("""
             lazy import math.pi
 
@@ -707,7 +707,7 @@ class ErrorHandlingTests(LazyImportTestCase):
         assert_python_ok("-c", code)
 
     def test_missing_attribute_raises_import_error(self):
-        """Accessing a nonexistent lazy submodule via from import raises ImportError."""
+        """Accessing a nonexistent lazy name via from import raises ImportError."""
         code = textwrap.dedent("""
             lazy from sys import doesnotexist
 

--- a/Lib/test/test_lazy_import/__init__.py
+++ b/Lib/test/test_lazy_import/__init__.py
@@ -678,17 +678,31 @@ class SysLazyImportsAPITests(LazyImportTestCase):
 class ErrorHandlingTests(LazyImportTestCase):
     """Tests for error handling during lazy import reification."""
 
-    def test_missing_lazy_submodule_raises_attribute_error(self):
+    def test_missing_lazy_submodule_raises_module_not_found_error(self):
         """Accessing a nonexistent lazy submodule via parent attr raises AttributeError."""
         code = textwrap.dedent("""
             lazy import test.test_lazy_import.data.nonexistent_module
 
             try:
                 _ = test.test_lazy_import.data.nonexistent_module
-            except AttributeError:
+            except ModuleNotFoundError:
                 pass
             else:
-                raise AssertionError("AttributeError was not raised")
+                raise AssertionError("ModuleNotFoundError was not raised")
+        """)
+        assert_python_ok("-c", code)
+
+    def test_non_package_lazily_imported(self):
+        """Accessing a nonexistent lazy submodule via parent attr raises AttributeError."""
+        code = textwrap.dedent("""
+            lazy import math.pi
+
+            try:
+                _ = math.pi
+            except ModuleNotFoundError:
+                pass
+            else:
+                raise AssertionError("ModuleNotFoundError was not raised")
         """)
         assert_python_ok("-c", code)
 

--- a/Lib/test/test_lazy_import/data/lazypkg/__init__.py
+++ b/Lib/test/test_lazy_import/data/lazypkg/__init__.py
@@ -1,0 +1,1 @@
+lazy from . import bar

--- a/Lib/test/test_lazy_import/data/lazypkg/bar.py
+++ b/Lib/test/test_lazy_import/data/lazypkg/bar.py
@@ -1,5 +1,2 @@
-import traceback
-traceback.print_stack()
-while True: pass
 print("BAR_MODULE_LOADED")
 def f(): pass

--- a/Lib/test/test_lazy_import/data/lazypkg/bar.py
+++ b/Lib/test/test_lazy_import/data/lazypkg/bar.py
@@ -1,0 +1,5 @@
+import traceback
+traceback.print_stack()
+while True: pass
+print("BAR_MODULE_LOADED")
+def f(): pass

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -5611,11 +5611,11 @@ class TestLazyImportSuggestions(unittest.TestCase):
 
     def test_attribute_error_does_not_reify_lazy_imports(self):
         """Printing an AttributeError should not trigger lazy import reification."""
-        # pkg.bar prints "BAR_MODULE_LOADED" when imported.
+        # lazypkg.bar prints "BAR_MODULE_LOADED" when imported.
         # If lazy import is reified during suggestion computation, we'll see it.
         code = textwrap.dedent("""
-            lazy import test.test_lazy_import.data.pkg.bar
-            test.test_lazy_import.data.pkg.nonexistent
+            lazy import test.test_lazy_import.data.lazypkg
+            test.test_lazy_import.data.lazypkg.nonexistent
         """)
         rc, stdout, stderr = assert_python_failure('-c', code)
         self.assertNotIn(b"BAR_MODULE_LOADED", stdout)
@@ -5624,9 +5624,9 @@ class TestLazyImportSuggestions(unittest.TestCase):
         """Formatting a traceback should not trigger lazy import reification."""
         code = textwrap.dedent("""
             import traceback
-            lazy import test.test_lazy_import.data.pkg.bar
+            lazy import test.test_lazy_import.data.lazypkg
             try:
-                test.test_lazy_import.data.pkg.nonexistent
+                test.test_lazy_import.data.lazypkg.nonexistent
             except AttributeError:
                 traceback.format_exc()
             print("OK")
@@ -5638,9 +5638,9 @@ class TestLazyImportSuggestions(unittest.TestCase):
     def test_suggestion_still_works_for_non_lazy_attributes(self):
         """Suggestions should still work for non-lazy module attributes."""
         code = textwrap.dedent("""
-            lazy import test.test_lazy_import.data.pkg.bar
+            lazy import test.test_lazy_import.data.lazypkg
             # Typo for __name__
-            test.test_lazy_import.data.pkg.__nme__
+            test.test_lazy_import.data.lazypkg.__nme__
         """)
         rc, stdout, stderr = assert_python_failure('-c', code)
         self.assertIn(b"__name__", stderr)

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2690,6 +2690,7 @@ TESTSUBDIRS=	idlelib/idle_test \
 		test/test_lazy_import/data/pkg \
 		test/test_lazy_import/data/badsyntax \
 		test/test_lazy_import/data/circular_import_pkg \
+		test/test_lazy_import/data/lazypkg \
 		test/test_lazy_import/data/metasyntactic \
 		test/test_lazy_import/data/metasyntactic/foo \
 		test/test_lazy_import/data/metasyntactic/foo/ack \

--- a/Python/import.c
+++ b/Python/import.c
@@ -3940,19 +3940,6 @@ _PyImport_LoadLazyImportTstate(PyThreadState *tstate, PyObject *lazy_import)
         goto error;
     }
 
-    Py_ssize_t dot = -1;
-    int full = 0;
-    if (lz->lz_attr != NULL) {
-        full = 1;
-    }
-    if (!full) {
-        dot = PyUnicode_FindChar(lz->lz_from, '.', 0,
-                                 PyUnicode_GET_LENGTH(lz->lz_from), 1);
-    }
-    if (dot < 0) {
-        full = 1;
-    }
-
     if (lz->lz_attr != NULL) {
         if (PyUnicode_Check(lz->lz_attr)) {
             fromlist = PyTuple_New(1);
@@ -3978,23 +3965,10 @@ _PyImport_LoadLazyImportTstate(PyThreadState *tstate, PyObject *lazy_import)
         PyErr_SetString(PyExc_ImportError, "__import__ not found");
         goto error;
     }
-    if (full) {
-        obj = _PyEval_ImportNameWithImport(
-            tstate, import_func, globals, globals,
-            lz->lz_from, fromlist, _PyLong_GetZero()
-        );
-    }
-    else {
-        PyObject *name = PyUnicode_Substring(lz->lz_from, 0, dot);
-        if (name == NULL) {
-            goto error;
-        }
-        obj = _PyEval_ImportNameWithImport(
-            tstate, import_func, globals, globals,
-            name, fromlist, _PyLong_GetZero()
-        );
-        Py_DECREF(name);
-    }
+    obj = _PyEval_ImportNameWithImport(
+        tstate, import_func, globals, globals,
+        lz->lz_from, fromlist, _PyLong_GetZero()
+    );
     if (obj == NULL) {
         goto error;
     }


### PR DESCRIPTION
As initially reported here: https://discuss.python.org/t/sys-lazy-modules-clarification/108385

`lazy import math.pi` has divergent behavior from `import math.pi`.  Currently we allow this to work and just give you the `math` module. Instead we should raise `ModuleNotFoundError` because `math.pi` is not a module.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-155194 -->
* Issue: gh-155194
<!-- /gh-issue-number -->
