### PR TITLE
gh-123059: Document archive timestamp timezone handling

### DIFF
--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -693,6 +693,12 @@ be finalized; only the internally used file object will be closed. See the
    :const:`None` the :class:`TarInfo` object will be excluded from the
    archive. See :ref:`tar-examples` for an example.
 
+   The file's last modification time is stored in the archive member's
+   :attr:`~TarInfo.mtime` as seconds since the epoch, without conversion to
+   local time.  Changing the process's time zone therefore does not itself
+   change the stored member timestamp, although the result can still vary if
+   the filesystem reports time-zone-dependent timestamps.
+
    .. versionchanged:: 3.2
       Added the *filter* parameter.
 

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -472,6 +472,14 @@ ZipFile objects
    given.
    The archive must be open with mode ``'w'``, ``'x'`` or ``'a'``.
 
+   The file's last modification time is converted to the current local time
+   and stored in the archive member's :attr:`~ZipInfo.date_time`.  Since ZIP
+   timestamps do not record a time zone, creating an archive from the same
+   file in different time zones can result in different stored timestamps.
+   To control the timestamp, create a :class:`ZipInfo` with an explicit
+   :attr:`~ZipInfo.date_time` and pass it with the file contents to
+   :meth:`writestr`.
+
    .. note::
 
       The ZIP file standard historically did not specify a metadata encoding,


### PR DESCRIPTION
Closes #123059.

This documents the different timestamp behavior used when adding filesystem entries to ZIP and tar archives:

- `ZipFile.write()` converts the filesystem modification time to the current local time, which can make otherwise identical archives differ across time zones. The docs now show how to supply an explicit `ZipInfo.date_time` with `writestr()` when the timestamp must be controlled.
- `TarFile.add()` stores the modification time as epoch seconds without a local-time conversion, while noting that filesystem-provided timestamps may still be time-zone-dependent.

Checks:

- `sphinx-lint` on `Doc/library/zipfile.rst` and `Doc/library/tarfile.rst`
- targeted Sphinx HTML build with warnings treated as errors
- `git diff --check`

Developed with help from Codex. I reviewed and understand the change.


<!-- gh-issue-number: gh-123059 -->
* Issue: gh-123059
<!-- /gh-issue-number -->
