### PR TITLE
gh-155193: Add missing canonical parameter to urlsafe_b64decode()

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -164,7 +164,7 @@ def urlsafe_b64encode(s, *, padded=True):
     return binascii.b2a_base64(s, padded=padded, newline=False,
                                alphabet=binascii.URLSAFE_BASE64_ALPHABET)
 
-def urlsafe_b64decode(s, *, padded=False):
+def urlsafe_b64decode(s, *, padded=False, canonical=False):
     """Decode bytes using the URL- and filesystem-safe Base64 alphabet.
 
     Argument s is a bytes-like object or ASCII string to decode.  The result
@@ -175,6 +175,9 @@ def urlsafe_b64decode(s, *, padded=False):
 
     If padded is false, padding in input is not required.
 
+    If canonical is true, non-canonical encodings (non-zero padding bits or
+    other non-canonical forms) are rejected.
+
     The alphabet uses '-' instead of '+' and '_' instead of '/'.
     """
     s = _bytes_from_decode_data(s)
@@ -184,7 +187,8 @@ def urlsafe_b64decode(s, *, padded=False):
             badchar = b
             break
     s = s.translate(_urlsafe_decode_translation)
-    result = binascii.a2b_base64(s, strict_mode=False, padded=padded)
+    result = binascii.a2b_base64(s, strict_mode=False, padded=padded,
+                                  canonical=canonical)
     if badchar is not None:
         import warnings
         warnings.warn(f'invalid character {chr(badchar)!a} in URL-safe Base64 data '


### PR DESCRIPTION
The what's new entry for 3.15 documents canonical=False being added to b32decode(), b32hexdecode(), b64decode(), urlsafe_b64decode(), a85decode(), b85decode(), and z85decode() (gh-146311), but urlsafe_b64decode() did not actually receive the parameter.

Add canonical=False to urlsafe_b64decode()'s signature and pass it through to binascii.a2b_base64(), consistent with b64decode(). The default preserves existing behavior.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-155193 -->
* Issue: gh-155193
<!-- /gh-issue-number -->
