### PR TITLE
gh-155009: Fix argparse test on non-UTF-8 locales like Raspbian

### DIFF
--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -7350,6 +7350,9 @@ class TestProgName(TestCase):
         basename = 'module' + os_helper.FS_NONASCII
         modulename = f'{self.dirname}.{basename}'
         self.make_script(self.dirname, basename)
+        # The filesystem encoding may be non-UTF-8,
+        # but the runner runs in UTF-8 mode
+        modulename = os.fsencode(modulename).decode("utf-8", "surrogateescape")
         runner_source = textwrap.dedent(f'''\
             import runpy
             runpy._run_module_as_main({modulename!r}, alter_argv=False)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Fix for https://github.com/python/cpython/pull/155199#issuecomment-5188033588

<!-- gh-issue-number: gh-155009 -->
* Issue: gh-155009
<!-- /gh-issue-number -->
