### PR TITLE
gh-69370: Fix "python -m inspect --details" for unencodable paths

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -3461,6 +3461,11 @@ def _main():
     import argparse
     import importlib
 
+    # The printed text can contain characters unencodable in the encoding
+    # of stdout, e.g. undecodable bytes of a file name.
+    if getattr(sys.stdout, 'errors', None) == 'strict':
+        sys.stdout.reconfigure(errors='backslashreplace')
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         'object',

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -3463,8 +3463,7 @@ def _main():
 
     # The printed text can contain characters unencodable in the encoding
     # of stdout, e.g. undecodable bytes of a file name.
-    if getattr(sys.stdout, 'errors', None) == 'strict':
-        sys.stdout.reconfigure(errors='backslashreplace')
+    sys.stdout.reconfigure(errors='backslashreplace')
 
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -6591,7 +6591,10 @@ class TestModuleCLI(unittest.TestCase):
         # of stdout.
         with temp_cwd() as test_dir:
             subdir = os.path.join(os.fsencode(test_dir), TESTFN_UNDECODABLE)
-            os.mkdir(subdir)
+            try:
+                os.mkdir(subdir)
+            except OSError:
+                self.skipTest('undecodable paths are not supported')
             with open(os.path.join(subdir, b'undecodable_mod.py'), 'w') as f:
                 f.write('"""Module docstring."""\n')
             rc, out, err = assert_python_ok('-X', 'utf8=0', '-m', 'inspect',

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -40,7 +40,7 @@ from test.support import cpython_only, import_helper
 from test.support import MISSING_C_DOCSTRINGS, ALWAYS_EQ
 from test.support import run_no_yield_async_fn, EqualToForwardRef
 from test.support.import_helper import DirsOnSysPath, ready_to_import
-from test.support.os_helper import TESTFN, temp_cwd
+from test.support.os_helper import TESTFN, TESTFN_UNDECODABLE, temp_cwd
 from test.support.script_helper import assert_python_ok, assert_python_failure, kill_python
 from test.support import has_subprocess_support
 from test import support
@@ -6583,6 +6583,22 @@ class TestModuleCLI(unittest.TestCase):
                                             'importlib.machinery:SOURCE_SUFFIXES')
         lines = err.decode().splitlines()
         self.assertEqual(lines, [self.NO_SOURCE_TARGET_ERROR])
+
+    @unittest.skipUnless(TESTFN_UNDECODABLE,
+                         'requires undecodable file names')
+    def test_details_undecodable_path(self):
+        # gh-69370: the path of the module is not encodable in the encoding
+        # of stdout.
+        with temp_cwd() as test_dir:
+            subdir = os.path.join(os.fsencode(test_dir), TESTFN_UNDECODABLE)
+            os.mkdir(subdir)
+            with open(os.path.join(subdir, b'undecodable_mod.py'), 'w') as f:
+                f.write('"""Module docstring."""\n')
+            rc, out, err = assert_python_ok('-X', 'utf8=0', '-m', 'inspect',
+                                            '--details', 'undecodable_mod',
+                                            PYTHONPATH=os.fsdecode(subdir))
+        self.assertIn(b'Target: undecodable_mod', out)
+        self.assertEqual(err, b'')
 
     def test_details_option_with_package(self):
         module_name = 'unittest'

--- a/Misc/NEWS.d/next/Library/2026-08-05-17-30-00.gh-issue-69370.inspCLI.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-05-17-30-00.gh-issue-69370.inspCLI.rst
@@ -1,0 +1,4 @@
+``python -m inspect --details`` no longer fails with
+:exc:`UnicodeEncodeError` if the path of the module contains characters
+unencodable in the encoding of :data:`sys.stdout`.  Such characters are now
+escaped with backslashes.

--- a/Misc/NEWS.d/next/Library/2026-08-05-17-30-00.gh-issue-69370.inspCLI.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-05-17-30-00.gh-issue-69370.inspCLI.rst
@@ -1,4 +1,4 @@
-``python -m inspect --details`` no longer fails with
+:program:`python -m inspect --details` no longer fails with
 :exc:`UnicodeEncodeError` if the path of the module contains characters
 unencodable in the encoding of :data:`sys.stdout`.  Such characters are now
 escaped with backslashes.


### PR DESCRIPTION
`python -m inspect --details` failed with `UnicodeEncodeError` if the path of the module contains characters unencodable in the encoding of `sys.stdout`, e.g. undecodable bytes of a file name.

Such characters are now escaped with backslashes, unless `sys.stdout` uses an error handler which can handle them.

<!-- gh-issue-number: gh-69370 -->
* Issue: gh-69370
<!-- /gh-issue-number -->
