### PR TITLE
gh-154930: Use atomic loads in UnicodeDecodeError.__str__

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-05-19-08-47.gh-issue-154930.-OifdL.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-05-19-08-47.gh-issue-154930.-OifdL.rst
@@ -1,0 +1,3 @@
+Use atomic loads for ``UnicodeDecodeError.start`` and
+``UnicodeDecodeError.end`` in ``UnicodeDecodeError.__str__()`` to avoid a
+data race in free-threaded builds.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -3945,7 +3945,8 @@ UnicodeDecodeError_str(PyObject *self)
         goto done;
     }
     Py_ssize_t len = PyBytes_GET_SIZE(exc->object);
-    Py_ssize_t start = exc->start, end = exc->end;
+    Py_ssize_t start = FT_ATOMIC_LOAD_SSIZE_RELAXED(exc->start);
+    Py_ssize_t end = FT_ATOMIC_LOAD_SSIZE_RELAXED(exc->end);
 
     if ((start >= 0 && start < len) && (end >= 0 && end <= len) && end == start + 1) {
         int badbyte = (int)(PyBytes_AS_STRING(exc->object)[start] & 0xff);


### PR DESCRIPTION
Closes issue gh-154930.

## Summary

`UnicodeDecodeError.__str__()` reads the `start` and `end` fields directly, while
assignments to these fields use atomic stores through `PyMember_SetOne`. In
free-threaded builds, this can result in a data race when `str(exc)` is called
concurrently with updates to `exc.start` or `exc.end`.

This change replaces the direct reads with `FT_ATOMIC_LOAD_SSIZE_RELAXED()` to
match the existing atomic store semantics.

## Tests

- Built CPython successfully.
- Ran:

  ```bash
  ./python -m test test_exceptions
  ```