### PR TITLE
gh-155258: Make the curses.complexstr signature introspectable

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -696,6 +696,10 @@ class TestCurses(unittest.TestCase):
                           lambda: curses.complexstr([cc('A')], attr=B))
         self.assertRaises(TypeError,
                           lambda: curses.complexstr(['A'], pair=0))
+        # The signature is introspectable: attr and pair have a default that
+        # can be rendered.
+        self.assertEqual(str(inspect.signature(curses.complexstr)),
+                         '(cells, /, attr=None, pair=None)')
 
     def test_in_wchstr(self):
         # in_wchstr() returns a complexstr -- the styled-cell counterpart of

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -1412,9 +1412,9 @@ _curses.complexstr.__new__ as complexstr_new
     cells: object
         An iterable of cells, each a complexchar or a str.
     /
-    attr: object = NULL
+    attr: object(c_default="NULL") = None
         Attributes applied to every cell (only with a string).
-    pair: object = NULL
+    pair: object(c_default="NULL") = None
         Color pair applied to every cell (only with a string).
 
 An immutable string of styled wide-character cells.
@@ -1431,7 +1431,7 @@ rendition, and attr and pair must be omitted.
 static PyObject *
 complexstr_new_impl(PyTypeObject *type, PyObject *cells, PyObject *attr,
                     PyObject *pair)
-/*[clinic end generated code: output=ef8a53143d35a32a input=9b75aee973cc6565]*/
+/*[clinic end generated code: output=ef8a53143d35a32a input=f152717ac17b5b88]*/
 {
     cursesmodule_state *state = get_cursesmodule_state_by_cls(type);
     /* A string is split into cells (grouping combining characters), not

--- a/Modules/clinic/_cursesmodule.c.h
+++ b/Modules/clinic/_cursesmodule.c.h
@@ -102,7 +102,7 @@ exit:
 }
 
 PyDoc_STRVAR(complexstr_new__doc__,
-"complexstr(cells, /, attr=<unrepresentable>, pair=<unrepresentable>)\n"
+"complexstr(cells, /, attr=None, pair=None)\n"
 "--\n"
 "\n"
 "An immutable string of styled wide-character cells.\n"
@@ -6585,4 +6585,4 @@ _curses_has_extended_color_support(PyObject *module, PyObject *Py_UNUSED(ignored
 #ifndef _CURSES_ASSUME_DEFAULT_COLORS_METHODDEF
     #define _CURSES_ASSUME_DEFAULT_COLORS_METHODDEF
 #endif /* !defined(_CURSES_ASSUME_DEFAULT_COLORS_METHODDEF) */
-/*[clinic end generated code: output=680f621e7c1f101b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f1b79ac96624e268 input=a9049054013a1b77]*/


### PR DESCRIPTION
`complexstr`'s two optional parameters were declared `object = NULL`, and `NULL` has no
Python repr, so Argument Clinic wrote `<unrepresentable>` into the text signature and
`inspect.signature()` raised.

Declaring them `object(c_default="NULL") = None` makes the default representable and
leaves the C default as `NULL`, so "omitted" and "given" stay distinguishable:

```
before:
  complexstr:  ValueError: <class 'curses.complexstr'> builtin has invalid signature
  __text_signature__: (cells, /, attr=<unrepresentable>, pair=<unrepresentable>)
after:
  signature: (cells, /, attr=None, pair=None)
```

Behaviour does not change. The six constructor forms that pass or omit *attr* and *pair*,
with a string and with a sequence, give identical results before and after, including the
three that raise. 37 other stdlib parameters already use this declaration.

`test_curses` passes under `TERM=xterm-256color` and `vt100`. The new assertion fails
without the change, with the `ValueError` above.

`complexstr` is new in 3.16, so there is no NEWS entry.


<!-- gh-issue-number: gh-155258 -->
* Issue: gh-155258
<!-- /gh-issue-number -->
