### PR TITLE
gh-75876: Use functools.wraps() in test.support test decorators

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1293,6 +1293,7 @@ def bigmemtest(size, memuse, dry_run=True):
     test doesn't support dummy runs when -M is not specified.
     """
     def decorator(f):
+        @functools.wraps(f)
         def wrapper(self):
             size = wrapper.size
             memuse = wrapper.memuse
@@ -1345,6 +1346,7 @@ def nomemtest(f):
 
 def bigaddrspacetest(f):
     """Decorator for tests that fill the address space."""
+    @functools.wraps(f)
     def wrapper(self):
         if max_memuse < MAX_Py_ssize_t:
             if MAX_Py_ssize_t >= 2**63 - 1 and max_memuse >= 2**31:
@@ -1450,6 +1452,7 @@ def no_rerun(reason):
     def deco(func):
         assert not isinstance(func, type), func
         _has_run = False
+        @functools.wraps(func)
         def wrapper(self):
             nonlocal _has_run
             if _has_run:


### PR DESCRIPTION
`bigmemtest()`, `bigaddrspacetest()` and `no_rerun()` returned a wrapper named
`wrapper`, so a decorator applied on top of them could not identify the test.
It blocks stacking `runInSubprocess()` on `bigmemtest()`.

<!-- gh-issue-number: gh-75876 -->
* Issue: gh-75876
<!-- /gh-issue-number -->