### PR TITLE
gh-155245: Fix calendar failing to import when strftime rejects %OB

### DIFF
--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -146,10 +146,10 @@ month_abbr = _localized_month('%b')
 try:
     standalone_month_name = _localized_month('%OB')
     standalone_month_abbr = _localized_month('%Ob')
-except ValueError:
-    standalone_month_name = month_name
-    standalone_month_abbr = month_abbr
-else:
+    # _localized_month only stores the format; strftime is called lazily when
+    # the names are first read, so systems that reject '%OB' raise ValueError
+    # here rather than above.
+    #
     # Some systems that do not support '%OB' will keep it as-is (i.e.,
     # we get [..., '%OB', '%OB', '%OB']), so for non-distinct names,
     # we fall back to month_name/month_abbr.
@@ -157,6 +157,9 @@ else:
         standalone_month_name = month_name
     if len(set(standalone_month_abbr)) != len(set(month_abbr)):
         standalone_month_abbr = month_abbr
+except ValueError:
+    standalone_month_name = month_name
+    standalone_month_abbr = month_abbr
 
 
 def isleap(year):

--- a/Lib/test/test_calendar.py
+++ b/Lib/test/test_calendar.py
@@ -2,6 +2,7 @@ import calendar
 import unittest
 
 from test import support
+from test.support import import_helper
 from test.support.script_helper import assert_python_ok, assert_python_failure
 import contextlib
 import datetime
@@ -11,6 +12,7 @@ import os
 import platform
 import sys
 import time
+from unittest import mock
 
 # From https://en.wikipedia.org/wiki/Leap_year_starting_on_Saturday
 result_0_02_text = """\
@@ -643,6 +645,26 @@ class CalendarTestCase(unittest.TestCase):
                                  list(calendar.standalone_month_name))
             self.assertListEqual(list(calendar.month_abbr),
                                  list(calendar.standalone_month_abbr))
+
+    def test_standalone_month_fallback_when_specifier_rejected(self):
+        # gh-155245: _localized_month stores the format string and only calls
+        # strftime when a name is first read, so a platform that rejects
+        # '%OB' raises ValueError while the fallback below is being computed,
+        # not while the object is being built. Importing calendar has to fall
+        # back to the regular names instead of failing outright.
+        class _RejectsStandalone(datetime.date):
+            def strftime(self, format):
+                if 'O' in format:
+                    raise ValueError(f'Invalid format string: {format}')
+                return super().strftime(format)
+
+        with mock.patch.object(datetime, 'date', _RejectsStandalone):
+            fresh_calendar = import_helper.import_fresh_module('calendar')
+
+        self.assertListEqual(list(fresh_calendar.standalone_month_name),
+                             list(fresh_calendar.month_name))
+        self.assertListEqual(list(fresh_calendar.standalone_month_abbr),
+                             list(fresh_calendar.month_abbr))
 
     def test_locale_text_calendar(self):
         try:

--- a/Misc/NEWS.d/next/Library/2026-08-06-13-05-42.gh-issue-155245.Rt4kQm.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-06-13-05-42.gh-issue-155245.Rt4kQm.rst
@@ -1,0 +1,5 @@
+Fix :mod:`calendar` failing to import on platforms whose ``strftime``
+rejects the ``%OB`` and ``%Ob`` format specifiers.  The names are computed
+lazily, so the resulting :exc:`ValueError` was raised outside the ``try``
+block that was meant to catch it, instead of falling back to the regular
+month names.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Fixes #155245.

`_localized_month` stores the format string and only calls `strftime` from
`__getitem__`, so `_localized_month('%OB')` never raises. The first `strftime`
call happens further down, in the comparison that detects systems which keep
`'%OB'` as-is — and that comparison sits in the `else` branch, outside the
`try` block meant to catch the failure:

```python
try:
    standalone_month_name = _localized_month('%OB')   # no strftime call yet
    ...
except ValueError:                                    # unreachable
    ...
else:
    if len(set(standalone_month_name)) != ...:        # strftime happens HERE
```

So on a platform whose `strftime` rejects `%OB`, the `ValueError` escapes and
`import calendar` fails outright. This is not specific to Wine — as written,
the `try`/`except` is unreachable on any such platform.

The fix moves the comparison into the `try` block so the intended fallback to
`month_name`/`month_abbr` applies. No behaviour change where `%OB` works.

Verified locally on a `main` build (3.16.0a0) by substituting a `datetime.date`
subclass whose `strftime` raises `ValueError` for `%O` formats, which reproduces
the reported traceback at `calendar.py:156` exactly. The added regression test
uses that substitution plus `import_helper.import_fresh_module('calendar')`, so
it needs no unusual platform: it fails on unpatched `main` and passes with the
fix. Full `test_calendar` passes (86 tests) and `Tools/patchcheck` is clean.

AI tools were used on this PR: Claude Code (Opus) located the cause, wrote the
patch and the test, and ran the verification. I reviewed the change, understand
it and can explain it, and I take responsibility for it.

<!-- gh-issue-number: gh-155245 -->
* Issue: gh-155245
<!-- /gh-issue-number -->
