### PR TITLE
gh-155273: Document PyConfig.lazy_imports in C API config docs

### DIFF
--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -373,10 +373,14 @@ Configuration Options
      - :c:member:`install_signal_handlers <PyConfig.install_signal_handlers>`
      - ``bool``
      - Read-only
-   * - ``"int_max_str_digits"``
-     - :c:member:`int_max_str_digits <PyConfig.int_max_str_digits>`
-     - ``int``
-     - Public
+    * - ``"int_max_str_digits"``
+      - :c:member:`int_max_str_digits <PyConfig.int_max_str_digits>`
+      - ``int``
+      - Public
+    * - ``"lazy_imports"``
+      - :c:member:`lazy_imports <PyConfig.lazy_imports>`
+      - ``int``
+      - Public
    * - ``"interactive"``
      - :c:member:`interactive <PyConfig.interactive>`
      - ``bool``
@@ -1542,6 +1546,24 @@ PyConfig
       (:data:`sys.int_info.default_max_str_digits`) in isolated mode.
 
       .. versionadded:: 3.12
+
+   .. c:member:: int lazy_imports
+
+      Controls the global lazy imports mode.
+
+      * ``-1``: ``"normal"`` - only imports explicitly marked with the ``lazy``
+        keyword are lazy (the default).
+      * ``1``: ``"all"`` - all top-level imports become potentially lazy.
+      * ``0``: rejected; not a valid value.
+
+      Configured by the :option:`-X lazy_imports <-X>` command line flag or
+      the :envvar:`PYTHON_LAZY_IMPORTS` environment variable.
+
+      See also :func:`sys.set_lazy_imports` and :pep:`810`.
+
+      Default: ``-1``.
+
+      .. versionadded:: 3.15
 
    .. c:member:: int cpu_count
 


### PR DESCRIPTION
Add missing documentation for `PyConfig.lazy_imports` to `Doc/c-api/init_config.rst`,
including the dictionary table entry and the `.. c:member::` block.

Closes #155273

<!-- gh-issue-number: gh-155273 -->
* Issue: gh-155273
<!-- /gh-issue-number -->
