### PR TITLE
gh-105499: Avoid using `functools.reduce()` to reconstruct `Union` objects

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -9806,6 +9806,7 @@ class AnnotatedTests(BaseTestCase):
         for args in itertools.permutations(get_args(expr1)):
             with self.subTest(args=args):
                 self.assertEqual(expr1, reduce(operator.or_, args))
+                self.assertEqual(expr1, Union[args])
 
         expr2 = Union[Annotated[int, 1], str, Annotated[str, {}], int]
         for args in itertools.permutations(get_args(expr2)):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -494,7 +494,7 @@ def _eval_type(t, globalns, localns, type_params, *, recursive_guard=frozenset()
         if isinstance(t, GenericAlias):
             return _rebuild_generic_alias(t, ev_args)
         if isinstance(t, Union):
-            return functools.reduce(operator.or_, ev_args)
+            return Union[ev_args]
         else:
             return t.copy_with(ev_args)
     return t
@@ -2546,7 +2546,7 @@ def _strip_annotations(t):
         stripped_args = tuple(_strip_annotations(a) for a in t.__args__)
         if stripped_args == t.__args__:
             return t
-        return functools.reduce(operator.or_, stripped_args)
+        return Union[stripped_args]
 
     return t
 


### PR DESCRIPTION
As `UnionType` is `Union` in 3.14+, we can now just use `Union[args]` to reconstruct `Union` objects in `typing`. No news entry necessary.

## Benchmarks


### Script 1: isolated construction cost

```python
import timeit
import functools
import operator
import typing

for n in (2, 3, 5, 10, 20, 40, 80):
    types_ = tuple(type(f"T{i}", (), {}) for i in range(n))
    t_reduce = min(timeit.repeat(lambda: functools.reduce(operator.or_, types_), number=20000, repeat=5))
    t_union = min(timeit.repeat(lambda: typing.Union[types_], number=20000, repeat=5))
    print(f"n={n:3d}  reduce(or_): {t_reduce/20000*1e9:9.1f} ns/call   "
          f"Union[tuple]: {t_union/20000*1e9:8.1f} ns/call   "
          f"speedup={t_reduce/t_union:.2f}x")
```

**Results:**

| members | `reduce(or_, ...)` | `Union[tuple]` | speedup |
|---:|---:|---:|---:|
| 2 | 448 ns | 407 ns | 1.10x |
| 3 | 734 ns | 436 ns | 1.68x |
| 5 | 1,521 ns | 630 ns | 2.42x |
| 10 | 4,669 ns | 862 ns | 5.41x |
| 20 | 13,967 ns | 1,388 ns | 10.06x |
| 40 | 45,431 ns | 2,119 ns | 21.44x |
| 80 | 161,641 ns | 4,533 ns | 35.66x |

```
n=  2  reduce(or_):     448.1 ns/call   Union[tuple]:    407.0 ns/call   speedup=1.10x
n=  3  reduce(or_):     733.8 ns/call   Union[tuple]:    436.2 ns/call   speedup=1.68x
n=  5  reduce(or_):    1521.4 ns/call   Union[tuple]:    630.0 ns/call   speedup=2.42x
n= 10  reduce(or_):    4668.7 ns/call   Union[tuple]:    862.4 ns/call   speedup=5.41x
n= 20  reduce(or_):   13966.6 ns/call   Union[tuple]:   1387.7 ns/call   speedup=10.06x
n= 40  reduce(or_):   45430.8 ns/call   Union[tuple]:   2119.1 ns/call   speedup=21.44x
n= 80  reduce(or_):  161641.4 ns/call   Union[tuple]:   4532.7 ns/call   speedup=35.66x
```

### Script 2: end-to-end `typing._eval_type()` on a `Union` of `n` forward refs

```python
import sys
import timeit
import typing
from typing import Union


class A: pass
class B: pass
class C: pass
class D: pass
class E: pass
class F: pass
class G: pass
class H: pass
class I_: pass
class J: pass


ALL = [A, B, C, D, E, F, G, H, I_, J, int, str, float, bytes, complex, bool,
       list, dict, set, tuple]


def make_union_alias(n):
    # Build typing.Union[ForwardRef, ForwardRef, ...] with n string members,
    # forcing typing._eval_type to rebuild the Union from evaluated args.
    names = [cls.__name__ for cls in ALL[:n]]
    ns = {cls.__name__: cls for cls in ALL[:n]}
    alias = Union[tuple(names)]  # each str member becomes a ForwardRef in __args__
    return alias, ns


def bench(label, n, stmt, **kw):
    t = min(timeit.repeat(stmt, number=n, repeat=5, globals={**globals(), **kw}))
    print(f"{label:20s} {t / n * 1e9:9.1f} ns/call  ({n} iters, best of 5)")


if __name__ == "__main__":
    for n in (2, 3, 5, 10, 20):
        alias, ns = make_union_alias(n)
        bench(f"n={n:2d}", 20_000, "typing._eval_type(alias, ns, ns, ())", alias=alias, ns=ns)
```

**Results**:

| members | before (`reduce`) | after (`Union[]`) | speedup |
|---:|---:|---:|---:|
| 2 | 7,630 ns | 7,995 ns | ~flat (noise) |
| 3 | 10,535 ns | 10,052 ns | 1.05x |
| 5 | 17,142 ns | 16,047 ns | 1.07x |
| 10 | 35,076 ns | 30,732 ns | 1.14x |
| 20 | 74,370 ns | 61,373 ns | 1.21x |

```
before (reduce/or_):
n= 2                    7629.6 ns/call  (20000 iters, best of 5)
n= 3                   10534.8 ns/call  (20000 iters, best of 5)
n= 5                   17141.8 ns/call  (20000 iters, best of 5)
n=10                   35075.9 ns/call  (20000 iters, best of 5)
n=20                   74370.2 ns/call  (20000 iters, best of 5)

after (Union[ev_args]):
n= 2                    7994.7 ns/call  (20000 iters, best of 5)
n= 3                   10052.3 ns/call  (20000 iters, best of 5)
n= 5                   16046.6 ns/call  (20000 iters, best of 5)
n=10                   30731.6 ns/call  (20000 iters, best of 5)
n=20                   61373.3 ns/call  (20000 iters, best of 5)
```



<!-- gh-issue-number: gh-105499 -->
* Issue: gh-105499
<!-- /gh-issue-number -->
