### PR TITLE
gh-155273: Document PyConfig.lazy_imports

### DIFF
--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -385,6 +385,10 @@ Configuration Options
      - :c:member:`isolated <PyConfig.isolated>`
      - ``bool``
      - Read-only
+   * - ``"lazy_imports"``
+     - :c:member:`lazy_imports <PyConfig.lazy_imports>`
+     - ``int``
+     - Public
    * - ``"legacy_windows_fs_encoding"``
      - :c:member:`legacy_windows_fs_encoding <PyPreConfig.legacy_windows_fs_encoding>`
      - ``bool``
@@ -1577,6 +1581,21 @@ PyConfig
 
       See also the :ref:`Isolated Configuration <init-isolated-conf>` and
       :c:member:`PyPreConfig.isolated`.
+
+   .. c:member:: int lazy_imports
+
+      Control :ref:`lazy imports <lazy-imports>`.
+
+      A value of ``-1`` keeps the default behaviour, where only imports marked
+      with the ``lazy`` keyword are lazy. A value of ``1`` makes every import
+      lazy. ``0`` is rejected.
+
+      Configured by the :option:`-X lazy_imports <-X>` command line option or
+      the :envvar:`PYTHON_LAZY_IMPORTS` environment variable.
+
+      Default: ``-1``.
+
+      .. versionadded:: 3.15
 
    .. c:member:: int legacy_windows_stdio
 


### PR DESCRIPTION
`lazy_imports` is a PUBLIC entry in `PYCONFIG_SPEC` (`Python/initconfig.c:127`) and a member of `PyConfig` (`Include/cpython/initconfig.h:194`), but it was the only one of the 25 PUBLIC options with no entry in this file. PEP 810 documented the feature in `Doc/c-api/import.rst`, `Doc/using/cmdline.rst` and the whatsnew, and missed this one.

This adds the row to the Configuration Options table and the `c:member:` block, both in their alphabetical place, and documents the tri-state: `-1` is the default and respects the `lazy` keyword, `1` makes every import lazy, `0` is rejected (`Python/initconfig.c:1092`, and the default is set at `:1206`).

I could not build the docs here: this environment has no `sphinx-build`, no `sphinx-lint` and no `pip`. Instead I checked that every target used already resolves in the tree (`_lazy-imports:` in `Doc/reference/simple_stmts.rst`, `.. envvar:: PYTHON_LAZY_IMPORTS` in `Doc/using/cmdline.rst`), and copied the `:option:`-X ... <-X>`` form and the row layout from the neighbouring entries. The readthedocs preview build on this PR is the real check.

3.15 has the same gap, so this looks like a backport candidate.


<!-- gh-issue-number: gh-155273 -->
* Issue: gh-155273
<!-- /gh-issue-number -->

