### PR TITLE
[3.14] gh-76075: Correct `datetime.timestamp` documentation (GH-131202)

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1531,11 +1531,11 @@ Instance methods:
    returned by :func:`time.time`.
 
    Naive :class:`.datetime` instances are assumed to represent local
-   time and this method relies on the platform C :c:func:`mktime`
-   function to perform the conversion. Since :class:`!datetime`
-   supports wider range of values than :c:func:`mktime` on many
-   platforms, this method may raise :exc:`OverflowError` or :exc:`OSError`
-   for times far in the past or far in the future.
+   time and this method relies on platform C functions to perform
+   the conversion. Since :class:`!datetime` supports a wider range of
+   values than the platform C functions on many platforms, this
+   method may raise :exc:`OverflowError` or :exc:`OSError` for times
+   far in the past or far in the future.
 
    For aware :class:`.datetime` instances, the return value is computed
    as::
@@ -1561,6 +1561,10 @@ Instance methods:
    .. versionchanged:: 3.6
       The :meth:`timestamp` method uses the :attr:`.fold` attribute to
       disambiguate the times during a repeated interval.
+
+   .. versionchanged:: 3.6
+      This method no longer relies on the platform C :c:func:`mktime`
+      function to perform conversions.
 
 
 .. method:: datetime.weekday()


### PR DESCRIPTION
(cherry picked from commit 86397cf65d024a39ae85b81d7f611ad4864a78b4)

Co-authored-by: Stan Ulbrych <89152624+StanFromIreland@users.noreply.github.com>

<!-- gh-issue-number: gh-76075 -->
* Issue: gh-76075
<!-- /gh-issue-number -->
