### PR TITLE
gh-155295: Avoid crash de-instrumenting malformed code objects

### DIFF
--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -499,6 +499,7 @@ class CodeTest(unittest.TestCase):
             with self.subTest(opcode_name=opcode_name):
                 script = textwrap.dedent(f"""
                     import dis
+                    import marshal
 
                     def func():
                         pass
@@ -506,12 +507,17 @@ class CodeTest(unittest.TestCase):
                     bytecode = bytearray(func.__code__.co_code)
                     bytecode[0] = dis._all_opmap[{opcode_name!r}]
                     code = func.__code__.replace(co_code=bytes(bytecode))
-                    try:
-                        code.co_code
-                    except SystemError as exc:
-                        assert str(exc) == "cannot de-instrument code object with invalid monitoring data"
-                    else:
-                        raise AssertionError("expected malformed code object to be rejected")
+                    operations = (
+                        lambda: code.co_code,
+                        lambda: marshal.dumps(code),
+                    )
+                    for operation in operations:
+                        try:
+                            operation()
+                        except SystemError as exc:
+                            assert str(exc) == "cannot de-instrument code object with invalid monitoring data"
+                        else:
+                            raise AssertionError("expected malformed code object to be rejected")
                 """)
                 assert_python_ok("-c", script)
 

--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -493,6 +493,28 @@ class CodeTest(unittest.TestCase):
         with self.assertRaisesRegex(SystemError, msg):
             foo()
 
+    @cpython_only
+    def test_co_code_with_invalid_monitoring_data(self):
+        for opcode_name in ("INSTRUMENTED_LINE", "INSTRUMENTED_INSTRUCTION"):
+            with self.subTest(opcode_name=opcode_name):
+                script = textwrap.dedent(f"""
+                    import dis
+
+                    def func():
+                        pass
+
+                    bytecode = bytearray(func.__code__.co_code)
+                    bytecode[0] = dis._all_opmap[{opcode_name!r}]
+                    code = func.__code__.replace(co_code=bytes(bytecode))
+                    try:
+                        code.co_code
+                    except SystemError as exc:
+                        assert str(exc) == "cannot de-instrument code object with invalid monitoring data"
+                    else:
+                        raise AssertionError("expected malformed code object to be rejected")
+                """)
+                assert_python_ok("-c", script)
+
     @requires_debug_ranges()
     def test_co_positions_artificial_instructions(self):
         import dis

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-06-19-00-00.gh-issue-155295.Km7QpL.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-06-19-00-00.gh-issue-155295.Km7QpL.rst
@@ -1,0 +1,2 @@
+Prevent a crash when accessing ``code.co_code`` on a malformed code object
+that contains instrumented opcodes without the corresponding monitoring data.

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -2199,11 +2199,23 @@ _PyCode_Clear_Executors(PyCodeObject *code)
 
 #endif
 
-static void
+static int
 deopt_code(PyCodeObject *code, _Py_CODEUNIT *instructions)
 {
     Py_ssize_t len = Py_SIZE(code);
     for (int i = 0; i < len; i++) {
+        int opcode = _PyCode_CODE(code)[i].op.code;
+        _PyCoMonitoringData *monitoring = code->_co_monitoring;
+        if ((opcode == INSTRUMENTED_LINE &&
+             (monitoring == NULL || monitoring->lines == NULL)) ||
+            (opcode == INSTRUMENTED_INSTRUCTION &&
+             (monitoring == NULL || monitoring->per_instruction_opcodes == NULL))) {
+            PyErr_SetString(
+                PyExc_SystemError,
+                "cannot de-instrument code object with invalid monitoring data");
+            return -1;
+        }
+
         _Py_CODEUNIT inst = _Py_GetBaseCodeUnit(code, i);
         assert(inst.op.code < MIN_SPECIALIZED_OPCODE);
         int caches = _PyOpcode_Caches[inst.op.code];
@@ -2213,6 +2225,7 @@ deopt_code(PyCodeObject *code, _Py_CODEUNIT *instructions)
         }
         i += caches;
     }
+    return 0;
 }
 
 PyObject *
@@ -2234,9 +2247,13 @@ _PyCode_GetCode(PyCodeObject *co)
         code = PyBytes_FromStringAndSize((const char *)_PyCode_CODE(co),
                                          _PyCode_NBYTES(co));
         if (code != NULL) {
-            deopt_code(co, (_Py_CODEUNIT *)PyBytes_AS_STRING(code));
-            assert(cached->_co_code == NULL);
-            FT_ATOMIC_STORE_PTR(cached->_co_code, code);
+            if (deopt_code(co, (_Py_CODEUNIT *)PyBytes_AS_STRING(code)) < 0) {
+                Py_CLEAR(code);
+            }
+            else {
+                assert(cached->_co_code == NULL);
+                FT_ATOMIC_STORE_PTR(cached->_co_code, code);
+            }
         }
     }
     Py_END_CRITICAL_SECTION();

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -106,6 +106,7 @@ module marshal
 #define WFERR_NESTEDTOODEEP 2
 #define WFERR_NOMEMORY 3
 #define WFERR_CODE_NOT_ALLOWED 4
+#define WFERR_EXCEPTION 5  // An exception is already set.
 
 typedef struct {
     FILE *fp;
@@ -694,7 +695,8 @@ w_complex_object(PyObject *v, char flag, WFILE *p)
         PyCodeObject *co = (PyCodeObject *)v;
         PyObject *co_code = _PyCode_GetCode(co);
         if (co_code == NULL) {
-            p->error = WFERR_NOMEMORY;
+            assert(PyErr_Occurred());
+            p->error = WFERR_EXCEPTION;
             return;
         }
         W_TYPE(TYPE_CODE, p);
@@ -1940,6 +1942,9 @@ _PyMarshal_WriteObjectToString(PyObject *x, int version, int allow_code)
         case WFERR_CODE_NOT_ALLOWED:
             PyErr_SetString(PyExc_ValueError,
                             "marshalling code objects is disallowed");
+            break;
+        case WFERR_EXCEPTION:
+            assert(PyErr_Occurred());
             break;
         default:
         case WFERR_UNMARSHALLABLE:


### PR DESCRIPTION
Prevent `_PyCode_GetCode()` from dereferencing missing monitoring data when a malformed code object contains `INSTRUMENTED_LINE` or `INSTRUMENTED_INSTRUCTION`.

## Origin and AI assistance

This failure was initially identified while reviewing production crash logs available to Datadog. The investigation, reproducer, implementation, tests, and this PR write-up were produced primarily with GPT-5.6 Sol (high), with human direction, review, and local validation.

`deopt_code()` now validates the opcode-specific monitoring array before calling `_Py_GetBaseCodeUnit()`. It raises `SystemError` and leaves the bytecode cache empty when the code object's instrumentation state is inconsistent.

`PyCode_GetCode()` documents that it returns `NULL` with an exception set on error. Because the new consistency check adds a non-allocation failure path, the marshal writer now preserves an exception already set by `_PyCode_GetCode()` rather than replacing it with `MemoryError`.

The regression test uses `CodeType.replace()` to create the malformed state in a subprocess. Without the original fix, both instrumented opcodes terminate the subprocess with `SIGSEGV`. The test covers direct `code.co_code` access and `marshal.dumps(code)`.

Validation:

- `./python -m test test_code -m test_co_code_with_invalid_monitoring_data --verbose`
- `./python -m test -j3 test_code test_marshal test_dis`
- `./python -m test -R 3:3 test_code -m test_co_code_with_invalid_monitoring_data`
- `PATH=/usr/bin:/bin:/usr/sbin:/sbin ./python -m test -j12`: 50,379 tests executed, 470 test files passed, 3,449 tests skipped, no failures
- `make patchcheck`

* Issue: gh-155295
