### PR TITLE
gh-75876: Correct the memory use declared by some bigmem tests

### DIFF
--- a/Lib/test/test_bigmem.py
+++ b/Lib/test/test_bigmem.py
@@ -901,7 +901,7 @@ class TupleTest(unittest.TestCase):
     def test_repeat_large(self, size):
         return self.basic_test_repeat(size)
 
-    @bigmemtest(size=_1G - 1, memuse=12)
+    @bigmemtest(size=_1G - 1, memuse=pointer_size * 3)
     def test_repeat_large_2(self, size):
         return self.basic_test_repeat(size)
 

--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -691,12 +691,12 @@ class HashLibTestCase(unittest.TestCase):
         )
 
     @unittest.skipIf(sys.maxsize < _4G + 5, 'test cannot run on 32-bit systems')
-    @bigmemtest(size=_4G + 5, memuse=1, dry_run=False)
+    @bigmemtest(size=_4G + 5, memuse=2, dry_run=False)
     def test_case_md5_huge(self, size):
         self.check('md5', b'A'*size, 'c9af2dff37468ce5dfee8f2cfc0a9c6d')
 
     @unittest.skipIf(sys.maxsize < _4G - 1, 'test cannot run on 32-bit systems')
-    @bigmemtest(size=_4G - 1, memuse=1, dry_run=False)
+    @bigmemtest(size=_4G - 1, memuse=2, dry_run=False)
     def test_case_md5_uintmax(self, size):
         self.check('md5', b'A'*size, '28138d306ff1b8281f1a9067e1a1a2b3')
 

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -2251,7 +2251,7 @@ class ReTests(unittest.TestCase):
 
     # The huge memuse is because of re.sub() using a list and a join()
     # to create the replacement result.
-    @bigmemtest(size=_2G, memuse=16 + 2)
+    @bigmemtest(size=_2G, memuse=16 + 3)
     def test_large_subn(self, size):
         # Issue #10182: indices were 32-bit-truncated.
         s = 'a' * size

--- a/Lib/test/test_tcl.py
+++ b/Lib/test/test_tcl.py
@@ -805,7 +805,7 @@ class BigmemTclTest(unittest.TestCase):
 
     @support.cpython_only
     @unittest.skipUnless(INT_MAX < PY_SSIZE_T_MAX, "needs UINT_MAX < SIZE_MAX")
-    @support.bigmemtest(size=INT_MAX + 1, memuse=2, dry_run=False)
+    @support.bigmemtest(size=INT_MAX + 1, memuse=3, dry_run=False)
     def test_huge_string_builtins(self, size):
         tk = self.interp.tk
         value = '1' + ' ' * size

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -1090,7 +1090,7 @@ class ZlibDecompressorTest(unittest.TestCase):
         self.assertRaises(EOFError, zlibd.decompress, b"")
 
     @support.skip_if_pgo_task
-    @bigmemtest(size=_4G + 100, memuse=3.3)
+    @bigmemtest(size=_4G + 100, memuse=4.5)
     def testDecompress4G(self, size):
         # "Test zlib._ZlibDecompressor.decompress() with >4GiB input"
         blocksize = min(10 * 1024 * 1024, size)


### PR DESCRIPTION
Some bigmem tests declare less memory than they use.  Measured as the peak RSS of a process running a single test with `-M`:

| test | declared | measured | |
| --- | --- | --- | --- |
| `TupleTest.test_repeat_large_2` | 12.0 GiB | 24.2 GiB | 2.02x |
| `HashLibTestCase.test_case_md5_huge` | 4.0 GiB | 8.3 GiB | 2.06x |
| `HashLibTestCase.test_case_md5_uintmax` | 4.0 GiB | 8.3 GiB | 2.06x |
| `ZlibDecompressorTest.testDecompress4G` | 13.2 GiB | 16.3 GiB | 1.23x |
| `BigmemTclTest.test_huge_string_builtins` | 4.0 GiB | 6.0 GiB | 1.51x |
| `ReTests.test_large_subn` | 36.0 GiB | 37.7 GiB | 1.05x |

`test_repeat_large_2` keeps 3 tuples of pointers alive, as `test_repeat_small` and `test_repeat_large` do, but declared `12` instead of `pointer_size * 3`, which is the count for a 32-bit build.

The md5 tests pass the data to `check_file_digest()`, which copies all of it into an `io.BytesIO()`.

`testDecompress4G` keeps the data, the compressed and the decompressed bytes alive at the same time, and the decompressor grows its output buffer.

These are the only tests which use more memory than they declare.  Every other bigmem test was measured too, except the two `test_marshal` tests which declare 256 GiB and cannot be run anywhere: the largest excess is 1.04x, and it is 20 MiB in the median.

<!-- gh-issue-number: gh-75876 -->
* Issue: gh-75876
<!-- /gh-issue-number -->

