### PR TITLE
[3.13] gh-75876: Use functools.wraps() in test.support test decorators (GH-155262)

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1181,6 +1181,7 @@ def bigmemtest(size, memuse, dry_run=True):
     test doesn't support dummy runs when -M is not specified.
     """
     def decorator(f):
+        @functools.wraps(f)
         def wrapper(self):
             size = wrapper.size
             memuse = wrapper.memuse
@@ -1233,6 +1234,7 @@ def nomemtest(f):
 
 def bigaddrspacetest(f):
     """Decorator for tests that fill the address space."""
+    @functools.wraps(f)
     def wrapper(self):
         if max_memuse < MAX_Py_ssize_t:
             if MAX_Py_ssize_t >= 2**63 - 1 and max_memuse >= 2**31:


### PR DESCRIPTION
Manual backport of GH-155262: `no_rerun()` does not exist on 3.13, so only `bigmemtest()` and `bigaddrspacetest()` are changed.

`bigmemtest()` returns a wrapper whose `__name__` is `"wrapper"`, so a decorator applied on top of it cannot identify the test.  `test.support.isolation.runInSubprocess()`, which is on this branch, looks the test up by name in the subprocess, so stacking it on `@bigmemtest` fails with `AttributeError: type object 'X' has no attribute 'wrapper'`.  No test in the suite stacks them yet, so nothing currently fails.

(cherry picked from commit c3aefdb9eff0734058376b96fc86d89b1a345d75)

<!-- gh-issue-number: gh-75876 -->
* Issue: gh-75876
<!-- /gh-issue-number -->
