### PR TITLE
gh-155324: Pickle frozendict with all protocols

### DIFF
--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2890,7 +2890,7 @@ class AbstractPickleTests:
     def test_recursive_frozendict_and_inst(self):
         if self.py_version < (3, 15):
             self.skipTest('need frozendict')
-        self._test_recursive_collection_and_inst(frozendict.fromkeys, minprotocol=2)
+        self._test_recursive_collection_and_inst(frozendict.fromkeys)
 
     def test_recursive_set_and_inst(self):
         self._test_recursive_collection_and_inst(set)
@@ -2929,7 +2929,7 @@ class AbstractPickleTests:
     def test_recursive_frozendict_in_key(self):
         if self.py_version < (3, 15):
             self.skipTest('need frozendict')
-        self._test_recursive_collection_in_key(frozendict, minprotocol=2)
+        self._test_recursive_collection_in_key(frozendict)
 
     def test_recursive_frozendict_subclass_in_key(self):
         if self.py_version < (3, 15):
@@ -2950,7 +2950,7 @@ class AbstractPickleTests:
     def test_recursive_frozendict_in_value(self):
         if self.py_version < (3, 15):
             self.skipTest('need frozendict')
-        self._test_recursive_collection_in_value(frozendict, minprotocol=2)
+        self._test_recursive_collection_in_value(frozendict)
 
     def test_recursive_frozendict_subclass_in_value(self):
         if self.py_version < (3, 15):
@@ -4635,7 +4635,7 @@ class AbstractPickleTests:
     def test_fast_save_enter_frozendict(self):
         if self.py_version < (3, 15):
             self.skipTest('need frozendict')
-        self.fast_save_enter(lambda i: frozendict(key=i), minprotocol=2)
+        self.fast_save_enter(lambda i: frozendict(key=i))
 
     def test_fast_save_enter_dict(self):
         self.fast_save_enter(lambda i: {"key": i})

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1991,19 +1991,14 @@ class FrozenDictTests(unittest.TestCase):
                 if type(fd) == FrozenDictSlots:
                     fd.slot_attr = 456
                 with self.subTest(fd=fd, proto=proto):
-                    if proto >= 2:
-                        p = pickle.dumps(fd, proto)
-                        fd2 = pickle.loads(p)
-                        self.assertEqual(fd2, fd)
-                        self.assertEqual(type(fd2), type(fd))
-                        if type(fd) == FrozenDict:
-                            self.assertEqual(fd2.attr, 123)
-                        if type(fd) == FrozenDictSlots:
-                            self.assertEqual(fd2.slot_attr, 456)
-                    else:
-                        # protocol 0 and 1 don't support frozendict
-                        with self.assertRaises(TypeError):
-                            pickle.dumps(fd, proto)
+                    p = pickle.dumps(fd, proto)
+                    fd2 = pickle.loads(p)
+                    self.assertEqual(fd2, fd)
+                    self.assertEqual(type(fd2), type(fd))
+                    if type(fd) == FrozenDict:
+                        self.assertEqual(fd2.attr, 123)
+                    if type(fd) == FrozenDictSlots:
+                        self.assertEqual(fd2.slot_attr, 456)
 
     def test_pickle_iter(self):
         fd = frozendict(c=1, b=2, a=3, d=4, e=5, f=6)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-07-18-19-51.gh-issue-155324.Pk4Rz7.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-07-18-19-51.gh-issue-155324.Pk4Rz7.rst
@@ -1,0 +1,3 @@
+``frozendict`` can now be pickled with all pickle protocols, matching
+:class:`frozenset`. Previously protocols 0 and 1 raised :exc:`TypeError`.
+Patch by tonghuaroot.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -8344,14 +8344,29 @@ _PyObject_InlineValuesConsistencyCheck(PyObject *obj)
 // --- frozendict implementation ---------------------------------------------
 
 static PyObject *
-frozendict_getnewargs(PyObject *op, PyObject *Py_UNUSED(dummy))
+frozendict_reduce(PyObject *op, PyObject *Py_UNUSED(dummy))
 {
-    // Call dict(op): convert 'op' frozendict to a dict
+    // Mirror frozenset.__reduce__ so frozendict pickles at every protocol
+    // (__getnewargs__ alone only works at protocol 2 and above).
+    // Call dict(op) to convert the frozendict to a dict argument.
     PyObject *arg = PyObject_CallOneArg((PyObject*)&PyDict_Type, op);
     if (arg == NULL) {
         return NULL;
     }
-    return Py_BuildValue("(N)", arg);
+    PyObject *args = PyTuple_Pack(1, arg);
+    Py_DECREF(arg);
+    if (args == NULL) {
+        return NULL;
+    }
+    PyObject *state = _PyObject_GetState(op);
+    if (state == NULL) {
+        Py_DECREF(args);
+        return NULL;
+    }
+    PyObject *result = PyTuple_Pack(3, Py_TYPE(op), args, state);
+    Py_DECREF(args);
+    Py_DECREF(state);
+    return result;
 }
 
 
@@ -8377,7 +8392,8 @@ static PyMethodDef frozendict_methods[] = {
     DICT___REVERSED___METHODDEF
     {"__class_getitem__", Py_GenericAlias, METH_O|METH_CLASS,
      PyDoc_STR("frozendicts are generic over two types, signifying (respectively) the types of the frozendict's keys and values")},
-    {"__getnewargs__", frozendict_getnewargs, METH_NOARGS},
+    {"__reduce__", frozendict_reduce, METH_NOARGS,
+     PyDoc_STR("Return state information for pickling.")},
     {NULL,              NULL}   /* sentinel */
 };
 


### PR DESCRIPTION
`frozendict` only defined `__getnewargs__`, so pickling raised `TypeError` at
protocols 0 and 1 (which do not use it); protocols 2 to 5 worked. Give
`frozendict` a `__reduce__` mirroring `frozenset`, so it pickles at every
protocol, including a subclass's instance state.


<!-- gh-issue-number: gh-155324 -->
* Issue: gh-155324
<!-- /gh-issue-number -->
