### PR TITLE
gh-155332: Use self.Value instead of bare Value in two threads-only pool tests

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3165,7 +3165,7 @@ class _TestPool(BaseTestCase):
 
         processes = 4
         p = self.Pool(processes)
-        last_produced_task_arg = Value("i")
+        last_produced_task_arg = self.Value("i", 0)
 
         def produce_args():
             for arg in itertools.count(1):
@@ -3202,7 +3202,7 @@ class _TestPool(BaseTestCase):
 
         processes = 4
         p = self.Pool(processes)
-        last_produced_task_arg = Value("i")
+        last_produced_task_arg = self.Value("i", 0)
 
         def produce_args():
             for arg in itertools.count(1):


### PR DESCRIPTION
Fixes a NameError when ctypes/sharedctypes are unavailable (gh-155332):
these two tests used the module-level `Value` from the guarded sharedctypes
import, with no HAS_SHAREDCTYPES skip guard.

The tests are threads-only, so self.Value resolves to
multiprocessing.dummy.Value and no longer depends on sharedctypes; this
also matches how the rest of the suite creates shared values. When ctypes
is available both forms are equivalent (value initialized to zero).

First contribution to CPython - happy to adjust to the project process