### PR TITLE
gh-155321: Avoid Python.h POSIX macro redefinition

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-08-07-00-00-00.gh-issue-155321.pythonh-posix.rst
+++ b/Misc/NEWS.d/next/Build/2026-08-07-00-00-00.gh-issue-155321.pythonh-posix.rst
@@ -1,0 +1,2 @@
+Allow :file:`Python.h` to be included after system headers that define
+``_POSIX_C_SOURCE`` without causing a macro redefinition diagnostic.

--- a/configure
+++ b/configure
@@ -4809,7 +4809,7 @@ printf "%s\n" "#define _XOPEN_SOURCE_EXTENDED 1" >>confdefs.h
 
 
 
-printf "%s\n" "#define _POSIX_C_SOURCE 202405L" >>confdefs.h
+printf "%s\n" "#define _PYTHON_POSIX_C_SOURCE 1" >>confdefs.h
 
 
   # Defining _POSIX_C_SOURCE and _XOPEN_SOURCE hides C23 library

--- a/configure.ac
+++ b/configure.ac
@@ -237,6 +237,15 @@ AH_BOTTOM([
 #define STRICT_SYSV_CURSES /* Don't use ncurses extensions */
 #endif
 
+/* Define _POSIX_C_SOURCE only when it was not defined by an earlier
+   system-header include. */
+#ifdef _PYTHON_POSIX_C_SOURCE
+#  ifndef _POSIX_C_SOURCE
+#    define _POSIX_C_SOURCE 202405L
+#  endif
+#  undef _PYTHON_POSIX_C_SOURCE
+#endif
+
 #endif /*Py_PYCONFIG_H*/
 ])
 
@@ -930,8 +939,8 @@ then
   AC_DEFINE([_XOPEN_SOURCE_EXTENDED], [1],
             [Define to activate Unix95-and-earlier features])
 
-  AC_DEFINE([_POSIX_C_SOURCE], [202405L],
-            [Define to activate features from IEEE Std 1003.1-2024])
+  AC_DEFINE([_PYTHON_POSIX_C_SOURCE], [1],
+            [Define to configure _POSIX_C_SOURCE in pyconfig.h])
 
   # Defining _POSIX_C_SOURCE and _XOPEN_SOURCE hides C23 library
   # declarations on FreeBSD (e.g. sinpi() in math.h) when compiling

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -2161,8 +2161,8 @@
 /* Define on NetBSD to activate all library features */
 #undef _NETBSD_SOURCE
 
-/* Define to activate features from IEEE Std 1003.1-2024 */
-#undef _POSIX_C_SOURCE
+/* Define to configure _POSIX_C_SOURCE in pyconfig.h */
+#undef _PYTHON_POSIX_C_SOURCE
 
 /* Define if you have POSIX threads, and your system does not define that. */
 #undef _POSIX_THREADS
@@ -2263,5 +2263,13 @@
 #define STRICT_SYSV_CURSES /* Don't use ncurses extensions */
 #endif
 
-#endif /*Py_PYCONFIG_H*/
+/* Define _POSIX_C_SOURCE only when it was not defined by an earlier
+   system-header include. */
+#ifdef _PYTHON_POSIX_C_SOURCE
+#  ifndef _POSIX_C_SOURCE
+#    define _POSIX_C_SOURCE 202405L
+#  endif
+#  undef _PYTHON_POSIX_C_SOURCE
+#endif
 
+#endif /*Py_PYCONFIG_H*/

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -2161,14 +2161,14 @@
 /* Define on NetBSD to activate all library features */
 #undef _NETBSD_SOURCE
 
-/* Define to configure _POSIX_C_SOURCE in pyconfig.h */
-#undef _PYTHON_POSIX_C_SOURCE
-
 /* Define if you have POSIX threads, and your system does not define that. */
 #undef _POSIX_THREADS
 
 /* framework name */
 #undef _PYTHONFRAMEWORK
+
+/* Define to configure _POSIX_C_SOURCE in pyconfig.h */
+#undef _PYTHON_POSIX_C_SOURCE
 
 /* Maximum length in bytes of a thread name */
 #undef _PYTHREAD_NAME_MAXLEN
@@ -2273,3 +2273,4 @@
 #endif
 
 #endif /*Py_PYCONFIG_H*/
+


### PR DESCRIPTION
Fixes #155321.

Summary:
- Generate a private configure marker and define _POSIX_C_SOURCE only when it was not defined by an earlier system-header include.
- Keep the configured 202405L value when Python.h is included first.

Tests:
- clang -Werror include-order checks with _POSIX_C_SOURCE present and absent.
- ./configure --with-pydebug --without-lto
- make -j4
- ./python.exe -m test test_zstd (119 tests)

<!-- gh-issue-number: gh-155321 -->
* Issue: gh-155321
<!-- /gh-issue-number -->
