### PR TITLE
gh-54643: Document the rules for public names in the tutorial

### DIFF
--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -603,3 +603,17 @@ modules found in a package.
 .. [#] In fact function definitions are also 'statements' that are 'executed'; the
    execution of a module-level function definition adds the function name to
    the module's global namespace.
+
+Public Names
+------------
+
+.. note::
+   When using a module, it is important to know which names (functions, classes, variables) are intended for you to use (the *public API*), and which are internal details that might change.
+
+The rules for public names are:
+
+1. If a module defines an ``__all__`` variable, only the names listed inside it are considered public. All remaining names are considered private.
+
+2. If a module does not define an ``__all__`` variable, then any name that does NOT start with an underscore (``_``) is considered public.
+
+3. Any imported names from other modules are not public, unless they are explicitly included in ``__all__``.


### PR DESCRIPTION
Fixes #54643

This PR adds a new section to modules.rst to clearly document the PEP 8 guidelines for public and private names.
As discussed in the issue, this moves the definition out of the dense language reference and into the tutorial so it is much easier for everyday users to find.

The update clarifies three key rules:
1-How __all__ explicitly defines a public API.
2-The fallback behavior for names without an _ prefix.
3-The rule that imported modules remain private.

Let me know if any of the wording needs to be tweaked!
Documentation preview : [https://cpython-previews--.org.readthedocs.build/](https://cpython-previews--.org.readthedocs.build/) 

<!-- gh-issue-number: gh-54643 -->
* Issue: gh-54643
<!-- /gh-issue-number -->
