### PR TITLE
gh-89132: Fix subclassing of annotated types

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -9943,6 +9943,36 @@ class AnnotatedTests(BaseTestCase):
             class C(Annotated):
                 pass
 
+    def test_subclass(self):
+        # gh-89132: subclassing an annotated type is the same as subclassing
+        # the annotated type itself.
+        class MyGeneric(Generic[T]):
+            pass
+
+        for tp in (list, List, List[int], list[int], MyGeneric[int],
+                   collections.abc.Sequence[int]):
+            with self.subTest(tp=tp):
+                class C(Annotated[tp, "a decoration"]):
+                    pass
+
+                class D(tp):
+                    pass
+
+                self.assertEqual(C.__bases__, D.__bases__)
+                self.assertEqual(C.__mro__[1:], D.__mro__[1:])
+
+    def test_cannot_subclass_not_subclassable(self):
+        # gh-89132: the error message is the same as for the annotated type.
+        for tp in (Union[int, str], int | str, T):
+            with self.subTest(tp=tp):
+                with self.assertRaises(TypeError) as cm:
+                    class D(tp):
+                        pass
+                with self.assertRaises(TypeError) as cm2:
+                    class C(Annotated[tp, "a decoration"]):
+                        pass
+                self.assertEqual(str(cm2.exception), str(cm.exception))
+
     def test_cannot_check_instance(self):
         with self.assertRaises(TypeError):
             isinstance(5, Annotated[int, "positive"])

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2254,7 +2254,14 @@ class _AnnotatedAlias(_NotIterable, _GenericAlias, _root=True):
         return super().__getattr__(attr)
 
     def __mro_entries__(self, bases):
-        return (self.__origin__,)
+        origin = self.__origin__
+        if not isinstance(origin, type):
+            # The origin can need a resolution itself, e.g. list[int].
+            meth = getattr(origin, '__mro_entries__', None)
+            if meth is not None:
+                bases = tuple(origin if b is self else b for b in bases)
+                return meth(bases)
+        return (origin,)
 
 
 @_TypedCacheSpecialForm

--- a/Misc/NEWS.d/next/Library/2026-08-07-03-40-00.gh-issue-89132.annmro.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-07-03-40-00.gh-issue-89132.annmro.rst
@@ -1,0 +1,4 @@
+Subclassing :data:`typing.Annotated` types now works if the annotated type
+is a generic alias, e.g. ``Annotated[list[int], "metadata"]``.  If the
+annotated type cannot be subclassed, the raised error is now the same as for
+that type.


### PR DESCRIPTION
Subclassing an annotated type only worked if the annotated type was a class:

```pycon
>>> from typing import Annotated, List
>>> class X(Annotated[List[int], 'metadata']): pass
...
TypeError: _GenericAlias.__init__() takes 3 positional arguments but 4 were given
>>> class X(Annotated[list[int], 'metadata']): pass
...
TypeError: GenericAlias expected 2 arguments, got 3
```

`__mro_entries__()` returned the annotated type itself, but it can need a resolution too. It now delegates to `__mro_entries__()` of the annotated type, so subclassing `Annotated[X, ...]` is the same as subclassing `X`, including the error if `X` cannot be subclassed.

<!-- gh-issue-number: gh-89132 -->
* Issue: gh-89132
<!-- /gh-issue-number -->
