### PR TITLE
gh-155358: Use named attributes with os module

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -857,7 +857,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
 
             self.send_response(HTTPStatus.OK)
             self.send_header("Content-type", ctype)
-            self.send_header("Content-Length", str(fs[6]))
+            self.send_header("Content-Length", str(fs.st_size))
             self.send_header("Last-Modified",
                 self.date_time_string(fs.st_mtime))
             self._send_extra_response_headers()

--- a/Lib/test/test_os/test_posix.py
+++ b/Lib/test/test_os/test_posix.py
@@ -1816,8 +1816,8 @@ class TestPosixDirFd(unittest.TestCase):
                 self.skipTest('posix.link(): %s' % e)
             self.addCleanup(posix.unlink, fulllinkname)
             # should have same inodes
-            self.assertEqual(posix.stat(fullname)[1],
-                posix.stat(fulllinkname)[1])
+            self.assertEqual(posix.stat(fullname).st_ino,
+                             posix.stat(fulllinkname).st_ino)
 
     @unittest.skipUnless(os.mkdir in os.supports_dir_fd, "test needs dir_fd support in os.mkdir()")
     def test_mkdir_dir_fd(self):

--- a/Tools/c-analyzer/distutils/dep_util.py
+++ b/Tools/c-analyzer/distutils/dep_util.py
@@ -20,9 +20,8 @@ def newer (source, target):
     if not os.path.exists(target):
         return 1
 
-    from stat import ST_MTIME
-    mtime1 = os.stat(source)[ST_MTIME]
-    mtime2 = os.stat(target)[ST_MTIME]
+    mtime1 = os.stat(source).st_mtime
+    mtime2 = os.stat(target).st_mtime
 
     return mtime1 > mtime2
 


### PR DESCRIPTION
Replace os.stat() result:

* st[1] => st.st_ino
* st[6] => st.st_size
* st[ST_MTIME] => st_mtime: change int type to float

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-155358 -->
* Issue: gh-155358
<!-- /gh-issue-number -->
