### PR TITLE
gh-155358: Use named attributes with test.support.script_helper

### DIFF
--- a/Lib/test/test_calendar.py
+++ b/Lib/test/test_calendar.py
@@ -1108,7 +1108,8 @@ class CommandLineTestCase(unittest.TestCase):
         return stdout.buffer.read()
 
     def run_cmd_ok(self, *args):
-        return assert_python_ok('-m', 'calendar', *args)[1]
+        proc = assert_python_ok('-m', 'calendar', *args)
+        return proc.out
 
     def assertCLIFails(self, *args):
         with self.captured_stderr_with_buffer() as stderr:

--- a/Lib/test/test_hash.py
+++ b/Lib/test/test_hash.py
@@ -182,10 +182,10 @@ class HashRandomizationTests:
             env['PYTHONHASHSEED'] = str(seed)
         else:
             env.pop('PYTHONHASHSEED', None)
-        out = assert_python_ok(
+        proc = assert_python_ok(
             '-c', self.get_hash_command(repr_),
             **env)
-        stdout = out[1].strip()
+        stdout = proc.out.strip()
         return int(stdout)
 
     def test_randomized_hash(self):

--- a/Lib/test/test_os/test_os.py
+++ b/Lib/test/test_os/test_os.py
@@ -2459,8 +2459,8 @@ class URandomTests(unittest.TestCase):
             'data = os.urandom(%s)' % count,
             'sys.stdout.buffer.write(data)',
             'sys.stdout.buffer.flush()'))
-        out = assert_python_ok('-c', code)
-        stdout = out[1]
+        proc = assert_python_ok('-c', code)
+        stdout = proc.out
         self.assertEqual(len(stdout), count)
         return stdout
 

--- a/Lib/test/test_script_helper.py
+++ b/Lib/test/test_script_helper.py
@@ -12,7 +12,7 @@ class TestScriptHelper(unittest.TestCase):
 
     def test_assert_python_ok(self):
         t = script_helper.assert_python_ok('-c', 'import sys; sys.exit(0)')
-        self.assertEqual(0, t[0], 'return code was not 0')
+        self.assertEqual(0, t.rc, 'return code was not 0')
 
     def test_assert_python_failure(self):
         # I didn't import the sys module so this child will fail.

--- a/Lib/test/test_utf8_mode.py
+++ b/Lib/test/test_utf8_mode.py
@@ -29,11 +29,11 @@ class UTF8ModeTests(unittest.TestCase):
     def get_output(self, *args, failure=False, **kw):
         kw = dict(self.DEFAULT_ENV, **kw)
         if failure:
-            out = assert_python_failure(*args, **kw)
-            out = out[2]
+            proc = assert_python_failure(*args, **kw)
+            out = proc.err
         else:
-            out = assert_python_ok(*args, **kw)
-            out = out[1]
+            proc = assert_python_ok(*args, **kw)
+            out = proc.out
         return out.decode().rstrip("\n\r")
 
     @unittest.skipIf(MS_WINDOWS, 'Windows has no POSIX locale')


### PR DESCRIPTION
Replace assert_python_ok() result:

* proc[0] => proc.rc
* proc[1] => proc.out
* proc[2] => proc.err

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-155358 -->
* Issue: gh-155358
<!-- /gh-issue-number -->
