### PR TITLE
gh-155376: prevent supercheck NULL dereference

### DIFF
--- a/Lib/test/test_super.py
+++ b/Lib/test/test_super.py
@@ -437,6 +437,11 @@ class TestSuper(unittest.TestCase):
                 with self.assertRaisesRegex(TypeError, regex):
                     c.method(type_, obj)
 
+    def test_supercheck_uninitialized_super(self):
+        s = super.__new__(super)
+        with self.assertRaisesRegex(TypeError, "super object has no type"):
+            s.__get__(1)
+
     def test_super___class__(self):
         class C:
             def method(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-08-14-04-39.gh-issue-155376.NkZ4mI.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-08-14-04-39.gh-issue-155376.NkZ4mI.rst
@@ -1,2 +1,2 @@
-Fix a crash in :func:`super` when an uninitialized `super` object created
-with `super.__new__(super)` was used as a descriptor.
+Fix a crash in :func:`super` when an uninitialized ``super`` object created
+with ``super.__new__(super)`` was used as a descriptor.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-08-14-04-39.gh-issue-155376.NkZ4mI.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-08-14-04-39.gh-issue-155376.NkZ4mI.rst
@@ -1,0 +1,2 @@
+Fix a crash in :func:`super` when an uninitialized `super` object created
+with `super.__new__(super)` was used as a descriptor.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-08.gh-issue-155376.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-08.gh-issue-155376.rst
@@ -1,0 +1,2 @@
+Fix a crash in :func:`super` when an uninitialized ``super`` object created
+with ``super.__new__(super)`` was used as a descriptor.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-08.gh-issue-155376.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-08.gh-issue-155376.rst
@@ -1,2 +1,0 @@
-Fix a crash in :func:`super` when an uninitialized ``super`` object created
-with ``super.__new__(super)`` was used as a descriptor.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -12562,6 +12562,12 @@ supercheck(PyTypeObject *type, PyObject *obj)
        This will allow using super() with a proxy for obj.
     */
 
+    if (type == NULL) {
+        PyErr_SetString(PyExc_TypeError,
+                        "super object has no type");
+        return NULL;
+    }
+
     /* Check for first bullet above (special case) */
     if (PyType_Check(obj) && PyType_IsSubtype((PyTypeObject *)obj, type)) {
         return (PyTypeObject *)Py_NewRef(obj);
@@ -12642,8 +12648,7 @@ super_descr_get(PyObject *self, PyObject *obj, PyObject *type)
         PyTypeObject *obj_type = supercheck(su->type, obj);
         if (obj_type == NULL)
             return NULL;
-        newobj = (superobject *)PySuper_Type.tp_new(&PySuper_Type,
-                                                 NULL, NULL);
+        newobj = (superobject *)PySuper_Type.tp_alloc(&PySuper_Type, 0);
         if (newobj == NULL) {
             Py_DECREF(obj_type);
             return NULL;


### PR DESCRIPTION
## Summary

Fix a NULL dereference in `supercheck()` when an uninitialized `super` object is used as a descriptor.

## What happened?

`super.__new__(super)` can create a `super` object whose internal `type` field is `NULL`. When that object is subsequently used through `__get__()`, `supercheck()` receives the NULL type pointer.

The error-handling path in `supercheck()` eventually formats an error message using `type->tp_name`, causing a NULL pointer dereference and a segmentation fault.

## Fix

This change:

- Adds an explicit NULL check for `type` in `supercheck()`.
- Raises `TypeError("super object has no type")` instead of dereferencing the NULL pointer.
- Uses `tp_alloc()` directly in `super_descr_get()` for the internal `super` object allocation.
- Adds a regression test for the uninitialized `super` case.
- Adds a NEWS entry documenting the crash fix.

## Reproducer

Before this change:

```python
s = super.__new__(super)
s.__get__(1)
```

resulted in:
```
Segmentation fault (core dumped)
```

After this change:
```
TypeError: super object has no type
```

## Tests 
```
./python -m test test_super — passed
./python -m test test_super test_descr — passed
git diff --check — passed
```

Closes issue gh-155376