### PR TITLE
gh-155140: Fix ipaddress.IPv6Address.is_link_local to require the strict fe80::/64 range

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -2410,7 +2410,7 @@ class IPv6Network(_BaseV6, _BaseNetwork):
 
 class _IPv6Constants:
 
-    _linklocal_network = IPv6Network('fe80::/10')
+    _linklocal_network = IPv6Network('fe80::/64')
 
     _multicast_network = IPv6Network('ff00::/8')
 

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -2472,12 +2472,13 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertEqual(False, ipaddress.ip_network('fbff:ffff::').is_private)
         self.assertEqual(False, ipaddress.ip_network('fe00::').is_private)
 
-        self.assertEqual(True, ipaddress.ip_network('fea0::').is_link_local)
-        self.assertEqual(True, ipaddress.ip_network(
-                'febf:ffff::').is_link_local)
+        self.assertEqual(False, ipaddress.ip_network('fea0::').is_link_local)
+        self.assertEqual(False, ipaddress.ip_network('febf:ffff::').is_link_local)
         self.assertEqual(False, ipaddress.ip_network(
                 'fe7f:ffff::').is_link_local)
         self.assertEqual(False, ipaddress.ip_network('fec0::').is_link_local)
+        self.assertEqual(True, ipaddress.ip_network('fe80::').is_link_local)
+        self.assertEqual(False, ipaddress.ip_network('fe80:6666:6666:6666:6666:6666:6666:6666').is_link_local)
 
         self.assertEqual(True, ipaddress.ip_interface('0:0::0:01').is_loopback)
         self.assertEqual(False, ipaddress.ip_interface('::1/127').is_loopback)
@@ -2511,12 +2512,13 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertEqual(False, ipaddress.ip_address('fbff:ffff::').is_private)
         self.assertEqual(False, ipaddress.ip_address('fe00::').is_private)
 
-        self.assertEqual(True, ipaddress.ip_address('fea0::').is_link_local)
-        self.assertEqual(True, ipaddress.ip_address(
-                'febf:ffff::').is_link_local)
+        self.assertEqual(False, ipaddress.ip_address('fea0::').is_link_local)
+        self.assertEqual(False, ipaddress.ip_address('febf:ffff::').is_link_local)
         self.assertEqual(False, ipaddress.ip_address(
                 'fe7f:ffff::').is_link_local)
         self.assertEqual(False, ipaddress.ip_address('fec0::').is_link_local)
+        self.assertEqual(True, ipaddress.ip_address('fe80::').is_link_local)
+        self.assertEqual(False, ipaddress.ip_address('fe80:6666:6666:6666:6666:6666:6666:6666').is_link_local)
 
         self.assertEqual(True, ipaddress.ip_address('0:0::0:01').is_loopback)
         self.assertEqual(True, ipaddress.ip_address('::1').is_loopback)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Fixes gh-155140.

Bug description:

`ipaddress.IPv6Address.is_link_local` currently checks membership in the broad `fe80::/10` block, but per RFC 4291 section 2.5.6 a true link-local address must have the first 64 bits equal to `fe80::` exactly (10-bit prefix followed by 54 zero bits). This means addresses that fall inside `fe80::/10` but outside `fe80::/64` are incorrectly reported as link-local.

Reproducer:

```python
import ipaddress
ipaddress.IPv6Address("fe80:6666:6666:6666:6666:6666:6666:6666").is_link_local
```

Current output on main: `True`
Expected output: `False`

Fix:

Change `_IPv6Constants._linklocal_network` from `fe80::/10` to `fe80::/64`, matching the strict RFC 4291 definition.

Testing:

Updated the existing `testReservedIpv6` assertions for `fea0::` and `febf:ffff::` (previously expected `True`, now correctly `False` since they fall outside `fe80::/64`), and added regression tests for `fe80::` (still `True`) and the originally reported `fe80:6666:...` address (now `False`), for both `ipaddress.ip_network` and `ipaddress.ip_address`.