### PR TITLE
gh-155385: Speed up `range.__contains__` for compact ints

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-08-15-55-16.gh-issue-155385.7DdKrH.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-08-15-55-16.gh-issue-155385.7DdKrH.rst
@@ -1,0 +1,4 @@
+Speed up ``in`` and :meth:`!count` on :class:`range` objects by up to 4x when
+the value and the range bounds are all small integers, by testing membership
+with machine arithmetic instead of the abstract number API.  Larger values fall
+back to the previous implementation.

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -454,9 +454,54 @@ fail:
     return NULL;
 }
 
+/* Fast path for the common case where the needle and all three range fields
+   are compact ints, so that the whole membership test can be done in
+   Py_ssize_t arithmetic instead of going through the abstract number API.
+
+   Compact ints hold a single digit, so their values are bounded by
+   PyLong_MASK (2**30 - 1 on 64-bit builds, 2**15 - 1 on 15-bit-digit builds).
+   That leaves at least one spare bit, so "value - start" cannot overflow
+   Py_ssize_t.
+
+   Assumes (PyLong_CheckExact(ob) || PyBool_Check(ob)).  Returns 1 or 0 like
+   range_contains_long(), or -1 to mean "not representable, use the general
+   path" -- this helper never raises, so -1 is not an error indicator here. */
+static int
+range_contains_compact_long(rangeobject *r, PyObject *ob)
+{
+    if (!_PyLong_IsCompact((PyLongObject *)ob) ||
+        !_PyLong_IsCompact((PyLongObject *)r->start) ||
+        !_PyLong_IsCompact((PyLongObject *)r->stop) ||
+        !_PyLong_IsCompact((PyLongObject *)r->step))
+    {
+        return -1;
+    }
+
+    Py_ssize_t value = _PyLong_CompactValue((PyLongObject *)ob);
+    Py_ssize_t start = _PyLong_CompactValue((PyLongObject *)r->start);
+    Py_ssize_t stop = _PyLong_CompactValue((PyLongObject *)r->stop);
+    Py_ssize_t step = _PyLong_CompactValue((PyLongObject *)r->step);
+
+    if (step > 0) {
+        /* positive steps: start <= ob < stop */
+        if (value < start || value >= stop) {
+            return 0;
+        }
+    }
+    else {
+        /* negative steps: stop < ob <= start */
+        if (value > start || value <= stop) {
+            return 0;
+        }
+    }
+    /* C and Python remainders differ in sign but never in whether they are
+       zero, so this matches the (ob - start) % step == 0 test below. */
+    return ((value - start) % step) == 0;
+}
+
 /* Assumes (PyLong_CheckExact(ob) || PyBool_Check(ob)) */
 static int
-range_contains_long(rangeobject *r, PyObject *ob)
+range_contains_long_slow(rangeobject *r, PyObject *ob)
 {
     PyObject *zero = _PyLong_GetZero();  // borrowed reference
     int cmp1, cmp2, cmp3;
@@ -498,6 +543,17 @@ range_contains_long(rangeobject *r, PyObject *ob)
     Py_XDECREF(tmp1);
     Py_XDECREF(tmp2);
     return result;
+}
+
+/* Assumes (PyLong_CheckExact(ob) || PyBool_Check(ob)) */
+static int
+range_contains_long(rangeobject *r, PyObject *ob)
+{
+    int result = range_contains_compact_long(r, ob);
+    if (result != -1) {
+        return result;
+    }
+    return range_contains_long_slow(r, ob);
 }
 
 static int


### PR DESCRIPTION
`range.__contains__` and `range.count()` route every exact-`int` or `bool`
needle through `range_contains_long()`, which performs the whole membership
test through the abstract number API: up to three `PyObject_RichCompareBool()`
calls, a `PyNumber_Subtract()`, a `PyNumber_Remainder()`, and a final
`PyObject_RichCompareBool()`, allocating two intermediate `PyLongObject`s along
the way.

That generality is only needed when an operand does not fit in a machine word.
This PR adds a fast path for the case where the needle and `r->start` /
`r->stop` / `r->step` are all compact ints, doing the bounds check and the
divisibility check in `Py_ssize_t`. Anything outside that domain falls through
to the previous implementation, renamed `range_contains_long_slow()` and
otherwise untouched.

### Why it is safe

- **No overflow.** Compact ints hold a single digit, so `|v| <= PyLong_MASK`
  (`2**30 - 1` on 64-bit builds). Hence `|value - start| <= 2**31 - 2`, which
  fits `Py_ssize_t` with room to spare — on 15-bit-digit and 32-bit builds too.
- **Same divisibility test.** C's `%` and Python's `%` differ in the *sign* of
  a non-zero result but never in whether the result is zero, so `== 0` is
  equivalent to the `PyNumber_Remainder(...) == 0` it replaces.
- **`step` is never 0**, rejected by `validate_step()` at construction, so the
  remainder is always defined.
- **The fields are always exact ints.** `make_range_object()` is the only place
  `start`/`stop`/`step` are assigned, and every caller supplies either a
  `PyNumber_Index()` result or `PyNumber_*` arithmetic over ints.
- **Non-int needles are unaffected** — `range_contains()` still sends them to
  `_PySequence_IterSearch()` before this code is reached.

### Testing

`test_range`, `test_list`, `test_tuple`, `test_bytes`, `test_str`, `test_dict`,
`test_index`, `test_int` and `test_long` all pass (`run=902`), as does
`-R 3:3 test_range` on a `--with-pydebug` build.

Beyond the suite, I diffed patched against unpatched output over ~125k
membership evaluations, with zero divergences:

- an exhaustive sweep of `start, stop ∈ [-8, 8]`, `step ∈ {±1, ±2, ±3, ±4}`,
  `needle ∈ [-12, 12]`, cross-checked against materialised `list(r)` for `in`,
  `.index()` and `.count()`;
- a boundary sweep with `start`/`stop` drawn from
  `{0, ±1, ±2, ±3, ±7, ±(2**30 - 2), ±(2**30 - 1), ±2**30, ±(2**30 + 1), ±2**31, ±10**30, ±10**100}`
  and `step ∈ {±1, ±3, ±(2**30 - 1), ±2**30, 10**40}`, which straddles the
  compact/non-compact boundary in each field independently;
- bools as needles, sliced ranges, empty ranges, and non-int needles
  (`float`, `int` subclass, `complex`, custom `__eq__`).

### Benchmarks

`--enable-optimizations=no --with-pydebug=no CFLAGS="-O3 -g0"`, gcc 13.3,
x86-64 Linux, otherwise-idle machine. Baseline and patched interpreters were
interleaved round by round, 120 samples per arm; figures are `min` per-loop ns.
The last row is a no-op control (a bare name load) included to show the harness
is unbiased.

| microbenchmark | before | after | |
| --- | ---: | ---: | ---: |
| `999 in range(0, 1000, 3)` | 59.5 ns | 14.8 ns | **4.02x** |
| `998 in range(0, 1000, 3)` (miss) | 63.1 ns | 14.0 ns | **4.49x** |
| `997 in range(1000, 0, -3)` | 56.4 ns | 14.0 ns | **4.03x** |
| `True in range(0, 1000, 3)` | 68.3 ns | 14.8 ns | **4.61x** |
| `range(0, 1000, 3).count(999)` | 67.9 ns | 20.6 ns | **3.29x** |
| `10**100 in range(0, 1000, 3)` (fallback) | 36.2 ns | 35.3 ns | 1.03x |
| `999 in range(0, 10**100, 3)` (fallback) | 59.5 ns | 57.6 ns | 1.03x |
| `6.0 in range(0, 8, 3)` (non-int) | 116.2 ns | 114.7 ns | 1.01x |
| *control:* `needle` | 7.46 ns | 7.50 ns | 0.99x |

Every fallback path is neutral within noise. `objdump` confirms the helper is
fully inlined into `range_contains_long()` — four tag tests and integer
arithmetic, no calls at all — while the fallback costs one load, one compare
and one branch before reaching the original code.


<!-- gh-issue-number: gh-155385 -->
* Issue: gh-155385
<!-- /gh-issue-number -->
