### PR TITLE
gh-155389: Return bytes from _pyio.BytesIO.peek()

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1010,9 +1010,10 @@ class BytesIO(BufferedIOBase):
         else:
             size = size_index()
 
+        if size < 1:
+            size = io.DEFAULT_BUFFER_SIZE
+
         with self._lock:
-            if size < 1:
-                size = io.DEFAULT_BUFFER_SIZE
             b = self._buffer[self._pos:self._pos + size]
             return b.take_bytes()
 

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1003,9 +1003,18 @@ class BytesIO(BufferedIOBase):
     def peek(self, size=0):
         if self.closed:
             raise ValueError("peek on closed file")
-        if size < 1:
-            return self._buffer[self._pos:self._pos + io.DEFAULT_BUFFER_SIZE]
-        return self._buffer[self._pos:self._pos + size]
+        try:
+            size_index = size.__index__
+        except AttributeError:
+            raise TypeError(f"{size!r} is not an integer")
+        else:
+            size = size_index()
+
+        with self._lock:
+            if size < 1:
+                size = io.DEFAULT_BUFFER_SIZE
+            b = self._buffer[self._pos:self._pos + size]
+            return b.take_bytes()
 
     def truncate(self, pos=None):
         if self.closed:

--- a/Lib/test/test_io/test_memoryio.py
+++ b/Lib/test/test_io/test_memoryio.py
@@ -574,6 +574,7 @@ class PyBytesIOTest(MemoryTestMixin, MemorySeekTestMixin, unittest.TestCase):
             self.assertIsInstance(memio.peek(), bytes)
             self.assertIsInstance(memio.peek(1), bytes)
             self.assertEqual(memio.peek(IntLike(3)), buf[:3])
+            self.assertRaises(TypeError, memio.peek, 1.5)
             self.assertEqual(memio.peek(1), buf[:1])
             self.assertEqual(memio.peek(1), buf[:1])
             self.assertEqual(memio.peek(), buf)

--- a/Lib/test/test_io/test_memoryio.py
+++ b/Lib/test/test_io/test_memoryio.py
@@ -570,6 +570,10 @@ class PyBytesIOTest(MemoryTestMixin, MemorySeekTestMixin, unittest.TestCase):
         buf = self.buftype("1234567890")
         with self.ioclass(buf) as memio:
             self.assertEqual(memio.tell(), 0)
+            # bytearray(b'1') == b'1', so the type has to be asserted separately.
+            self.assertIsInstance(memio.peek(), bytes)
+            self.assertIsInstance(memio.peek(1), bytes)
+            self.assertEqual(memio.peek(IntLike(3)), buf[:3])
             self.assertEqual(memio.peek(1), buf[:1])
             self.assertEqual(memio.peek(1), buf[:1])
             self.assertEqual(memio.peek(), buf)


### PR DESCRIPTION
`_pyio.BytesIO.peek()` returned a slice of the internal `bytearray`, so it gave a `bytearray` where the C version and the docs say `bytes`. It also did not accept an `__index__`-able size, and did not take the lock while slicing.

It now does what `read()` does: coerce the size, take the lock, convert with `take_bytes()`.

`test_peek` only used `assertEqual`, and `bytearray(b'1') == b'1'`, so it passed either way. It now checks the type and an `__index__` size, and fails without the change.

`BytesIO.peek()` is new in 3.16, so there is no NEWS entry.



<!-- gh-issue-number: gh-155389 -->
* Issue: gh-155389
<!-- /gh-issue-number -->
