### PR TITLE
gh-155354: Document that sys no longer clears the type cache

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -233,17 +233,14 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
 .. function:: _clear_type_cache()
 
-   Clear the internal type cache. The type cache is used to speed up attribute
-   and method lookups. Use the function *only* to drop unnecessary references
-   during reference leak debugging.
-
-   This function should be used for internal and specialized purposes only.
+   This function is a no-op. It used to clear the internal type cache, which
+   is now implemented per-type.
 
    .. deprecated:: 3.13
       Use the more general :func:`_clear_internal_caches` function instead.
 
-   .. versionchanged:: next
-      The type cache is no longer cleared, as it is now implemented per-type.
+   .. versionchanged:: 3.16
+      This function is now a no-op.
 
 
 .. function:: _clear_internal_caches()
@@ -253,7 +250,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
    .. versionadded:: 3.13
 
-   .. versionchanged:: next
+   .. versionchanged:: 3.16
       The type cache is no longer cleared, as it is now implemented per-type.
 
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -242,6 +242,9 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    .. deprecated:: 3.13
       Use the more general :func:`_clear_internal_caches` function instead.
 
+   .. versionchanged:: next
+      The type cache is no longer cleared, as it is now implemented per-type.
+
 
 .. function:: _clear_internal_caches()
 
@@ -249,6 +252,9 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    release unnecessary references and memory blocks when hunting for leaks.
 
    .. versionadded:: 3.13
+
+   .. versionchanged:: next
+      The type cache is no longer cleared, as it is now implemented per-type.
 
 
 .. function:: _current_frames()


### PR DESCRIPTION
`sys._clear_type_cache()` and `sys._clear_internal_caches()` still say they clear the type cache. They stopped doing so when `PyType_ClearCache()` became a no-op, and only the C API page was updated at the time.

This adds the same note to both, matching the wording already on `Doc/c-api/type.rst`.

<!-- gh-issue-number: gh-155354 -->
* Issue: gh-155354
<!-- /gh-issue-number -->

