### PR TITLE
gh-155397: Raise InvalidFileException for malformed XML plists in plistlib

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -67,7 +67,7 @@ import itertools
 import os
 import re
 import struct
-from xml.parsers.expat import ParserCreate
+from xml.parsers.expat import ExpatError, ParserCreate
 
 
 PlistFormat = enum.Enum('PlistFormat', 'FMT_XML FMT_BINARY', module=__name__)
@@ -185,7 +185,15 @@ class _PlistParser:
         self.parser.EndElementHandler = self.handle_end_element
         self.parser.CharacterDataHandler = self.handle_data
         self.parser.EntityDeclHandler = self.handle_entity_decl
-        self.parser.ParseFile(fileobj)
+        try:
+            self.parser.ParseFile(fileobj)
+        except (ExpatError, LookupError):
+            # gh-155397: ExpatError is raised for XML that is not
+            # well-formed, and LookupError for a <?xml ... ?> declaration
+            # naming an unknown encoding; neither is a ValueError, so it
+            # would otherwise escape uncaught instead of the documented
+            # InvalidFileException.
+            raise InvalidFileException()
         return self.root
 
     def handle_entity_decl(self, entity_name, is_parameter_entity, value, base, system_id, public_id, notation_name):

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -933,6 +933,24 @@ class TestPlistlib(unittest.TestCase):
                                     "XML entity declarations are not supported"):
             plistlib.loads(XML_PLIST_WITH_ENTITY, fmt=plistlib.FMT_XML)
 
+    def test_xml_plist_not_well_formed(self):
+        # gh-155397: malformed XML must raise InvalidFileException, not the
+        # underlying xml.parsers.expat.ExpatError.
+        with self.assertRaises(plistlib.InvalidFileException):
+            plistlib.loads(b"<plist><dict>")
+        with self.assertRaises(plistlib.InvalidFileException):
+            plistlib.loads(b"<plist><foo></bar></plist>")
+        with self.assertRaises(plistlib.InvalidFileException):
+            plistlib.loads(b"<plist>&undefined_entity;</plist>")
+
+    def test_xml_plist_unknown_encoding(self):
+        # gh-155397: an <?xml ... ?> declaration naming an encoding unknown
+        # to Python must raise InvalidFileException, not the underlying
+        # LookupError.
+        with self.assertRaises(plistlib.InvalidFileException):
+            plistlib.loads(
+                b'<?xml version="1.0" encoding="BogusEncoding"?><plist></plist>')
+
     def test_load_aware_datetime(self):
         dt = plistlib.loads(b"<plist><date>2023-12-10T08:03:30Z</date></plist>",
                             aware_datetime=True)

--- a/Misc/NEWS.d/next/Library/2026-08-08-17-00-00.gh-issue-155397.pL3xq9.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-08-17-00-00.gh-issue-155397.pL3xq9.rst
@@ -1,0 +1,4 @@
+Fix :mod:`plistlib` to raise :exc:`~plistlib.InvalidFileException` instead
+of leaking the underlying :exc:`xml.parsers.expat.ExpatError` (for
+not-well-formed XML) or :exc:`LookupError` (for an ``<?xml ... ?>``
+declaration naming an unknown encoding) when parsing a malformed XML plist.


### PR DESCRIPTION
`_PlistParser.parse()` called expat's `ParseFile()` with no exception translation, so two classes of malformed XML plist escaped as the underlying exception instead of the documented `InvalidFileException`:

* XML that is not well-formed raised `xml.parsers.expat.ExpatError`.
* An `<?xml ... ?>` declaration naming an encoding unknown to Python's codec registry raised `LookupError` (this is what CIFuzz found in gh-152211).

Neither exception type is a `ValueError`, so code written against the documented contract (catching `InvalidFileException`, or even just `ValueError`) did not catch them.

The fix wraps `ParseFile()` and translates both into `InvalidFileException`, the same way `_BinaryPlistParser.parse()` already does for its own format.

Fixes gh-155397.

<!-- gh-issue-number: gh-155397 -->
* Issue: gh-155397
<!-- /gh-issue-number -->
