### PR TITLE
gh-155406: Fix struct.unpack_from documentation signature

### DIFF
--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -79,7 +79,7 @@ The module defines the following exception and functions:
    size required by the format, as reflected by :func:`calcsize`.
 
 
-.. function:: unpack_from(format, /, buffer, offset=0)
+.. function:: unpack_from(format, buffer, offset=0)
 
    Unpack from *buffer* starting at position *offset*, according to the format
    string *format*.  The result is a tuple even if it contains exactly one


### PR DESCRIPTION
Problem: The struct.unpack_from() documentation incorrectly shows a '/' separator in the signature.

Solution: Remove the spurious '/' separator. The correct signature is unpack_from(format, buffer, offset=0).

Changes: Modified Doc/library/struct.rst to fix the function signature.

Testing: This is a documentation-only change that matches the actual function signature and usage in test code.

Compatibility: No behavior changes, documentation correction only.

<!-- gh-issue-number: gh-155406 -->
* Issue: gh-155406
<!-- /gh-issue-number -->
