### PR TITLE
gh-155423: Make BaseFileTest.tearDown() in test_logging robust

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -6446,11 +6446,12 @@ class BaseFileTest(BaseTest):
         self.rmfiles = []
 
     def tearDown(self):
-        for fn in self.rmfiles:
-            os.unlink(fn)
-        if os.path.exists(self.fn):
-            os.unlink(self.fn)
-        BaseTest.tearDown(self)
+        try:
+            for fn in self.rmfiles:
+                os_helper.unlink(fn)
+            os_helper.unlink(self.fn)
+        finally:
+            BaseTest.tearDown(self)
 
     def assertLogFile(self, filename):
         "Assert a log file is there and register it for deletion"


### PR DESCRIPTION
Call `BaseTest.tearDown()` from a `finally` block, and unlink the log files with `os_helper.unlink()`, which ignores a missing file.


<!-- gh-issue-number: gh-155423 -->
* Issue: gh-155423
<!-- /gh-issue-number -->
