### PR TITLE
gh-155428: align `hmac.digest` and `hmac.HMAC.digest` outputs when using  small block sizes

### DIFF
--- a/Lib/hmac.py
+++ b/Lib/hmac.py
@@ -49,6 +49,27 @@ def _get_digest_constructor(digest_like):
     return digest_wrapper
 
 
+def _select_blocksize(obj, default, stacklevel=3):
+    if hasattr(obj, 'block_size'):
+        blocksize = obj.block_size
+        if blocksize < 16:
+            import warnings
+
+            warnings.warn(f"block_size of {blocksize} seems too small; "
+                          f"using our default of {default}.",
+                          RuntimeWarning, stacklevel=stacklevel)
+            blocksize = default
+    else:
+        import warnings
+
+        warnings.warn("No block_size attribute on given digest object; "
+                      f"Assuming {default}.",
+                      RuntimeWarning, stacklevel=stacklevel)
+        blocksize = default
+    return blocksize
+
+
+
 class HMAC:
     """RFC 2104 HMAC class.  Also complies with RFC 4231.
 
@@ -116,8 +137,6 @@ class HMAC:
         self.block_size = self._hmac.block_size
 
     def _init_old(self, key, msg, digestmod):
-        import warnings
-
         digest_cons = _get_digest_constructor(digestmod)
         if _is_shake_constructor(digest_cons):
             raise ValueError(f"unsupported hash algorithm {digestmod}")
@@ -127,19 +146,7 @@ class HMAC:
         self._inner = digest_cons()
         self.digest_size = self._inner.digest_size
 
-        if hasattr(self._inner, 'block_size'):
-            blocksize = self._inner.block_size
-            if blocksize < 16:
-                warnings.warn(f"block_size of {blocksize} seems too small; "
-                              f"using our default of {self.blocksize}.",
-                              RuntimeWarning, 2)
-                blocksize = self.blocksize  # pragma: no cover
-        else:
-            warnings.warn("No block_size attribute on given digest object; "
-                          f"Assuming {self.blocksize}.",
-                          RuntimeWarning, 2)
-            blocksize = self.blocksize  # pragma: no cover
-
+        blocksize = _select_blocksize(self._inner, self.blocksize)
         if len(key) > blocksize:
             key = digest_cons(key).digest()
 
@@ -272,7 +279,7 @@ def _compute_digest_fallback(key, msg, digest):
         raise ValueError(f"unsupported hash algorithm {digest}")
     inner = digest_cons()
     outer = digest_cons()
-    blocksize = getattr(inner, 'block_size', 64)
+    blocksize = _select_blocksize(inner, HMAC.blocksize)
     if len(key) > blocksize:
         key = digest_cons(key).digest()
     key = key.ljust(blocksize, b'\0')

--- a/Misc/NEWS.d/next/Library/2026-08-09-14-26-48.gh-issue-155428.wi0_fI.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-09-14-26-48.gh-issue-155428.wi0_fI.rst
@@ -1,0 +1,3 @@
+Ensure that :func:`hmac.digest` and :meth:`hmac.HMAC.digest` output
+identical values when using a digest's block size smaller than 16. Patch by
+Bénédikt Tran.


### PR DESCRIPTION
I still need to add tests but I don't have time today.

<!-- gh-issue-number: gh-155428 -->
* Issue: gh-155428
<!-- /gh-issue-number -->
