### PR TITLE
gh-85470: Delay load ole32.dll in the _ctypes module

### DIFF
--- a/Misc/NEWS.d/next/Windows/2026-08-09-15-40-00.gh-issue-85470.Lm4Xt9.rst
+++ b/Misc/NEWS.d/next/Windows/2026-08-09-15-40-00.gh-issue-85470.Lm4Xt9.rst
@@ -1,0 +1,4 @@
+Importing :mod:`ctypes` on Windows no longer loads ``user32.dll``, which
+made the system treat the process as a GUI process and stop sending logoff
+and shutdown console control events to it.  ``ole32.dll``, which pulled
+``user32.dll`` in, is now delay loaded.

--- a/PCbuild/_ctypes.vcxproj
+++ b/PCbuild/_ctypes.vcxproj
@@ -98,6 +98,7 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>/EXPORT:DllGetClassObject,PRIVATE /EXPORT:DllCanUnloadNow,PRIVATE %(AdditionalOptions)</AdditionalOptions>
+      <DelayLoadDLLs>ole32.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Measured on Windows 11 with a debug x64 build -- `import _ctypes` before the change loads `user32.dll`, `ole32.dll`, `gdi32.dll`, `win32u.dll` and `combase.dll`; after it, only `combase.dll` remains (pulled in by `oleaut32`, which does not depend on `user32`). A plain `python.exe` already loaded none of them, so `ctypes` was the last thing making the interpreter a GUI process -- and it is the module a console script needs in order to call `SetConsoleCtrlHandler()` in the first place.

`ProgIDFromCLSID()` in `SetComError()` is the only ole32 use in `_ctypes`, and it is reached only when formatting an error from a COM interface method. `PCbuild/_wmi.vcxproj` already delay loads the same DLL.

`test_ctypes` passes (679 tests). This covers the PCbuild build only; resolving `ProgIDFromCLSID()` through `GetProcAddress()` would also cover other toolchains, at the cost of some C code.


<!-- gh-issue-number: gh-85470 -->
* Issue: gh-85470
<!-- /gh-issue-number -->
