### PR TITLE
gh-155436: Fix configparser.getboolean() for value-less options

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -1222,7 +1222,7 @@ class RawConfigParser(MutableMapping):
     def _convert_to_boolean(self, value):
         """Return a boolean value translating from other types if necessary.
         """
-        if value.lower() not in self.BOOLEAN_STATES:
+        if value is None or value.lower() not in self.BOOLEAN_STATES:
             raise ValueError('Not a boolean: %s' % value)
         return self.BOOLEAN_STATES[value.lower()]
 

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -1338,6 +1338,14 @@ class ConfigParserTestCaseExtendedInterpolation(BasicTestCase, unittest.TestCase
 class ConfigParserTestCaseNoValue(ConfigParserTestCase):
     allow_no_value = True
 
+    def test_getboolean_with_no_value(self):
+        cf = self.fromstring("[section]\noption\n")
+
+        with self.assertRaisesRegex(ValueError, "Not a boolean: None"):
+            cf.getboolean("section", "option")
+        with self.assertRaisesRegex(ValueError, "Not a boolean: None"):
+            cf["section"].getboolean("option")
+
 
 class NoValueAndExtendedInterpolation(CfgParserTestCaseClass):
     interpolation = configparser.ExtendedInterpolation()

--- a/Misc/NEWS.d/next/Library/2026-08-09-22-50-19.gh-issue-155436.gyB8_I.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-09-22-50-19.gh-issue-155436.gyB8_I.rst
@@ -1,0 +1,3 @@
+:class:`configparser.ConfigParser` now raises :exc:`ValueError` instead of
+:exc:`AttributeError` when :meth:`~configparser.ConfigParser.getboolean` is
+called on an option without a value while ``allow_no_value=True``.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-155436 -->
* Issue: gh-155436
<!-- /gh-issue-number -->
