### PR TITLE
gh-155433: Fix TaskGroup losing outside cancellation after cancel()

### DIFF
--- a/Lib/asyncio/taskgroups.py
+++ b/Lib/asyncio/taskgroups.py
@@ -116,6 +116,7 @@ class TaskGroup:
         # can be cancelled multiple times if our parent task
         # is being cancelled repeatedly (or even once, when
         # our own cancellation is already in progress)
+        pending_cancellation_error = None
         while self._tasks:
             if self._on_completed_fut is None:
                 self._on_completed_fut = self._loop.create_future()
@@ -123,6 +124,7 @@ class TaskGroup:
             try:
                 await self._on_completed_fut
             except exceptions.CancelledError as ex:
+                pending_cancellation_error = ex
                 if not self._aborting:
                     # Our parent task is being cancelled:
                     #
@@ -151,9 +153,9 @@ class TaskGroup:
                 # If there are no pending cancellations left,
                 # don't propagate CancelledError.
                 propagate_cancellation_error = None
-            else:
+            elif propagate_cancellation_error is None:
                 # gh-155433: the remaining cancellation is not ours, don't drop it
-                propagate_cancellation_error = exceptions.CancelledError()
+                propagate_cancellation_error = pending_cancellation_error
 
         # Propagate CancelledError if there is one, except if there
         # are other errors -- those have priority.

--- a/Lib/asyncio/taskgroups.py
+++ b/Lib/asyncio/taskgroups.py
@@ -151,6 +151,9 @@ class TaskGroup:
                 # If there are no pending cancellations left,
                 # don't propagate CancelledError.
                 propagate_cancellation_error = None
+            else:
+                # gh-155433: the remaining cancellation is not ours, don't drop it
+                propagate_cancellation_error = exceptions.CancelledError()
 
         # Propagate CancelledError if there is one, except if there
         # are other errors -- those have priority.

--- a/Lib/test/test_asyncio/test_taskgroups.py
+++ b/Lib/test/test_asyncio/test_taskgroups.py
@@ -1170,9 +1170,10 @@ class BaseTestTaskGroup:
 
         task = asyncio.create_task(body())
         await asyncio.sleep(0.01)
-        task.cancel()
-        with self.assertRaises(asyncio.CancelledError):
+        task.cancel('message')
+        with self.assertRaises(asyncio.CancelledError) as cm:
             await task
+        self.assertEqual('message', cm.exception.args[0])
 
     async def test_taskgroup_cancel_before_exception(self):
         async def raise_exc(parent_tg: asyncio.TaskGroup):

--- a/Lib/test/test_asyncio/test_taskgroups.py
+++ b/Lib/test/test_asyncio/test_taskgroups.py
@@ -1154,6 +1154,26 @@ class BaseTestTaskGroup:
             with self.assertRaises(RuntimeError):
                 tg.create_task(asyncio.sleep(1))
 
+    async def test_taskgroup_cancel_keeps_outer_cancellation(self):
+        # gh-155433: any cancellation from outside the group must propagate.
+        async def child():
+            try:
+                await asyncio.sleep(10)
+            finally:
+                await asyncio.sleep(0.1)
+
+        async def body():
+            async with asyncio.TaskGroup() as tg:
+                tg.create_task(child())
+                await asyncio.sleep(0)
+                tg.cancel()
+
+        task = asyncio.create_task(body())
+        await asyncio.sleep(0.01)
+        task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+
     async def test_taskgroup_cancel_before_exception(self):
         async def raise_exc(parent_tg: asyncio.TaskGroup):
             parent_tg.cancel()

--- a/Misc/NEWS.d/next/Library/2026-08-09-16-14-38.gh-issue-155433.KL7tHV.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-09-16-14-38.gh-issue-155433.KL7tHV.rst
@@ -1,0 +1,2 @@
+Fix :class:`asyncio.TaskGroup` losing outside cancellation after
+``cancel()``.


### PR DESCRIPTION
Fix TaskGroup losing outside cancellation after cancel()

For more details see gh-155433
