### PR TITLE
gh-102184: Test os.sync() only if the "walltime" resource is enabled

### DIFF
--- a/Lib/test/test_os/test_posix.py
+++ b/Lib/test/test_os/test_posix.py
@@ -71,7 +71,7 @@ class PosixTester(unittest.TestCase):
         NO_ARG_FUNCTIONS = [ "ctermid", "getcwd", "getcwdb", "uname",
                              "times", "getloadavg",
                              "getegid", "geteuid", "getgid", "getgroups",
-                             "getpid", "getpgrp", "getppid", "getuid", "sync",
+                             "getpid", "getpgrp", "getppid", "getuid",
                            ]
 
         for name in NO_ARG_FUNCTIONS:
@@ -80,6 +80,13 @@ class PosixTester(unittest.TestCase):
                 with self.subTest(name):
                     posix_func()
                     self.assertRaises(TypeError, posix_func, 1)
+
+    # gh-102184: sync() can block for a long time.
+    @support.requires_resource('walltime')
+    @unittest.skipUnless(hasattr(posix, 'sync'), 'test needs posix.sync()')
+    def test_sync(self):
+        posix.sync()
+        self.assertRaises(TypeError, posix.sync, 1)
 
     @unittest.skipUnless(hasattr(posix, 'getresuid'),
                          'test needs posix.getresuid()')


### PR DESCRIPTION
`sync()` was called unconditionally in `testNoArgFunctions()`, so a plain `make test` flushed every filesystem buffer on the machine. It is now a separate test gated on `walltime`, the resource for tests that are slow by the clock -- `largefile`, as proposed in #102185, and `cpu` describe the wrong cost.


<!-- gh-issue-number: gh-102184 -->
* Issue: gh-102184
<!-- /gh-issue-number -->
