### PR TITLE
gh-155452: Prevent recursion crash in dir()

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -700,6 +700,20 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         f = Foo()
         self.assertIn("y", dir(f))
 
+        # dir(obj) - cyclic __bases__ must raise RecursionError
+        class Fake:
+            pass
+
+        a = Fake()
+        a.__bases__ = (a,)
+
+        class C:
+            @property
+            def __class__(self):
+                return a
+
+        self.assertRaises(RecursionError, dir, C())
+
         # dir(obj_no__dict__)
         class Foo(object):
             __slots__ = []

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -700,20 +700,6 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         f = Foo()
         self.assertIn("y", dir(f))
 
-        # dir(obj) - cyclic __bases__ must raise RecursionError
-        class Fake:
-            pass
-
-        a = Fake()
-        a.__bases__ = (a,)
-
-        class C:
-            @property
-            def __class__(self):
-                return a
-
-        self.assertRaises(RecursionError, dir, C())
-
         # dir(obj_no__dict__)
         class Foo(object):
             __slots__ = []
@@ -768,6 +754,22 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
 
         # test that object has a __dir__()
         self.assertEqual(sorted([].__dir__()), dir([]))
+
+    @support.skip_emscripten_stack_overflow()
+    @support.skip_wasi_stack_overflow()
+    def test_dir_cyclic_bases(self):
+        class Fake:
+            pass
+
+        a = Fake()
+        a.__bases__ = (a,)
+
+        class C:
+            @property
+            def __class__(self):
+                return a
+
+        self.assertRaises(RecursionError, dir, C())
 
     def test___ne__(self):
         self.assertFalse(None.__ne__(None))

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-09-21-24-08.gh-issue-155452.4mUzjM.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-09-21-24-08.gh-issue-155452.4mUzjM.rst
@@ -1,0 +1,2 @@
+Fix a crash in :func:`dir` when an object's ``__class__`` has cyclic
+``__bases__``.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3,6 +3,7 @@
 #include "Python.h"
 #include "pycore_abstract.h"      // _PySequence_IterSearch()
 #include "pycore_call.h"          // _PyObject_VectorcallTstate()
+#include "pycore_ceval.h"         // _Py_EnterRecursiveCall()
 #include "pycore_code.h"          // CO_FAST_FREE
 #include "pycore_descrobject.h"   // _PyMember_GetOffset()
 #include "pycore_dict.h"          // _PyDict_KeysSize()
@@ -6949,22 +6950,27 @@ merge_class_dict(PyObject *dict, PyObject *aclass)
             Py_DECREF(bases);
             return -1;
         }
-        else {
-            for (i = 0; i < n; i++) {
-                int status;
-                PyObject *base = PySequence_GetItem(bases, i);
-                if (base == NULL) {
-                    Py_DECREF(bases);
-                    return -1;
-                }
-                status = merge_class_dict(dict, base);
-                Py_DECREF(base);
-                if (status < 0) {
-                    Py_DECREF(bases);
-                    return -1;
-                }
+        if (_Py_EnterRecursiveCall(" in __bases__")) {
+            Py_DECREF(bases);
+            return -1;
+        }
+        for (i = 0; i < n; i++) {
+            int status;
+            PyObject *base = PySequence_GetItem(bases, i);
+            if (base == NULL) {
+                _Py_LeaveRecursiveCall();
+                Py_DECREF(bases);
+                return -1;
+            }
+            status = merge_class_dict(dict, base);
+            Py_DECREF(base);
+            if (status < 0) {
+                _Py_LeaveRecursiveCall();
+                Py_DECREF(bases);
+                return -1;
             }
         }
+        _Py_LeaveRecursiveCall();
         Py_DECREF(bases);
     }
     return 0;


### PR DESCRIPTION
gh-155452: Prevent recursion crash in `dir()` when `__bases__` is cyclic.

### Summary

`dir()` could cause a native stack overflow when an object's `__class__`
provided a cyclic `__bases__` attribute.

`merge_class_dict()` recursively traverses `__bases__` without a recursion
guard. This change protects that recursion with `_Py_EnterRecursiveCall()`
and `_Py_LeaveRecursiveCall()`, matching the existing protection in
`abstract_issubclass()`.

### Changes

- Add the required `pycore_ceval.h` include.
- Guard recursive `__bases__` traversal in `merge_class_dict()`.
- Add a regression test using a one-node cyclic `__bases__` graph.
- Add a NEWS entry.

### Testing

Before the fix, the reproducer resulted in:

```text
Segmentation fault
rc=139
```

After the fix, it raises:
```
RecursionError: Stack overflow (used 8120 kB) in __bases__
```

Targeted regression test:
```
./python -m test test_builtin -m test_dir
== Tests result: SUCCESS ==
1 test OK.
```

Closes issue gh-155452