### PR TITLE
gh-155454: Fix platform.libc_ver() crash on threaded libc without version

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -240,7 +240,8 @@ def libc_ver(executable=None, lib='', version='', chunksize=16384):
                     lib = 'libc'
                     if soversion and (not ver or V(soversion) > V(ver)):
                         ver = soversion
-                    if threads and ver[-len(threads):] != threads:
+                    if (threads and ver is not None
+                            and ver[-len(threads):] != threads):
                         ver = ver + threads
             elif musl:
                 lib = 'musl'

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -576,6 +576,7 @@ class PlatformTest(unittest.TestCase):
                 (b'GLIBC_2.9', ('glibc', '2.9')),
                 (b'libc.so.1.2.5', ('libc', '1.2.5')),
                 (b'libc_pthread.so.1.2.5', ('libc', '1.2.5_pthread')),
+                (b'libc_r.so', ('libc', '')),
                 (b'/aports/main/musl/src/musl-1.2.5', ('musl', '1.2.5')),
                 # musl uses semver, but we accept some variations anyway:
                 (b'/aports/main/musl/src/musl-12.5', ('musl', '12.5')),

--- a/Misc/NEWS.d/next/Library/2026-08-10-12-19-07.gh-issue-155454.Lb7Cq4.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-10-12-19-07.gh-issue-155454.Lb7Cq4.rst
@@ -1,0 +1,3 @@
+Fix :func:`platform.libc_ver` crashing with :exc:`TypeError` when the scanned
+binary references a threaded C library (such as ``libc_r``) that has no version
+number. Patch by tonghuaroot.


### PR DESCRIPTION
In the `so` branch of `platform.libc_ver()`, a match with a thread suffix
(`libc_r`, `libc_pthread`) but no version number left `ver` as `None`, which was
then subscripted, raising `TypeError`. Guard the thread-suffix check with
`ver is not None`. Regression from gh-90548.


<!-- gh-issue-number: gh-155454 -->
* Issue: gh-155454
<!-- /gh-issue-number -->
