### PR TITLE
gh-154916: Fix data race on a shared `types.GenericAlias` iterator in `ga_iter_reduce` under free-threading

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-10-16-57-53.gh-issue-154916.6ozWLF.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-10-16-57-53.gh-issue-154916.6ozWLF.rst
@@ -1,0 +1,2 @@
+Fix data race when calling :meth:`~object.__reduce__` on a shared :class:`types.GenericAlias` iterator
+under the :term:`free-threaded build`.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -992,13 +992,14 @@ ga_iter_reduce(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *iter = _PyEval_GetBuiltin(&_Py_ID(iter));
     gaiterobject *gi = (gaiterobject *)self;
+    PyObject *obj = FT_ATOMIC_LOAD_PTR(gi->obj);
 
     /* _PyEval_GetBuiltin can invoke arbitrary code,
      * call must be before access of iterator pointers.
      * see issue #101765 */
 
-    if (gi->obj)
-        return Py_BuildValue("N(O)", iter, gi->obj);
+    if (obj)
+        return Py_BuildValue("N(O)", iter, obj);
     else
         return Py_BuildValue("N(())", iter);
 }


### PR DESCRIPTION
Follow-up to https://github.com/python/cpython/pull/154108.

<!-- gh-issue-number: gh-154916 -->
* Issue: gh-154916
<!-- /gh-issue-number -->
