### PR TITLE
gh-155477: Fix multiprocessing.Pool deadlock on close() with a buffersize imap

### DIFF
--- a/Lib/multiprocessing/pool.py
+++ b/Lib/multiprocessing/pool.py
@@ -668,7 +668,7 @@ class Pool(object):
             self._change_notifier.put(None)
             # Wake any task generator throttled on a buffersize semaphore so
             # it observes the CLOSE state and stops submitting.
-            for sema in tuple(self._taskqueue_buffersize_semaphores):
+            for sema in list(self._taskqueue_buffersize_semaphores):
                 sema.release()
 
     def terminate(self):

--- a/Lib/multiprocessing/pool.py
+++ b/Lib/multiprocessing/pool.py
@@ -403,6 +403,11 @@ class Pool(object):
                 enumerated_iter = iter(enumerate(iterable))
                 while True:
                     sema.acquire()
+                    if self._state != RUN:
+                        # The pool is closing or terminating; stop submitting
+                        # the still-throttled tasks so the task handler can
+                        # finish instead of blocking here forever.
+                        break
                     try:
                         i, x = next(enumerated_iter)
                     except StopIteration:
@@ -661,6 +666,10 @@ class Pool(object):
             self._state = CLOSE
             self._worker_handler._state = CLOSE
             self._change_notifier.put(None)
+            # Wake any task generator throttled on a buffersize semaphore so
+            # it observes the CLOSE state and stops submitting.
+            for sema in tuple(self._taskqueue_buffersize_semaphores):
+                sema.release()
 
     def terminate(self):
         util.debug('terminating pool')

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -3227,6 +3227,27 @@ class _TestPool(BaseTestCase):
         p.terminate()
         p.join()
 
+    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @support.subTests('method_name', ("imap", "imap_unordered"))
+    def test_imap_with_buffersize_close_after_partial_consumption(
+        self, method_name
+    ):
+        # close()/join() must not deadlock when a buffersize iterator is
+        # only partially consumed (the throttled task generator must stop).
+        p = self.Pool(2)
+        method = getattr(p, method_name)
+        it = method(sqr, range(1000), buffersize=2)
+        next(it)
+        finished = threading.Event()
+        def finalize():
+            p.close()
+            p.join()
+            finished.set()
+        t = threading.Thread(target=finalize)
+        t.start()
+        t.join(support.SHORT_TIMEOUT)
+        self.assertTrue(finished.is_set(), "close()/join() deadlocked")
+
     @support.subTests('method_name', ("imap", "imap_unordered"))
     def test_imap_and_imap_unordered_with_buffersize_on_empty_iterable(
         self, method_name

--- a/Misc/NEWS.d/next/Library/2026-08-10-17-54-16.gh-issue-155477.Mp6Db2.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-10-17-54-16.gh-issue-155477.Mp6Db2.rst
@@ -1,3 +1,0 @@
-Fix a deadlock when ``multiprocessing.pool.Pool.close()`` is followed by
-``join()`` after only partially consuming an ``imap()`` or ``imap_unordered()``
-iterator that was created with a *buffersize*. Patch by tonghuaroot.

--- a/Misc/NEWS.d/next/Library/2026-08-10-17-54-16.gh-issue-155477.Mp6Db2.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-10-17-54-16.gh-issue-155477.Mp6Db2.rst
@@ -1,0 +1,3 @@
+Fix a deadlock when ``multiprocessing.pool.Pool.close()`` is followed by
+``join()`` after only partially consuming an ``imap()`` or ``imap_unordered()``
+iterator that was created with a *buffersize*. Patch by tonghuaroot.


### PR DESCRIPTION
The *buffersize* variant of `Pool.imap()`/`imap_unordered()` throttles the task
generator on a semaphore. `close()` did not release those semaphores (only
`terminate()` did), so a partially-consumed iterator left the task handler
blocked in `sema.acquire()` and `join()` deadlocked. Release the buffersize
semaphores in `close()`, and stop the task generator once the pool leaves the
RUN state. Introduced in gh-64192.


<!-- gh-issue-number: gh-155477 -->
* Issue: gh-155477
<!-- /gh-issue-number -->
