### PR TITLE
gh-151925: Fix minor issues in clarification introduced by gh-152463

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -806,8 +806,11 @@ Comprehensions
    List and set comprehensions, generator expressions, and dictionary
    comprehensions. ``elt`` (or ``key`` and ``value``) is a single node
    representing the part that will be evaluated for each item.
+
    For dictionary comprehensions using unpacking, for example
-   ``{**item for item in items}``, ``value`` is ``None``,
+   ``{**item for item in items}``, the expression to be expanded goes in
+   ``key`` and ``value`` is ``None``.
+
    ``generators`` is a list of :class:`comprehension` nodes.
 
    .. doctest::


### PR DESCRIPTION
Follow-up to GH-152463 which restores the paragraph break before the generators description, which I presume was accidentally removed, and mention that the expanded expression goes in key.

CC @adqm 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151925 -->
* Issue: gh-151925
<!-- /gh-issue-number -->
