### PR TITLE
Mention that venv --prompt may expand its argument using the shell

### DIFF
--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -144,6 +144,8 @@ The command, if run with ``-h``, will show the available options::
 .. option:: --prompt <PROMPT>
 
    Provides an alternative prompt prefix for this environment.
+   Depending on the operating system, the prompt string may be
+   evaluated by the shell.
 
 .. option:: --upgrade-deps
 


### PR DESCRIPTION
Red Hat Product Security asked me to forward an AI-generated vulnerability report. However, I do not think the report is real (no trust boundary) is crossed, so I'm proposing to enhance the documentation instead.

I've been instructed to mention this: Found by AISLE in partnership with Red Hat. (But I think the report is incorrect.)