### PR TITLE
gh-151365: Retry git fetch in CI workflows

### DIFF
--- a/.github/workflows/reusable-check-html-ids.yml
+++ b/.github/workflows/reusable-check-html-ids.yml
@@ -23,17 +23,33 @@ jobs:
       - name: 'Find merge base'
         id: merge-base
         run: |
+          # Fetching can fail with "fatal: shallow file has changed since we
+          # read it", especially for old pull requests, which have a lot of
+          # history to fetch.  Retry it several times (see gh-151365).
+          retry_fetch() {
+            for attempt in $(seq 5); do
+              if [ "${attempt}" -gt 1 ]; then
+                echo "::warning::git fetch failed, retrying (attempt ${attempt})"
+                sleep 3
+              fi
+              if git fetch "$@"; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
           BASE="${{ github.event.pull_request.base.sha }}"
           HEAD="${{ github.event.pull_request.head.sha }}"
-          git fetch --depth=$((${{ github.event.pull_request.commits }} + 10)) --no-tags origin "$BASE" "$HEAD"
+          retry_fetch --depth=$((${{ github.event.pull_request.commits }} + 10)) --no-tags origin "$BASE" "$HEAD"
 
           if ! MERGE_BASE=$(git merge-base "$BASE" "$HEAD" 2>/dev/null); then
-            git fetch --deepen=1 --no-tags origin "$BASE" "$HEAD"
+            retry_fetch --deepen=1 --no-tags origin "$BASE" "$HEAD"
 
             OLDEST=$(git rev-list --reflog --max-parents=0 --reverse "${BASE}^" "${HEAD}^" | head -1)
             TIMESTAMP=$(git show --format=%at --no-patch "$OLDEST")
 
-            git fetch --shallow-since="$TIMESTAMP" --no-tags origin "$BASE" "$HEAD"
+            retry_fetch --shallow-since="$TIMESTAMP" --no-tags origin "$BASE" "$HEAD"
 
             MERGE_BASE=$(git merge-base "$BASE" "$HEAD")
           fi

--- a/.github/workflows/reusable-context.yml
+++ b/.github/workflows/reusable-context.yml
@@ -96,8 +96,24 @@ jobs:
       run: |
         set -eux
 
+        # Fetching can fail with "fatal: shallow file has changed since we
+        # read it", especially for old pull requests, which have a lot of
+        # history to fetch.  Retry it several times (see gh-151365).
+        retry_fetch() {
+          for attempt in $(seq 5); do
+            if [ "${attempt}" -gt 1 ]; then
+              echo "::warning::git fetch failed, retrying (attempt ${attempt})"
+              sleep 3
+            fi
+            if git fetch "$@"; then
+              return 0
+            fi
+          done
+          return 1
+        }
+
         # Fetch enough history to find a common ancestor commit (aka merge-base):
-        git fetch origin "${refspec_pr}" --depth=$(( commits + 1 )) \
+        retry_fetch origin "${refspec_pr}" --depth=$(( commits + 1 )) \
           --no-tags --prune --no-recurse-submodules
 
         # This should get the oldest commit in the local fetched history (which may not be the commit the PR branched from):
@@ -105,7 +121,7 @@ jobs:
         DATE=$( git log --date=iso8601 --format=%cd "${COMMON_ANCESTOR}" )
 
         # Get all commits since that commit date from the base branch (eg: main):
-        git fetch origin "${refspec_base}" --shallow-since="${DATE}" \
+        retry_fetch origin "${refspec_base}" --shallow-since="${DATE}" \
           --no-tags --prune --no-recurse-submodules
       env:
         branch_pr: 'origin/${{ github.event.pull_request.head.ref }}'

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -51,8 +51,24 @@ jobs:
     - name: 'Fetch commits to get branch diff'
       if: github.event_name == 'pull_request'
       run: |
+        # Fetching can fail with "fatal: shallow file has changed since we
+        # read it", especially for old pull requests, which have a lot of
+        # history to fetch.  Retry it several times (see gh-151365).
+        retry_fetch() {
+          for attempt in $(seq 5); do
+            if [ "${attempt}" -gt 1 ]; then
+              echo "::warning::git fetch failed, retrying (attempt ${attempt})"
+              sleep 3
+            fi
+            if git fetch "$@"; then
+              return 0
+            fi
+          done
+          return 1
+        }
+
         # Fetch enough history to find a common ancestor commit (aka merge-base):
-        git fetch origin "${refspec_pr}" --depth=$(( commits + 1 )) \
+        retry_fetch origin "${refspec_pr}" --depth=$(( commits + 1 )) \
           --no-tags --prune --no-recurse-submodules
 
         # This should get the oldest commit in the local fetched history (which may not be the commit the PR branched from):
@@ -60,7 +76,7 @@ jobs:
         DATE=$( git log --date=iso8601 --format=%cd "${COMMON_ANCESTOR}" )
 
         # Get all commits since that commit date from the base branch (eg: master or main):
-        git fetch origin "${refspec_base}" --shallow-since="${DATE}" \
+        retry_fetch origin "${refspec_base}" --shallow-since="${DATE}" \
           --no-tags --prune --no-recurse-submodules
     - name: 'Set up Python'
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
Fetching the history for computing the branch diff can fail with `fatal: shallow file has changed since we read it`, a git 2.54 bug (fixed in git 2.55, which is not yet in the runner images) which is hit especially often for old pull requests, which have a lot of history to fetch.

Retry the fetch up to 5 times, and annotate the run with a warning on every retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-151365 -->
* Issue: gh-151365
<!-- /gh-issue-number -->
