### PR TITLE
gh-155493: Fix crash in decimal SignalDict on re-entrant Context teardown

### DIFF
--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -2988,6 +2988,34 @@ class ContextAPItests:
             assert_signals(self, c, 'traps', [InvalidOperation, DivisionByZero,
                                               Overflow])
 
+    def test_signaldict_reentrant_dealloc(self):
+        # A __bool__ that deallocates the owning context while assigning to or
+        # comparing Context.flags must raise, not crash.
+        if self.decimal is not C:
+            self.skipTest("SignalDict only exists in the C implementation")
+        Context = self.decimal.Context
+        InvalidOperation = self.decimal.InvalidOperation
+
+        class Evil:
+            def __init__(self, box):
+                self.box = box
+            def __bool__(self):
+                import gc
+                self.box.clear()
+                gc.collect()
+                return True
+
+        box = [Context()]
+        flags = box[0].flags
+        with self.assertRaises(ValueError):
+            flags[InvalidOperation] = Evil(box)
+
+        box = [Context()]
+        other = box[0].flags.copy()
+        other[InvalidOperation] = Evil(box)
+        with self.assertRaises(ValueError):
+            box[0].flags == other
+
     def test_pickle(self):
 
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):

--- a/Misc/NEWS.d/next/Library/2026-08-10-12-30-00.gh-issue-155493.Sd3Uf9.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-10-12-30-00.gh-issue-155493.Sd3Uf9.rst
@@ -1,0 +1,3 @@
+Fix a crash in the C implementation of :mod:`decimal` when a value's
+``__bool__`` deallocates the owning context while it is assigned to, or
+compared against, ``Context.flags``. Patch by tonghuaroot.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -740,6 +740,11 @@ signaldict_setitem(PyObject *self, PyObject *key, PyObject *value)
         return -1;
     }
 
+    if (SdFlagAddr(self) == NULL) {
+        /* value.__bool__() may have deallocated the owning context. */
+        return value_error_int(INVALID_SIGNALDICT_ERROR_MSG);
+    }
+
     if (x == 1) {
         SdFlags(self) |= flag;
     }
@@ -813,6 +818,10 @@ signaldict_richcompare(PyObject *v, PyObject *w, int op)
                 else {
                     return NULL;
                 }
+            }
+            else if (SdFlagAddr(v) == NULL) {
+                /* w's __bool__() may have deallocated v's context. */
+                return value_error_ptr(INVALID_SIGNALDICT_ERROR_MSG);
             }
             else {
                 res = (SdFlags(v)==flags) ^ (op==Py_NE) ? Py_True : Py_False;


### PR DESCRIPTION
`signaldict_setitem` and `signaldict_richcompare` read the borrowed flags
pointer after `PyObject_IsTrue` calls the value's `__bool__`, which can
deallocate the owning `Context`. gh-146011 added this guard to
`signaldict_repr`; this extends it to the two remaining methods that borrow
the pointer across a Python call.


<!-- gh-issue-number: gh-155493 -->
* Issue: gh-155493
<!-- /gh-issue-number -->
