### PR TITLE
gh-153400: Use glibc functions instead of syscall()

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-08-10-22-11-15.gh-issue-153400.Ds3GI3.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-10-22-11-15.gh-issue-153400.Ds3GI3.rst
@@ -1,0 +1,4 @@
+:mod:`os` and :mod:`signal`: Use glibc functions instead of ``syscall()``:
+``pidfd_open()``, ``pidfd_getfd()`` and ``pidfd_send_signal()`` (glibc 2.36),
+``gettid()`` and ``getdents64()`` (glibc 2.30), and ``getrandom()`` (glibc
+2.25). Patch by Victor Stinner.

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -388,20 +388,26 @@ _close_range_except(int start_fd,
     return 0;
 }
 
-#if defined(__linux__) && defined(HAVE_SYS_SYSCALL_H)
+#if defined(HAVE_GETDENTS64) \
+    || (defined(__linux__) && defined(HAVE_SYS_SYSCALL_H))
+
+#ifdef HAVE_GETDENTS64
+#  define py_dirent64 dirent64
+#else
 /* It doesn't matter if d_name has room for NAME_MAX chars; we're using this
  * only to read a directory of short file descriptor number names.  The kernel
  * will return an error if we didn't give it enough space.  Highly Unlikely.
  * This structure is very old and stable: It will not change unless the kernel
  * chooses to break compatibility with all existing binaries.  Highly Unlikely.
  */
-struct linux_dirent64 {
+struct py_dirent64 {
    unsigned long long d_ino;
    long long d_off;
    unsigned short d_reclen;     /* Length of this linux_dirent */
    unsigned char  d_type;
    char           d_name[256];  /* Filename (null-terminated) */
 };
+#endif  // !HAVE_GETDENTS64
 
 static int
 _brute_force_closer(int first, int last)
@@ -441,19 +447,27 @@ _close_open_fds_safe(int start_fd, int *fds_to_keep, Py_ssize_t fds_to_keep_len)
                             _brute_force_closer);
         return;
     } else {
-        char buffer[sizeof(struct linux_dirent64)];
-        int bytes;
-        while ((bytes = syscall(SYS_getdents64, fd_dir_fd,
-                                (struct linux_dirent64 *)buffer,
-                                sizeof(buffer))) > 0) {
-            struct linux_dirent64 *entry;
+        char buffer[sizeof(struct py_dirent64)];
+        Py_ssize_t bytes;
+        while (1) {
+#ifdef HAVE_GETDENTS64
+            bytes = getdents64(fd_dir_fd, buffer, sizeof(buffer));
+#else
+            bytes = syscall(SYS_getdents64, fd_dir_fd,
+                            (struct py_dirent64 *)buffer, sizeof(buffer));
+#endif
+            if (bytes <= 0) {
+                break;
+            }
+
+            struct py_dirent64 *entry;
             int offset;
 #ifdef _Py_MEMORY_SANITIZER
             __msan_unpoison(buffer, bytes);
 #endif
             for (offset = 0; offset < bytes; offset += entry->d_reclen) {
                 int fd;
-                entry = (struct linux_dirent64 *)(buffer + offset);
+                entry = (struct py_dirent64 *)(buffer + offset);
                 if ((fd = _pos_int_from_ascii(entry->d_name)) < 0)
                     continue;  /* Not a number. */
                 if (fd != fd_dir_fd && fd >= start_fd &&

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -6330,7 +6330,7 @@ os_wait(PyObject *module, PyObject *Py_UNUSED(ignored))
 
 #endif /* defined(HAVE_WAIT) */
 
-#if (defined(__linux__) && defined(__NR_pidfd_open) && !(defined(__ANDROID__) && __ANDROID_API__ < 31))
+#if (defined(HAVE_PIDFD_OPEN) || (defined(__linux__) && defined(__NR_pidfd_open) && !(defined(__ANDROID__) && __ANDROID_API__ < 31)))
 
 PyDoc_STRVAR(os_pidfd_open__doc__,
 "pidfd_open($module, /, pid, flags=0)\n"
@@ -6405,9 +6405,9 @@ exit:
     return return_value;
 }
 
-#endif /* (defined(__linux__) && defined(__NR_pidfd_open) && !(defined(__ANDROID__) && __ANDROID_API__ < 31)) */
+#endif /* (defined(HAVE_PIDFD_OPEN) || (defined(__linux__) && defined(__NR_pidfd_open) && !(defined(__ANDROID__) && __ANDROID_API__ < 31))) */
 
-#if (defined(__linux__) && defined(__NR_pidfd_getfd) && !(defined(__ANDROID__) && __ANDROID_API__ < 31))
+#if (defined(HAVE_PIDFD_GETFD) || (defined(__linux__) && defined(__NR_pidfd_getfd) && !(defined(__ANDROID__) && __ANDROID_API__ < 31)))
 
 PyDoc_STRVAR(os_pidfd_getfd__doc__,
 "pidfd_getfd($module, /, pidfd, targetfd, *, flags=0)\n"
@@ -6492,7 +6492,7 @@ exit:
     return return_value;
 }
 
-#endif /* (defined(__linux__) && defined(__NR_pidfd_getfd) && !(defined(__ANDROID__) && __ANDROID_API__ < 31)) */
+#endif /* (defined(HAVE_PIDFD_GETFD) || (defined(__linux__) && defined(__NR_pidfd_getfd) && !(defined(__ANDROID__) && __ANDROID_API__ < 31))) */
 
 #if defined(HAVE_SETNS)
 
@@ -12578,7 +12578,7 @@ exit:
     return return_value;
 }
 
-#if defined(HAVE_GETRANDOM_SYSCALL)
+#if (defined(HAVE_GETRANDOM) || defined(HAVE_GETRANDOM_SYSCALL))
 
 PyDoc_STRVAR(os_getrandom__doc__,
 "getrandom($module, /, size, flags=0)\n"
@@ -12659,7 +12659,7 @@ exit:
     return return_value;
 }
 
-#endif /* defined(HAVE_GETRANDOM_SYSCALL) */
+#endif /* (defined(HAVE_GETRANDOM) || defined(HAVE_GETRANDOM_SYSCALL)) */
 
 #if (defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_APP) || defined(MS_WINDOWS_SYSTEM))
 
@@ -13734,4 +13734,4 @@ exit:
 #ifndef OS__EMSCRIPTEN_LOG_METHODDEF
     #define OS__EMSCRIPTEN_LOG_METHODDEF
 #endif /* !defined(OS__EMSCRIPTEN_LOG_METHODDEF) */
-/*[clinic end generated code: output=d641f02a97057666 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ffde468159c24b32 input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -12590,7 +12590,7 @@ PyDoc_STRVAR(os_getrandom__doc__,
     {"getrandom", _PyCFunction_CAST(os_getrandom), METH_FASTCALL|METH_KEYWORDS, os_getrandom__doc__},
 
 static PyObject *
-os_getrandom_impl(PyObject *module, Py_ssize_t size, int flags);
+os_getrandom_impl(PyObject *module, Py_ssize_t size, unsigned int flags);
 
 static PyObject *
 os_getrandom(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
@@ -12626,7 +12626,7 @@ os_getrandom(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
     PyObject *argsbuf[2];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     Py_ssize_t size;
-    int flags = 0;
+    unsigned int flags = 0;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
             /*minpos*/ 1, /*maxpos*/ 2, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
@@ -12648,9 +12648,21 @@ os_getrandom(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
     if (!noptargs) {
         goto skip_optional_pos;
     }
-    flags = PyLong_AsInt(args[1]);
-    if (flags == -1 && PyErr_Occurred()) {
-        goto exit;
+    {
+        Py_ssize_t _bytes = PyLong_AsNativeBytes(args[1], &flags, sizeof(unsigned int),
+                Py_ASNATIVEBYTES_NATIVE_ENDIAN |
+                Py_ASNATIVEBYTES_ALLOW_INDEX |
+                Py_ASNATIVEBYTES_UNSIGNED_BUFFER);
+        if (_bytes < 0) {
+            goto exit;
+        }
+        if ((size_t)_bytes > sizeof(unsigned int)) {
+            if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                "integer value out of range", 1) < 0)
+            {
+                goto exit;
+            }
+        }
     }
 skip_optional_pos:
     return_value = os_getrandom_impl(module, size, flags);
@@ -13734,4 +13746,4 @@ exit:
 #ifndef OS__EMSCRIPTEN_LOG_METHODDEF
     #define OS__EMSCRIPTEN_LOG_METHODDEF
 #endif /* !defined(OS__EMSCRIPTEN_LOG_METHODDEF) */
-/*[clinic end generated code: output=ffde468159c24b32 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6dc1e061bfd47375 input=a9049054013a1b77]*/

--- a/Modules/clinic/signalmodule.c.h
+++ b/Modules/clinic/signalmodule.c.h
@@ -689,7 +689,7 @@ exit:
 
 #endif /* defined(HAVE_PTHREAD_KILL) */
 
-#if (defined(__linux__) && defined(__NR_pidfd_send_signal) && !(defined(__ANDROID__) && __ANDROID_API__ < 31))
+#if (defined(HAVE_PIDFD_SEND_SIGNAL) || (defined(__linux__) && defined(__NR_pidfd_send_signal) && !(defined(__ANDROID__) && __ANDROID_API__ < 31)))
 
 PyDoc_STRVAR(signal_pidfd_send_signal__doc__,
 "pidfd_send_signal($module, pidfd, signalnum, siginfo=None, flags=0, /)\n"
@@ -702,7 +702,7 @@ PyDoc_STRVAR(signal_pidfd_send_signal__doc__,
 
 static PyObject *
 signal_pidfd_send_signal_impl(PyObject *module, int pidfd, int signalnum,
-                              PyObject *siginfo, int flags);
+                              PyObject *siginfo, unsigned int flags);
 
 static PyObject *
 signal_pidfd_send_signal(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
@@ -711,7 +711,7 @@ signal_pidfd_send_signal(PyObject *module, PyObject *const *args, Py_ssize_t nar
     int pidfd;
     int signalnum;
     PyObject *siginfo = Py_None;
-    int flags = 0;
+    unsigned int flags = 0;
 
     if (!_PyArg_CheckPositional("pidfd_send_signal", nargs, 2, 4)) {
         goto exit;
@@ -731,9 +731,21 @@ signal_pidfd_send_signal(PyObject *module, PyObject *const *args, Py_ssize_t nar
     if (nargs < 4) {
         goto skip_optional;
     }
-    flags = PyLong_AsInt(args[3]);
-    if (flags == -1 && PyErr_Occurred()) {
-        goto exit;
+    {
+        Py_ssize_t _bytes = PyLong_AsNativeBytes(args[3], &flags, sizeof(unsigned int),
+                Py_ASNATIVEBYTES_NATIVE_ENDIAN |
+                Py_ASNATIVEBYTES_ALLOW_INDEX |
+                Py_ASNATIVEBYTES_UNSIGNED_BUFFER);
+        if (_bytes < 0) {
+            goto exit;
+        }
+        if ((size_t)_bytes > sizeof(unsigned int)) {
+            if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                "integer value out of range", 1) < 0)
+            {
+                goto exit;
+            }
+        }
     }
 skip_optional:
     return_value = signal_pidfd_send_signal_impl(module, pidfd, signalnum, siginfo, flags);
@@ -742,7 +754,7 @@ exit:
     return return_value;
 }
 
-#endif /* (defined(__linux__) && defined(__NR_pidfd_send_signal) && !(defined(__ANDROID__) && __ANDROID_API__ < 31)) */
+#endif /* (defined(HAVE_PIDFD_SEND_SIGNAL) || (defined(__linux__) && defined(__NR_pidfd_send_signal) && !(defined(__ANDROID__) && __ANDROID_API__ < 31))) */
 
 #ifndef SIGNAL_ALARM_METHODDEF
     #define SIGNAL_ALARM_METHODDEF
@@ -795,4 +807,4 @@ exit:
 #ifndef SIGNAL_PIDFD_SEND_SIGNAL_METHODDEF
     #define SIGNAL_PIDFD_SEND_SIGNAL_METHODDEF
 #endif /* !defined(SIGNAL_PIDFD_SEND_SIGNAL_METHODDEF) */
-/*[clinic end generated code: output=0731d6f05c42c09a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2a04ec31f49b1c93 input=a9049054013a1b77]*/

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -68,6 +68,10 @@
 #  include "emscripten.h"         // emscripten_debugger()
 #endif
 
+#ifdef HAVE_SYS_RANDOM_H
+#  include <sys/random.h>
+#endif
+
 #ifdef HAVE_SYS_UIO_H
 #  include <sys/uio.h>
 #endif
@@ -10810,8 +10814,9 @@ os_wait_impl(PyObject *module)
 
 
 // This system call always crashes on older Android versions.
-#if defined(__linux__) && defined(__NR_pidfd_open) && \
-    !(defined(__ANDROID__) && __ANDROID_API__ < 31)
+#if defined(HAVE_PIDFD_OPEN) \
+    || (defined(__linux__) && defined(__NR_pidfd_open) \
+        && !(defined(__ANDROID__) && __ANDROID_API__ < 31))
 /*[clinic input]
 os.pidfd_open
   pid: pid_t
@@ -10827,7 +10832,11 @@ static PyObject *
 os_pidfd_open_impl(PyObject *module, pid_t pid, unsigned int flags)
 /*[clinic end generated code: output=5c7252698947dc41 input=03058b32c389f874]*/
 {
+#ifdef HAVE_PIDFD_OPEN
+    int fd = pidfd_open(pid, flags);
+#else
     int fd = syscall(__NR_pidfd_open, pid, flags);
+#endif
     if (fd < 0) {
         return posix_error();
     }
@@ -10836,8 +10845,9 @@ os_pidfd_open_impl(PyObject *module, pid_t pid, unsigned int flags)
 #endif
 
 
-#if defined(__linux__) && defined(__NR_pidfd_getfd) && \
-    !(defined(__ANDROID__) && __ANDROID_API__ < 31)
+#if defined(HAVE_PIDFD_GETFD) \
+    || (defined(__linux__) && defined(__NR_pidfd_getfd) \
+        && !(defined(__ANDROID__) && __ANDROID_API__ < 31))
 /*[clinic input]
 os.pidfd_getfd
   pidfd: int
@@ -10856,7 +10866,11 @@ os_pidfd_getfd_impl(PyObject *module, int pidfd, int targetfd,
                     unsigned int flags)
 /*[clinic end generated code: output=e1a1415a13c7137f input=ef6417fb10deb1cc]*/
 {
+#ifdef HAVE_PIDFD_GETFD
+    int fd = pidfd_getfd(pidfd, targetfd, flags);
+#else
     int fd = syscall(__NR_pidfd_getfd, pidfd, targetfd, flags);
+#endif
     if (fd < 0) {
         return posix_error();
     }
@@ -17369,7 +17383,7 @@ os_fspath_impl(PyObject *module, PyObject *path)
     return PyOS_FSPath(path);
 }
 
-#ifdef HAVE_GETRANDOM_SYSCALL
+#if defined(HAVE_GETRANDOM) || defined(HAVE_GETRANDOM_SYSCALL)
 /*[clinic input]
 os.getrandom
 
@@ -17396,7 +17410,11 @@ os_getrandom_impl(PyObject *module, Py_ssize_t size, int flags)
 
     Py_ssize_t n;
     while (1) {
+#ifdef HAVE_GETRANDOM
+        n = getrandom(data, size, flags);
+#else
         n = syscall(SYS_getrandom, data, size, flags);
+#endif
         if (n < 0 && errno == EINTR) {
             if (PyErr_CheckSignals() < 0) {
                 goto error;
@@ -18504,7 +18522,7 @@ all_ins(PyObject *m)
     if (PyModule_AddIntMacro(m, RTLD_MEMBER)) return -1;
 #endif
 
-#ifdef HAVE_GETRANDOM_SYSCALL
+#if defined(HAVE_GETRANDOM) || defined(HAVE_GETRANDOM_SYSCALL)
     if (PyModule_AddIntMacro(m, GRND_RANDOM)) return -1;
     if (PyModule_AddIntMacro(m, GRND_NONBLOCK)) return -1;
 #endif

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -69,7 +69,7 @@
 #endif
 
 #ifdef HAVE_SYS_RANDOM_H
-#  include <sys/random.h>
+#  include <sys/random.h>         // getrandom()
 #endif
 
 #ifdef HAVE_SYS_UIO_H
@@ -17388,14 +17388,14 @@ os_fspath_impl(PyObject *module, PyObject *path)
 os.getrandom
 
     size: Py_ssize_t
-    flags: int=0
+    flags: unsigned_int(bitwise=True) = 0
 
 Obtain a series of random bytes.
 [clinic start generated code]*/
 
 static PyObject *
-os_getrandom_impl(PyObject *module, Py_ssize_t size, int flags)
-/*[clinic end generated code: output=b3a618196a61409c input=59bafac39c594947]*/
+os_getrandom_impl(PyObject *module, Py_ssize_t size, unsigned int flags)
+/*[clinic end generated code: output=c2163c05f0e1d0a1 input=e0174983f5703f82]*/
 {
     if (size < 0) {
         errno = EINVAL;

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -53,6 +53,10 @@
 #  include <pthread.h>
 #endif
 
+#ifdef HAVE_SYS_PIDFD_H
+#  include <sys/pidfd.h>          // pidfd_send_signal()
+#endif
+
 #ifndef SIG_ERR
 #  define SIG_ERR ((PyOS_sighandler_t)(-1))
 #endif
@@ -1300,15 +1304,16 @@ signal_pthread_kill_impl(PyObject *module, unsigned long thread_id,
 
 
 // This system call always crashes on older Android versions.
-#if defined(__linux__) && defined(__NR_pidfd_send_signal) && \
-    !(defined(__ANDROID__) && __ANDROID_API__ < 31)
+#if defined(HAVE_PIDFD_SEND_SIGNAL) \
+    || (defined(__linux__) && defined(__NR_pidfd_send_signal) \
+        && !(defined(__ANDROID__) && __ANDROID_API__ < 31))
 /*[clinic input]
 signal.pidfd_send_signal
 
     pidfd: int
     signalnum: int
     siginfo: object = None
-    flags: int = 0
+    flags: unsigned_int(bitwise=True) = 0
     /
 
 Send a signal to a process referred to by a pid file descriptor.
@@ -1316,15 +1321,20 @@ Send a signal to a process referred to by a pid file descriptor.
 
 static PyObject *
 signal_pidfd_send_signal_impl(PyObject *module, int pidfd, int signalnum,
-                              PyObject *siginfo, int flags)
-/*[clinic end generated code: output=2d59f04a75d9cbdf input=2a6543a1f4ac2000]*/
+                              PyObject *siginfo, unsigned int flags)
+/*[clinic end generated code: output=1804b5a19d269104 input=a6e82a3c264fa19d]*/
 
 {
     if (siginfo != Py_None) {
         PyErr_SetString(PyExc_TypeError, "siginfo must be None");
         return NULL;
     }
-    if (syscall(__NR_pidfd_send_signal, pidfd, signalnum, NULL, flags) < 0) {
+#ifdef HAVE_PIDFD_SEND_SIGNAL
+    int res = pidfd_send_signal(pidfd, signalnum, NULL, flags);
+#else
+    int res = syscall(__NR_pidfd_send_signal, pidfd, signalnum, NULL, flags);
+#endif
+    if (res < 0) {
         PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }

--- a/Python/bootstrap_hash.c
+++ b/Python/bootstrap_hash.c
@@ -126,9 +126,6 @@ py_getrandom(void *buffer, Py_ssize_t size, int blocking, int raise)
             n = getrandom(dest, n, flags);
         }
 #else
-        /* On Linux, use the syscall() function because the GNU libc doesn't
-           expose the Linux getrandom() syscall yet. See:
-           https://sourceware.org/bugzilla/show_bug.cgi?id=17252 */
         if (raise) {
             Py_BEGIN_ALLOW_THREADS
             n = syscall(SYS_getrandom, dest, n, flags);

--- a/Python/perf_jit_trampoline.c
+++ b/Python/perf_jit_trampoline.c
@@ -672,6 +672,8 @@ static void perf_map_jit_write_entry_with_name(
     uint64_t thread_id = 0;
     pthread_threadid_np(NULL, &thread_id);
     ev.thread_id = (uint32_t)thread_id;
+#elif defined(HAVE_GETTID)
+    ev.thread_id = gettid();
 #else
     ev.thread_id = syscall(SYS_gettid);  // Get thread ID via system call
 #endif

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -18,7 +18,9 @@
 #include <signal.h>
 #include <unistd.h>             /* pause(), also getthrid() on OpenBSD */
 
-#if defined(__linux__)
+#ifdef HAVE_GETTID
+#   include <unistd.h>          // gettid()
+#elif defined(__linux__)
 #   include <sys/syscall.h>     /* syscall(SYS_gettid) */
 #elif defined(__FreeBSD__)
 #   include <pthread_np.h>      /* pthread_getthreadid_np() */
@@ -380,6 +382,9 @@ PyThread_get_thread_native_id(void)
 #ifdef __APPLE__
     uint64_t native_id;
     (void) pthread_threadid_np(NULL, &native_id);
+#elif defined(HAVE_GETTID)
+    pid_t native_id;
+    native_id = gettid();
 #elif defined(__linux__)
     pid_t native_id;
     native_id = syscall(SYS_gettid);

--- a/configure
+++ b/configure
@@ -20523,6 +20523,12 @@ then :
   printf "%s\n" "#define HAVE_GAI_STRERROR 1" >>confdefs.h
 
 fi
+ac_fn_c_check_func "$LINENO" "getdents64" "ac_cv_func_getdents64"
+if test "x$ac_cv_func_getdents64" = xyes
+then :
+  printf "%s\n" "#define HAVE_GETDENTS64 1" >>confdefs.h
+
+fi
 ac_fn_c_check_func "$LINENO" "getegid" "ac_cv_func_getegid"
 if test "x$ac_cv_func_getegid" = xyes
 then :
@@ -20697,6 +20703,12 @@ then :
   printf "%s\n" "#define HAVE_GETSPNAM 1" >>confdefs.h
 
 fi
+ac_fn_c_check_func "$LINENO" "gettid" "ac_cv_func_gettid"
+if test "x$ac_cv_func_gettid" = xyes
+then :
+  printf "%s\n" "#define HAVE_GETTID 1" >>confdefs.h
+
+fi
 ac_fn_c_check_func "$LINENO" "getuid" "ac_cv_func_getuid"
 if test "x$ac_cv_func_getuid" = xyes
 then :
@@ -20863,6 +20875,24 @@ ac_fn_c_check_func "$LINENO" "pause" "ac_cv_func_pause"
 if test "x$ac_cv_func_pause" = xyes
 then :
   printf "%s\n" "#define HAVE_PAUSE 1" >>confdefs.h
+
+fi
+ac_fn_c_check_func "$LINENO" "pidfd_open" "ac_cv_func_pidfd_open"
+if test "x$ac_cv_func_pidfd_open" = xyes
+then :
+  printf "%s\n" "#define HAVE_PIDFD_OPEN 1" >>confdefs.h
+
+fi
+ac_fn_c_check_func "$LINENO" "pidfd_getfd" "ac_cv_func_pidfd_getfd"
+if test "x$ac_cv_func_pidfd_getfd" = xyes
+then :
+  printf "%s\n" "#define HAVE_PIDFD_GETFD 1" >>confdefs.h
+
+fi
+ac_fn_c_check_func "$LINENO" "pidfd_send_signal" "ac_cv_func_pidfd_send_signal"
+if test "x$ac_cv_func_pidfd_send_signal" = xyes
+then :
+  printf "%s\n" "#define HAVE_PIDFD_SEND_SIGNAL 1" >>confdefs.h
 
 fi
 ac_fn_c_check_func "$LINENO" "pipe" "ac_cv_func_pipe"

--- a/configure.ac
+++ b/configure.ac
@@ -5497,13 +5497,14 @@ AC_CHECK_FUNCS([ \
   copy_file_range ctermid dladdr dup execv explicit_bzero explicit_memset \
   faccessat fchmod fchmodat fchown fchownat fdopendir fdwalk fexecve \
   fork fork1 fpathconf fstatat ftime ftruncate futimens futimes futimesat \
-  gai_strerror getegid geteuid getgid getgrent getgrgid getgrgid_r \
+  gai_strerror getdents64 getegid geteuid getgid getgrent getgrgid getgrgid_r \
   getgrnam_r getgrouplist gethostname getitimer getloadavg getlogin getlogin_r \
   getpeername getpgid getpid getppid getpriority _getpty \
   getpwent getpwnam_r getpwuid getpwuid_r getresgid getresuid getrusage getsid getspent \
-  getspnam getuid getwd grantpt if_nameindex initgroups kill killpg lchown linkat \
+  getspnam gettid getuid getwd grantpt if_nameindex initgroups kill killpg lchown linkat \
   lockf lstat lutimes madvise mbrtowc memrchr mkdirat mkfifo mkfifoat \
-  mknod mknodat mktime mmap mremap nice openat opendir pathconf pause pipe \
+  mknod mknodat mktime mmap mremap nice openat opendir pathconf pause \
+  pidfd_open pidfd_getfd pidfd_send_signal pipe \
   plock poll ppoll posix_fadvise posix_fallocate posix_openpt posix_spawn posix_spawnp \
   posix_spawn_file_actions_addclosefrom_np \
   pread preadv preadv2 process_vm_readv \

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -579,6 +579,9 @@
 /* Define this if you have flockfile(), getc_unlocked(), and funlockfile() */
 #undef HAVE_GETC_UNLOCKED
 
+/* Define to 1 if you have the 'getdents64' function. */
+#undef HAVE_GETDENTS64
+
 /* Define to 1 if you have the 'getegid' function. */
 #undef HAVE_GETEGID
 
@@ -713,6 +716,9 @@
 
 /* Define to 1 if you have the 'getspnam' function. */
 #undef HAVE_GETSPNAM
+
+/* Define to 1 if you have the 'gettid' function. */
+#undef HAVE_GETTID
 
 /* Define to 1 if you have the 'getuid' function. */
 #undef HAVE_GETUID
@@ -1045,6 +1051,15 @@
 
 /* Define to 1 if you have the 'pause' function. */
 #undef HAVE_PAUSE
+
+/* Define to 1 if you have the 'pidfd_getfd' function. */
+#undef HAVE_PIDFD_GETFD
+
+/* Define to 1 if you have the 'pidfd_open' function. */
+#undef HAVE_PIDFD_OPEN
+
+/* Define to 1 if you have the 'pidfd_send_signal' function. */
+#undef HAVE_PIDFD_SEND_SIGNAL
 
 /* Define to 1 if you have the 'pipe' function. */
 #undef HAVE_PIPE


### PR DESCRIPTION
Use glibc functions instead of syscall(): pidfd_open(), pidfd_getfd() and pidfd_send_signal() (glibc 2.36), gettid() and getdents64() (glibc 2.30), and getrandom() (glibc 2.25).

Use unsigned int for os.getrandom() flags and signal.pidfd_send_signal() flags.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-153400 -->
* Issue: gh-153400
<!-- /gh-issue-number -->
