### PR TITLE
gh-155499: Fix curses border() and box() rejecting 0 mixed with str/bytes

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -1521,6 +1521,21 @@ class TestCurses(unittest.TestCase):
                     win.box(v, v)
                     self.assertEqual(win.instr(0, 1, 1), b)
 
+    def test_border_box_zero_sentinel(self):
+        # gh-155499: 0 must still mean "use the default character" even
+        # when mixed with a one-character str/bytes argument.
+        win = curses.newwin(5, 10, 5, 2)
+        win.border('|', '|', '-', '-')
+        win.border('|', '|', '-', '-', 0, 0, 0, 0)
+        win.border(0, '|', 0, '-', 0, 0, 0, 0)
+        self.assertRaises(TypeError, win.border,
+                          '|', '|', '-', '-', 1, 0, 0, 0)
+        win.box('|', 0)
+        win.box(0, '-')
+        win.box(0, 0)
+        self.assertRaises(TypeError, win.box, '|', 1)
+        self.assertRaises(TypeError, win.box, 1, '-')
+
     def test_unctrl(self):
         self.assertEqual(curses.unctrl(b'A'), b'A')
         self.assertEqual(curses.unctrl('A'), b'A')

--- a/Misc/NEWS.d/next/Library/2026-08-10-20-05-55.gh-issue-155499._P6SDK.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-10-20-05-55.gh-issue-155499._P6SDK.rst
@@ -1,0 +1,3 @@
+:meth:`curses.window.border` and :meth:`curses.window.box` no longer raise
+:exc:`TypeError` when ``0`` is mixed with a one-character string or bytes
+argument, restoring the documented default-character sentinel behavior.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -2711,6 +2711,9 @@ _curses_window_border_impl(PyCursesWindowObject *self, PyObject *ls,
             else if (types[i] == 2) {
                 wch_p[i] = &wch[i];
             }
+            else if (types[i] == 1 && ch[i] == 0) {
+                wch_p[i] = NULL;  /* int 0 also means "use default" */
+            }
             else {
                 PyErr_SetString(PyExc_TypeError,
                                 "border() cannot mix integer or bytes "
@@ -2775,15 +2778,37 @@ _curses_window_box_impl(PyCursesWindowObject *self, int group_right_1,
         }
     }
     if (t1 == 2 || t2 == 2) {
-        if (t1 != 2 || t2 != 2) {
-            PyErr_SetString(PyExc_TypeError,
-                            "box() cannot mix integer or bytes characters "
-                            "with wide string characters");
-            return NULL;
+        const cchar_t *wch1_p, *wch2_p;
+
+        if (t1 == 2) {
+            wch1_p = &wch1;
         }
-        int rtn = wborder_set(self->win, &wch1, &wch1, &wch2, &wch2,
+        else if (t1 == 1 && ch1 == 0) {
+            wch1_p = NULL;
+        }
+        else {
+            goto mixed_type_error;
+        }
+
+        if (t2 == 2) {
+            wch2_p = &wch2;
+        }
+        else if (t2 == 1 && ch2 == 0) {
+            wch2_p = NULL;
+        }
+        else {
+            goto mixed_type_error;
+        }
+
+        int rtn = wborder_set(self->win, wch1_p, wch1_p, wch2_p, wch2_p,
                               NULL, NULL, NULL, NULL);
         return curses_window_check_err(self, rtn, "wborder_set", "box");
+
+    mixed_type_error:
+        PyErr_SetString(PyExc_TypeError,
+                         "box() cannot mix integer or bytes characters "
+                         "with wide string characters");
+        return NULL;
     }
 #else
     if (group_right_1) {

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -2705,14 +2705,11 @@ _curses_window_border_impl(PyCursesWindowObject *self, PyObject *ls,
     }
     if (use_wide) {
         for (i = 0; i < 8; i++) {
-            if (objs[i] == NULL) {
+            if (objs[i] == NULL || (types[i] == 1 && ch[i] == 0)) {
                 wch_p[i] = NULL;  /* use the default character */
             }
             else if (types[i] == 2) {
                 wch_p[i] = &wch[i];
-            }
-            else if (types[i] == 1 && ch[i] == 0) {
-                wch_p[i] = NULL;  /* int 0 also means "use default" */
             }
             else {
                 PyErr_SetString(PyExc_TypeError,
@@ -2778,37 +2775,19 @@ _curses_window_box_impl(PyCursesWindowObject *self, int group_right_1,
         }
     }
     if (t1 == 2 || t2 == 2) {
-        const cchar_t *wch1_p, *wch2_p;
-
-        if (t1 == 2) {
-            wch1_p = &wch1;
+        int t1_ok = (t1 == 2) || (t1 == 1 && ch1 == 0);
+        int t2_ok = (t2 == 2) || (t2 == 1 && ch2 == 0);
+        if (!t1_ok || !t2_ok) {
+            PyErr_SetString(PyExc_TypeError,
+                            "box() cannot mix integer or bytes characters "
+                            "with wide string characters");
+            return NULL;
         }
-        else if (t1 == 1 && ch1 == 0) {
-            wch1_p = NULL;
-        }
-        else {
-            goto mixed_type_error;
-        }
-
-        if (t2 == 2) {
-            wch2_p = &wch2;
-        }
-        else if (t2 == 1 && ch2 == 0) {
-            wch2_p = NULL;
-        }
-        else {
-            goto mixed_type_error;
-        }
-
+        const cchar_t *wch1_p = (t1 == 2) ? &wch1 : NULL;
+        const cchar_t *wch2_p = (t2 == 2) ? &wch2 : NULL;
         int rtn = wborder_set(self->win, wch1_p, wch1_p, wch2_p, wch2_p,
                               NULL, NULL, NULL, NULL);
         return curses_window_check_err(self, rtn, "wborder_set", "box");
-
-    mixed_type_error:
-        PyErr_SetString(PyExc_TypeError,
-                         "box() cannot mix integer or bytes characters "
-                         "with wide string characters");
-        return NULL;
     }
 #else
     if (group_right_1) {


### PR DESCRIPTION
Fixes #155499

`border()` and `box()` were raising `TypeError` when you mix a one-character `str`/`bytes` arg with a plain `0`, even though `0` is documented as meaning "use the default character" for that spot. This broke in GH-151758, which added a check to stop mixing wide-char types with int/bytes types, but didn't account for `0` being a valid sentinel value regardless of type.

For `border()`, the fix is small — just treat an int argument as fine when its value is `0`, in addition to the existing wide-char case.

`box()` needed a bit more work. It was checking `verch` and `horch` together (`t1 != 2 || t2 != 2`), so it would already reject the call before it even got to check whether the individual value was `0`. I restructured it to resolve each side's `cchar_t` pointer on its own, so `0` is accepted per-side instead of requiring both sides to match types.

Added a test (`test_border_box_zero_sentinel`) covering both functions with `0` mixed in, and also checking that a real type mismatch (like `1` mixed with a `str`) still correctly raises `TypeError`.

<!-- gh-issue-number: gh-155499 -->
* Issue: gh-155499
<!-- /gh-issue-number -->
