### PR TITLE
[3.10] gh-98820: Fix quadratic time in csv.Sniffer for quoted fields (GH-154867)

### DIFF
--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -218,7 +218,9 @@ class Sniffer:
         # The body of a quoted field ends at the first quote which is
         # not doubled, as it does for a reader.  A lazy ".*?" scans to
         # the end of the sample instead, from every start: quadratically.
-        body = r'(?:(?P=quote){2}|(?!(?P=quote)).)*+'
+        # As an unrolled loop it is unambiguous, so it does not backtrack.
+        other = r'(?:(?!(?P=quote)).)*'
+        body = r'%s(?:(?P=quote){2}%s)*' % (other, other)
         matches = []
         for restr in (r'(?P<delim>[^\w\n"\'])(?P<space> ?)(?P<quote>["\'])%s(?P=quote)(?P=delim)',   # ,"...",
                       r'(?:^|\n)(?P<quote>["\'])%s(?P=quote)(?P<delim>[^\w\n"\'])(?P<space> ?)',     #  "...",

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -215,12 +215,16 @@ class Sniffer:
         this way.
         """
 
+        # The body of a quoted field ends at the first quote which is
+        # not doubled, as it does for a reader.  A lazy ".*?" scans to
+        # the end of the sample instead, from every start: quadratically.
+        body = r'(?:(?P=quote){2}|(?!(?P=quote)).)*+'
         matches = []
-        for restr in (r'(?P<delim>[^\w\n"\'])(?P<space> ?)(?P<quote>["\']).*?(?P=quote)(?P=delim)', # ,".*?",
-                      r'(?:^|\n)(?P<quote>["\']).*?(?P=quote)(?P<delim>[^\w\n"\'])(?P<space> ?)',   #  ".*?",
-                      r'(?P<delim>[^\w\n"\'])(?P<space> ?)(?P<quote>["\']).*?(?P=quote)(?:$|\n)',   # ,".*?"
-                      r'(?:^|\n)(?P<quote>["\']).*?(?P=quote)(?:$|\n)'):                            #  ".*?" (no delim, no space)
-            regexp = re.compile(restr, re.DOTALL | re.MULTILINE)
+        for restr in (r'(?P<delim>[^\w\n"\'])(?P<space> ?)(?P<quote>["\'])%s(?P=quote)(?P=delim)',   # ,"...",
+                      r'(?:^|\n)(?P<quote>["\'])%s(?P=quote)(?P<delim>[^\w\n"\'])(?P<space> ?)',     #  "...",
+                      r'(?P<delim>[^\w\n"\'])(?P<space> ?)(?P<quote>["\'])%s(?P=quote)(?:$|\n)',  # ,"..."
+                      r'(?:^|\n)(?P<quote>["\'])%s(?P=quote)(?:$|\n)'):                           #  "..." (no delim, no space)
+            regexp = re.compile(restr % body, re.DOTALL | re.MULTILINE)
             matches = regexp.findall(data)
             if matches:
                 break

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1232,6 +1232,13 @@ Stonecutters Seafood and Chop House+ Lemont+ IL+ 12/19/02+ Week Back
         self.assertEqual(dialect.delimiter, ' ')
         self.assertIs(dialect.doublequote, False)
 
+    def test_sniff_quoted_single_column(self):
+        # gh-98820: this sample used to take minutes.
+        sniffer = csv.Sniffer()
+        sample = '"abcdefghijklmnopqrstuvwxyz"\n' * 10000
+        with self.assertRaisesRegex(csv.Error, "Could not determine delimiter"):
+            sniffer.sniff(sample, delimiters=',:|\t')
+
 
 class NUL:
     def write(s, *args):

--- a/Misc/NEWS.d/next/Library/2026-07-29-11-20-00.gh-issue-98820.Qm7Hs4.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-11-20-00.gh-issue-98820.Qm7Hs4.rst
@@ -1,0 +1,2 @@
+Fix quadratic time in :meth:`csv.Sniffer.sniff` for a sample which contains
+quoted fields, in particular for a single column of quoted fields.


### PR DESCRIPTION
Manual backport of #154867, cherry-picked from the 3.12 backport (#155166), with one 3.10-only change in the second commit.

Possessive quantifiers were added in 3.11, so `(?:(?P=quote){2}|(?!(?P=quote)).)*+` does not compile here.  The body is matched as an unrolled loop instead; since the quote character is a backreference, the "not a quote" atom needs a lookahead:

```python
other = r'(?:(?!(?P=quote)).)*'
body = r'%s(?:(?P=quote){2}%s)*' % (other, other)
```

Every position matches only one of the two alternatives, and each iteration of the outer loop consumes the two quote characters, so it does not backtrack.

Checked against the 3.11 version of the file: no difference in the sniffed dialect on 90000 samples, and the same timings — sniffing `'"abcdefghijklmnopqrstuvwxyz"\n' * n` with `delimiters=',:|\t'` takes 0.147, 0.298 and 0.602 s for n = 2500, 5000 and 10000, against 0.142, 0.286 and 0.569 s on 3.11.

<!-- gh-issue-number: gh-98820 -->
* Issue: gh-98820
<!-- /gh-issue-number -->
