### PR TITLE
gh-155445: Fix the calculation of constant HAVE_GETVALUE in `test._test_multiprocessing`. 

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -138,8 +138,11 @@ SHUTDOWN_TIMEOUT = support.SHORT_TIMEOUT
 
 WAIT_ACTIVE_CHILDREN_TIMEOUT = 5.0
 
-HAVE_GETVALUE = not getattr(_multiprocessing,
-                            'HAVE_BROKEN_SEM_GETVALUE', False)
+try:
+    HAVE_GETVALUE = not getattr(_multiprocessing,'flags') \
+                            .get('HAVE_BROKEN_SEM_GETVALUE', False)
+except:
+    HAVE_GETVALUE = True
 
 WIN32 = (sys.platform == "win32")
 
@@ -1752,9 +1755,9 @@ class _TestSemaphore(BaseTestCase):
         sem = self.BoundedSemaphore(2)
         self._test_semaphore(sem)
         # Currently fails on OS/X
-        #if HAVE_GETVALUE:
-        #    self.assertRaises(ValueError, sem.release)
-        #    self.assertReturnsIfImplemented(2, get_value, sem)
+        if HAVE_GETVALUE:
+            self.assertRaises(ValueError, sem.release)
+            self.assertReturnsIfImplemented(2, get_value, sem)
 
     def test_timeout(self):
         if self.TYPE != 'processes':

--- a/Misc/NEWS.d/next/Tests/2026-08-11-20-46-03.gh-issue-155445.iEVmED.rst
+++ b/Misc/NEWS.d/next/Tests/2026-08-11-20-46-03.gh-issue-155445.iEVmED.rst
@@ -1,0 +1,1 @@
+Fix the calculation of constant HAVE_GETVALUE in `test._test_multiprocessing.py` file.

--- a/Misc/NEWS.d/next/Tests/2026-08-11-20-46-03.gh-issue-155445.iEVmED.rst
+++ b/Misc/NEWS.d/next/Tests/2026-08-11-20-46-03.gh-issue-155445.iEVmED.rst
@@ -1,1 +1,1 @@
-Fix the calculation of constant HAVE_GETVALUE in `test._test_multiprocessing.py` file.
+Fix the calculation of constant HAVE_GETVALUE in ``test._test_multiprocessing.py`` test file.


### PR DESCRIPTION
Fix the calculation of this constant getting the value from `flags` dictionary if it is present in the attributes of `_multiprocessing` module.

```python
try:
    HAVE_GETVALUE = not getattr(_multiprocessing,'flags') \
                            .get('HAVE_BROKEN_SEM_GETVALUE', False)
except:
    HAVE_GETVALUE = True
```

Reactivate the second part of `test_bounded_semaphore` test.
https://github.com/python/cpython/blob/6f7fb6c95ba9e4d5c1b86d0d4ad83d0cd495976b/Lib/test/_test_multiprocessing.py#L1751-L1758

<!-- gh-issue-number: gh-155445 -->
* Issue: gh-155445
<!-- /gh-issue-number -->
