### PR TITLE
gh-142349: Clarify that sys.lazy_modules may contain extra items

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1485,11 +1485,24 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 .. data:: lazy_modules
 
    A :class:`set` of fully qualified module name strings that have been lazily
-   imported in the current interpreter but not yet loaded.  When a
-   lazily imported module is accessed for the first time, its name is removed
-   from this set.
+   imported in the current interpreter but not yet loaded.
+   When a lazily imported module is accessed for the first time, its name is
+   typically removed from this set.
 
-   This attribute is intended for debugging and introspection.
+   The set may contain some additional strings.
+   It is intended for debugging and introspection, and consumers are expected
+   to verify each entry's status.
+
+   .. impl-detail::
+
+      Currently, :data:`!lazy_modules` may also contain:
+
+      * names of *attributes* (non-modules), such as ``"pathlib.Path"`` after
+        running ``lazy from pathlib import Path``, and
+      * names of items than have already been accessed.
+
+      In future versions of Python, these may be removed, and/or additional
+      extras may be added.
 
    See also :func:`set_lazy_imports` and :pep:`810`.
 


### PR DESCRIPTION
As an author of a debugging/introspection tool, I need an honest description of what's in `lazy_modules` and what kinds of post-processing I'm expected to do.

Exposing internals rather than a super-polished API is fine, but needs to be described as such :)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-142349 -->
* Issue: gh-142349
<!-- /gh-issue-number -->
