### PR TITLE
[3.15] gh-154874: Fix the sign of curses.termattrs() (GH-154875)

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -1023,6 +1023,20 @@ class TestCurses(unittest.TestCase):
         self.assertIsInstance(c, bytes)
         self.assertEqual(len(c), 1)
 
+    def test_termattrs_is_not_negative(self):
+        # A_ITALIC is the topmost bit of a 32-bit attribute mask, so termattrs()
+        # only tells a signed result from an unsigned one on a terminal that
+        # advertises it.  3.15 lacks the newterm()/pty harness used on main, so
+        # exercise the current screen: skip when the top bit is not advertised.
+        attrs = curses.termattrs()
+        italic = getattr(curses, 'A_ITALIC', 0)
+        if not italic or not attrs & italic:
+            self.skipTest('the terminal advertises no attribute in the top bit')
+        self.assertGreaterEqual(attrs, 0)
+        # termattrs() exists to be passed back to the attribute functions,
+        # which reject a negative mask.
+        self.stdscr.attrset(attrs)
+
     def test_output_options(self):
         stdscr = self.stdscr
 

--- a/Misc/NEWS.d/next/Library/2026-07-29-11-58-17.gh-issue-154874.NAPdBp.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-29-11-58-17.gh-issue-154874.NAPdBp.rst
@@ -1,0 +1,3 @@
+Fix :func:`curses.termattrs` returning a negative value on a terminal that
+supports :const:`curses.A_ITALIC`, which left its result unusable as an
+attribute mask.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -4959,7 +4959,11 @@ Return a logical OR of all video attributes supported by the terminal.
 static PyObject *
 _curses_termattrs_impl(PyObject *module)
 /*[clinic end generated code: output=b06f437fce1b6fc4 input=0559882a04f84d1d]*/
-NoArgReturnIntFunctionBody(termattrs)
+{
+    PyCursesStatefulInitialised(module);
+
+    return PyLong_FromUnsignedLong((unsigned long)(chtype)termattrs());
+}
 
 /*[clinic input]
 @permit_long_summary


### PR DESCRIPTION
## Summary

Backport of GH-154875 to 3.15.

`curses.termattrs()` returns a `chtype` mask, but it was routed through an `int` to check for `ERR`. On a terminal that advertises `A_ITALIC` (topmost bit of a 32-bit mask), the result came back negative and the attribute functions rejected it:

```
>>> curses.termattrs()
-2130771968
>>> curses.newwin(1, 1).attrset(curses.termattrs())
OverflowError: can't convert negative value to unsigned int
```

This returns the mask unsigned via `PyLong_FromUnsignedLong`, matching `getattrs()`, `slk_attr()`, and `term_attrs()`.

The main-branch regression test uses `newterm()` over a pseudo-terminal (`NewtermTestBase`), which is not present on 3.15. The 3.15 test is adapted onto `TestCurses` and skips when the current terminal does not advertise a top-bit attribute.

(cherry picked from commit 0b083c43a455fbdf5378495751e142ea83e294b0)

Fixes #154874

## Test plan

- [ ] CI: `test_curses` (requires curses resource)
- Local: full CPython rebuild not run in this environment; change matches main fix in `Modules/_cursesmodule.c` and includes NEWS + adapted unit test.

### AI/LLM disclosure

AI coding tools assisted with the change and this description.

<!-- gh-issue-number: gh-154874 -->
* Issue: gh-154874
<!-- /gh-issue-number -->
