### PR TITLE
gh-154753: Update references to moved files in the docs

### DIFF
--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -1106,7 +1106,7 @@ Finally it should be mentioned that Capsules offer additional functionality,
 which is especially useful for memory allocation and deallocation of the pointer
 stored in a Capsule. The details are described in the Python/C API Reference
 Manual in the section :ref:`capsules` and in the implementation of Capsules (files
-:file:`Include/pycapsule.h` and :file:`Objects/pycapsule.c` in the Python source
+:file:`Include/pycapsule.h` and :file:`Objects/capsule.c` in the Python source
 code distribution).
 
 .. rubric:: Footnotes

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1941,7 +1941,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
       The interpreter is about to execute a new line of code or re-execute the
       condition of a loop.  The local trace function is called; *arg* is
       ``None``; the return value specifies the new local trace function.  See
-      :file:`InternalDocs/code_objects.md` for a detailed explanation of how this
+      :source:`InternalDocs/code_objects.md` for a detailed explanation of how this
       works.
       Per-line events may be disabled for a frame by setting
       :attr:`~frame.f_trace_lines` to :const:`False` on that

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1941,7 +1941,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
       The interpreter is about to execute a new line of code or re-execute the
       condition of a loop.  The local trace function is called; *arg* is
       ``None``; the return value specifies the new local trace function.  See
-      :file:`Objects/lnotab_notes.txt` for a detailed explanation of how this
+      :file:`InternalDocs/code_objects.md` for a detailed explanation of how this
       works.
       Per-line events may be disabled for a frame by setting
       :attr:`~frame.f_trace_lines` to :const:`False` on that

--- a/Doc/using/android.rst
+++ b/Doc/using/android.rst
@@ -37,7 +37,7 @@ much easier experience:
 * `Termux <https://termux.dev/en/>`__
 
 If you're sure you want to do all of this manually, read on. You can use the
-:source:`testbed app <Android/testbed>` as a guide; each step below contains a
+:source:`testbed app <Platforms/Android/testbed>` as a guide; each step below contains a
 link to the relevant file.
 
 * First, acquire a build of Python for Android:
@@ -47,10 +47,10 @@ link to the relevant file.
     mentioned below is at the top level of the package.
 
   * Or if you want to build it yourself, follow the instructions in
-    :source:`Android/README.md`. The ``prefix`` directory will be created under
+    :source:`Platforms/Android/README.md`. The ``prefix`` directory will be created under
     :samp:`cross-build/{HOST}`.
 
-* Add code to your :source:`build.gradle <Android/testbed/app/build.gradle.kts>`
+* Add code to your :source:`build.gradle <Platforms/Android/testbed/app/build.gradle.kts>`
   file to copy the following items into your project. All except your own Python
   code can be copied from ``prefix/lib``:
 
@@ -65,10 +65,10 @@ link to the relevant file.
     * ``python*.*/site-packages`` (your own Python code)
 
 * Add code to your app to :source:`extract the assets to the filesystem
-  <Android/testbed/app/src/main/java/org/python/testbed/MainActivity.kt>`.
+  <Platforms/Android/testbed/app/src/main/java/org/python/testbed/MainActivity.kt>`.
 
 * Add code to your app to :source:`start Python in embedded mode
-  <Android/testbed/app/src/main/c/main_activity.c>`. This will need to be C code
+  <Platforms/Android/testbed/app/src/main/c/main_activity.c>`. This will need to be C code
   called via JNI.
 
 Building a Python package for Android

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -1275,7 +1275,7 @@ See :source:`Mac/README.rst`.
 iOS Options
 -----------
 
-See :source:`iOS/README.rst`.
+See :source:`Platforms/Apple/iOS/README.md`.
 
 .. option:: --enable-framework=INSTALLDIR
 

--- a/Doc/using/ios.rst
+++ b/Doc/using/ios.rst
@@ -272,7 +272,7 @@ be used as a testbed project for running your Python library's test suite on iOS
 
 After building or obtaining an iOS XCFramework (see :source:`Platforms/Apple/iOS/README.md`
 for details), create a clone of the Python iOS testbed project. If you used the
-``Apple`` build script to build the XCframework, you can run:
+``Platforms/Apple`` build script to build the XCframework, you can run:
 
 .. code-block:: bash
 

--- a/Doc/using/ios.rst
+++ b/Doc/using/ios.rst
@@ -170,7 +170,7 @@ helpful.
 To add Python to an iOS Xcode project:
 
 1. Build or obtain a Python ``XCFramework``. See the instructions in
-   :source:`Apple/iOS/README.md` (in the CPython source distribution) for details on
+   :source:`Platforms/Apple/iOS/README.md` (in the CPython source distribution) for details on
    how to build a Python ``XCFramework``. At a minimum, you will need a build
    that supports ``arm64-apple-ios``, plus one of either
    ``arm64-apple-ios-simulator`` or ``x86_64-apple-ios-simulator``.
@@ -266,11 +266,11 @@ modules in your app, some additional steps will be required:
 Testing a Python package
 ------------------------
 
-The CPython source tree contains :source:`a testbed project <Apple/iOS/testbed>` that
+The CPython source tree contains :source:`a testbed project <Platforms/Apple/testbed>` that
 is used to run the CPython test suite on the iOS simulator. This testbed can also
 be used as a testbed project for running your Python library's test suite on iOS.
 
-After building or obtaining an iOS XCFramework (see :source:`Apple/iOS/README.md`
+After building or obtaining an iOS XCFramework (see :source:`Platforms/Apple/iOS/README.md`
 for details), create a clone of the Python iOS testbed project. If you used the
 ``Apple`` build script to build the XCframework, you can run:
 
@@ -282,7 +282,7 @@ Or, if you've sourced your own XCframework, by running:
 
 .. code-block:: bash
 
-    $ python Apple/testbed clone --platform iOS --framework <path/to/Python.xcframework> --app <path/to/module1> --app <path/to/module2> app-testbed
+    $ python Platforms/Apple/testbed clone --platform iOS --framework <path/to/Python.xcframework> --app <path/to/module1> --app <path/to/module2> app-testbed
 
 Any folders specified with the ``--app`` flag will be copied into the cloned
 testbed project. The resulting testbed will be created in the ``app-testbed``

--- a/InternalDocs/code_objects.md
+++ b/InternalDocs/code_objects.md
@@ -48,7 +48,7 @@ Note that traceback objects don't store all this information -- they store the s
 number, for backward compatibility, and the "last instruction" value.
 The rest can be computed from the last instruction (`tb_lasti`) with the help of the
 locations table. For Python code, there is a convenience method
-(`codeobject.co_positions`)[https://docs.python.org/dev/reference/datamodel.html#codeobject.co_positions]
+[`codeobject.co_positions`](https://docs.python.org/dev/reference/datamodel.html#codeobject.co_positions)
 which returns an iterator of `({line}, {endline}, {column}, {endcolumn})` tuples,
 one per instruction.
 There is also `co_lines()` which returns an iterator of `({start}, {end}, {line})` tuples,

--- a/InternalDocs/jit.md
+++ b/InternalDocs/jit.md
@@ -140,7 +140,7 @@ template file [`Tools/jit/template.c`](../Tools/jit/template.c).
 Each of the `.c` files is compiled by LLVM, to produce an object file
 that contains a function that executes the opcode. These compiled
 functions are used to generate the file
-[`jit_stencils.h`](../jit_stencils.h), which contains the functions
+`jit_stencils.h`, which contains the functions
 that the JIT can use to emit code for each of the bytecodes.
 
 For Python maintainers this means that changes to the bytecodes and


### PR DESCRIPTION
### Summary

Update documentation references to reflect files that have moved to their current locations in the CPython source tree.

The changes include:

* Update Android testbed and README references to `Platforms/Android/`.
* Update iOS documentation references to `Platforms/Apple/`.
* Update the iOS configuration documentation to reference `Platforms/Apple/iOS/README.md`.
* Update the Capsules implementation reference from `Objects/pycapsule.c` to `Objects/capsule.c`.
* Update the code object documentation reference from the removed `Objects/lnotab_notes.txt` to `InternalDocs/code_objects.md`.
* Fix the malformed Markdown link for `codeobject.co_positions`.
* Remove the broken link to the generated `jit_stencils.h` file.

### Tests

* `git diff --cached --check` — passed
* Targeted pre-commit checks — passed
* `make -C Doc html SPHINXOPTS="-j1"` — completed with one pre-existing duplicate-label warning in `Doc/using/windows.rst` and `Doc/reference/datamodel.rst`.


Closes issue gh-154753