### PR TITLE
gh-155485: Skip test_subparser_inherits_reparse_deferral with Expat < 2.6.0

### DIFF
--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -1046,10 +1046,6 @@ class ParentParserLifetimeTest(unittest.TestCase):
         del subparser
 
     # gh-155485: GetReparseDeferralEnabled always returns False with Expat <2.6.0.
-    # Hence, we skip this test when pyxepat was compiled with Expat <2.6.0.
-    # We check the default value on a new parser instance to detect
-    # the compile-time expat version, rather than checking expat.version_info
-    # which stores the runtime expat version (to avoid problems like gh-144739).
     @unittest.skipIf(not expat.ParserCreate().GetReparseDeferralEnabled(),
                      "requires Python compiled with Expat >= 2.6.0")
     def test_subparser_inherits_reparse_deferral(self):

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -1045,6 +1045,13 @@ class ParentParserLifetimeTest(unittest.TestCase):
         del parser
         del subparser
 
+    # gh-155485: GetReparseDeferralEnabled always returns False with Expat <2.6.0.
+    # Hence, we skip this test when pyxepat was compiled with Expat <2.6.0.
+    # We check the default value on a new parser instance to detect
+    # the compile-time expat version, rather than checking expat.version_info
+    # which stores the runtime expat version (to avoid problems like gh-144739).
+    @unittest.skipIf(not expat.ParserCreate().GetReparseDeferralEnabled(),
+                     "requires Python compiled with Expat >= 2.6.0")
     def test_subparser_inherits_reparse_deferral(self):
         for enabled in (True, False):
             parser = expat.ParserCreate()

--- a/Misc/NEWS.d/next/Tests/2026-08-11-13-03-14.gh-issue-155485.UliOyg.rst
+++ b/Misc/NEWS.d/next/Tests/2026-08-11-13-03-14.gh-issue-155485.UliOyg.rst
@@ -1,0 +1,4 @@
+Skip ``test_subparser_inherits_reparse_deferral`` in ``test_pyexpat`` when
+Python was compiled against Expat < 2.6.0.
+:meth:`~xml.parsers.expat.xmlparser.GetReparseDeferralEnabled`
+always returns false with this Expat version and hence the test does not work.

--- a/Misc/NEWS.d/next/Tests/2026-08-11-13-03-14.gh-issue-155485.UliOyg.rst
+++ b/Misc/NEWS.d/next/Tests/2026-08-11-13-03-14.gh-issue-155485.UliOyg.rst
@@ -1,4 +1,0 @@
-Skip ``test_subparser_inherits_reparse_deferral`` in ``test_pyexpat`` when
-Python was compiled against Expat < 2.6.0.
-:meth:`~xml.parsers.expat.xmlparser.GetReparseDeferralEnabled`
-always returns false with this Expat version and hence the test does not work.


### PR DESCRIPTION
The test was added in 7d760134cc20f444412c54fc8395ca6f2421ad73, and fails when CPython is compiled against expat < 2.6.0:

    test_subparser_inherits_reparse_deferral (test.test_pyexpat.ParentParserLifetimeTest.test_subparser_inherits_reparse_deferral) ... FAIL
    ======================================================================
    FAIL: test_subparser_inherits_reparse_deferral (test.test_pyexpat.ParentParserLifetimeTest.test_subparser_inherits_reparse_deferral)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/builddir/build/BUILD/Python-3.13.15/Lib/test/test_pyexpat.py", line 960, in test_subparser_inherits_reparse_deferral
        self.assertEqual(subparser.GetReparseDeferralEnabled(), enabled)
        ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    AssertionError: False != True
    ----------------------------------------------------------------------

With XML_COMBINED_VERSION < 20600,
SetReparseDeferralEnabled is a complete no-op[1],
both the expat call and the cache update are inside #if XML_COMBINED_VERSION >= 20600. The cache stays at its initial value of false[2],
which the subparser copies and GetReparseDeferralEnabled returns. The test's enabled=True iteration then asserts False == True.

This is consistent with the documented behavior[3]: GetReparseDeferralEnabled says "always returns false with Expat <2.6.0".

Hence, the test makes no sense on Expat < 2.6.0.

Similarly to gh-144739,
the test's skip decorator needs to check for the compile-time Expat version, as the behavior is determined by #ifs, not by runtime capabilities. Python compiled with Expat 2.5.x still fails the test even if Expat was updated to 2.6.0+ on runtime.

We originally saw the test failure in EPEL 9
(has expat 2.5.0 with some security backports),
when we updated to Python 3.13.15.
I used LLM to analyze the cause of the test failure.

[1] https://github.com/python/cpython/blob/v3.15.0rc1/Modules/pyexpat.c#L847-L850
[2] https://github.com/python/cpython/blob/v3.15.0rc1/Modules/pyexpat.c#L1529
[3] https://github.com/python/cpython/blob/v3.15.0rc1/Modules/pyexpat.c#L858

Assisted-By: Claude Opus 4.6

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-155485 -->
* Issue: gh-155485
<!-- /gh-issue-number -->
