### PR TITLE
gh-155561: Build most _testlimitedcapi files with Py_TARGET_ABI3T

### DIFF
--- a/Modules/_testlimitedcapi.c
+++ b/Modules/_testlimitedcapi.c
@@ -10,8 +10,8 @@
 #ifdef Py_GIL_DISABLED
    // FIXME: use the Py_TARGET_ABI3T
 #else
-   // Need limited C API version 3.13 for Py_MOD_GIL_NOT_USED
-#  define Py_LIMITED_API 0x030d0000
+   // Use the oldest limited C API version
+#  define Py_LIMITED_API 0x03020000
 #endif
 
 #include "_testlimitedcapi/parts.h"

--- a/Modules/_testlimitedcapi.c
+++ b/Modules/_testlimitedcapi.c
@@ -8,7 +8,7 @@
 #include "pyconfig.h"   // Py_GIL_DISABLED
 
 #ifdef Py_GIL_DISABLED
-   // FIXME: use the Py_TARGET_ABI3T
+   // Cannot test the limited C API
 #else
    // Use the oldest limited C API version
 #  define Py_LIMITED_API 0x03020000

--- a/Modules/_testlimitedcapi.c
+++ b/Modules/_testlimitedcapi.c
@@ -5,6 +5,15 @@
  * standard Python regression test, via Lib/test/test_capi.py.
  */
 
+#include "pyconfig.h"   // Py_GIL_DISABLED
+
+#ifdef Py_GIL_DISABLED
+   // FIXME: use the Py_TARGET_ABI3T
+#else
+   // Need limited C API version 3.13 for Py_MOD_GIL_NOT_USED
+#  define Py_LIMITED_API 0x030d0000
+#endif
+
 #include "_testlimitedcapi/parts.h"
 
 static PyMethodDef TestMethods[] = {

--- a/Modules/_testlimitedcapi/capsule.c
+++ b/Modules/_testlimitedcapi/capsule.c
@@ -1,5 +1,8 @@
 #include "parts.h"
 
+#include <stdlib.h>               // free()
+
+
 static void
 capsule_destructor(PyObject *op)
 {

--- a/Modules/_testlimitedcapi/codec.c
+++ b/Modules/_testlimitedcapi/codec.c
@@ -1,7 +1,8 @@
 #include "pyconfig.h"   // Py_GIL_DISABLED
-
-// Need limited C API version 3.5 for PyCodec_NameReplaceErrors()
-#if !defined(Py_GIL_DISABLED) && !defined(Py_LIMITED_API)
+#ifdef Py_GIL_DISABLED
+#  define Py_TARGET_ABI3T 0x030f0000
+#else
+   // Need limited C API version 3.5 for PyCodec_NameReplaceErrors()
 #  define Py_LIMITED_API 0x03050000
 #endif
 

--- a/Modules/_testlimitedcapi/file.c
+++ b/Modules/_testlimitedcapi/file.c
@@ -1,5 +1,7 @@
 #include "pyconfig.h"   // Py_GIL_DISABLED
-#ifndef Py_GIL_DISABLED
+#ifdef Py_GIL_DISABLED
+#  define Py_TARGET_ABI3T 0x030f0000
+#else
    // Need limited C API 3.13 for PyLong_AsInt()
 #  define Py_LIMITED_API 0x030d0000
 #endif

--- a/Modules/_testlimitedcapi/heaptype_relative.c
+++ b/Modules/_testlimitedcapi/heaptype_relative.c
@@ -1,6 +1,8 @@
-// Need limited C API version 3.15 for _DuringGC functions
 #include "pyconfig.h"   // Py_GIL_DISABLED
-#if !defined(Py_GIL_DISABLED) && !defined(Py_LIMITED_API)
+#ifdef Py_GIL_DISABLED
+   // FIXME: use the Py_TARGET_ABI3T
+#else
+   // Need limited C API version 3.15 for _DuringGC functions
 #  define Py_LIMITED_API 0x030f0000
 #endif
 

--- a/Modules/_testlimitedcapi/heaptype_relative.c
+++ b/Modules/_testlimitedcapi/heaptype_relative.c
@@ -1,6 +1,6 @@
 #include "pyconfig.h"   // Py_GIL_DISABLED
 #ifdef Py_GIL_DISABLED
-   // FIXME: use the Py_TARGET_ABI3T
+   // Cannot test the limited C API
 #else
    // Need limited C API version 3.15 for _DuringGC functions
 #  define Py_LIMITED_API 0x030f0000

--- a/Modules/_testlimitedcapi/import.c
+++ b/Modules/_testlimitedcapi/import.c
@@ -1,6 +1,8 @@
-// Need limited C API version 3.13 for PyImport_AddModuleRef()
 #include "pyconfig.h"   // Py_GIL_DISABLED
-#if !defined(Py_GIL_DISABLED) && !defined(Py_LIMITED_API)
+#ifdef Py_GIL_DISABLED
+#  define Py_TARGET_ABI3T 0x030f0000
+#else
+   // Need limited C API version 3.13 for PyImport_AddModuleRef()
 #  define Py_LIMITED_API 0x030d0000
 #endif
 

--- a/Modules/_testlimitedcapi/list.c
+++ b/Modules/_testlimitedcapi/list.c
@@ -1,6 +1,8 @@
-// Need limited C API version 3.13 for PyList_GetItemRef()
 #include "pyconfig.h"   // Py_GIL_DISABLED
-#if !defined(Py_GIL_DISABLED) && !defined(Py_LIMITED_API)
+#ifdef Py_GIL_DISABLED
+#  define Py_TARGET_ABI3T 0x030f0000
+#else
+   // Need limited C API version 3.13 for PyList_GetItemRef()
 #  define Py_LIMITED_API 0x030d0000
 #endif
 

--- a/Modules/_testlimitedcapi/long.c
+++ b/Modules/_testlimitedcapi/long.c
@@ -1,5 +1,7 @@
 #include "pyconfig.h"   // Py_GIL_DISABLED
-#ifndef Py_GIL_DISABLED
+#ifdef Py_GIL_DISABLED
+#  define Py_TARGET_ABI3T 0x030f0000
+#else
    // Need limited C API 3.14 to test PyLong_AsInt64()
 #  define Py_LIMITED_API 0x030e0000
 #endif

--- a/Modules/_testlimitedcapi/object.c
+++ b/Modules/_testlimitedcapi/object.c
@@ -1,6 +1,8 @@
-// Need limited C API version 3.13 for Py_GetConstant()
 #include "pyconfig.h"   // Py_GIL_DISABLED
-#if !defined(Py_GIL_DISABLED) && !defined(Py_LIMITED_API)
+#ifdef Py_GIL_DISABLED
+#  define Py_TARGET_ABI3T 0x030f0000
+#else
+   // Need limited C API version 3.13 for Py_GetConstant()
 #  define Py_LIMITED_API 0x030d0000
 #endif
 

--- a/Modules/_testlimitedcapi/parts.h
+++ b/Modules/_testlimitedcapi/parts.h
@@ -8,7 +8,7 @@
 
 // Use the limited C API
 #ifdef Py_GIL_DISABLED
-   // FIXME: use the Py_TARGET_ABI3T
+   // Cannot test the limited C API
 #elif !defined(Py_LIMITED_API)
    // Need limited C API version 3.5 for PyModule_AddFunctions()
 #  define Py_LIMITED_API 0x03050000

--- a/Modules/_testlimitedcapi/parts.h
+++ b/Modules/_testlimitedcapi/parts.h
@@ -7,8 +7,10 @@
 #include "pyconfig.h"   // Py_GIL_DISABLED
 
 // Use the limited C API
-#if !defined(Py_GIL_DISABLED) && !defined(Py_LIMITED_API)
-   // need limited C API version 3.5 for PyModule_AddFunctions()
+#ifdef Py_GIL_DISABLED
+   // FIXME: use the Py_TARGET_ABI3T
+#elif !defined(Py_LIMITED_API)
+   // Need limited C API version 3.5 for PyModule_AddFunctions()
 #  define Py_LIMITED_API 0x03050000
 #endif
 

--- a/Modules/_testlimitedcapi/slots.c
+++ b/Modules/_testlimitedcapi/slots.c
@@ -1,4 +1,10 @@
-#define Py_LIMITED_API 0x030f0000
+#include "pyconfig.h"   // Py_GIL_DISABLED
+#ifdef Py_GIL_DISABLED
+#  define Py_TARGET_ABI3T 0x030f0000
+#else
+   // Need limited C API version 3.15 for PyType_FromSlots()
+#  define Py_LIMITED_API 0x030f0000
+#endif
 
 #include "parts.h"
 

--- a/Modules/_testlimitedcapi/slots.c
+++ b/Modules/_testlimitedcapi/slots.c
@@ -1,10 +1,5 @@
-#include "pyconfig.h"   // Py_GIL_DISABLED
-#ifdef Py_GIL_DISABLED
-#  define Py_TARGET_ABI3T 0x030f0000
-#else
-   // Need limited C API version 3.15 for PyType_FromSlots()
-#  define Py_LIMITED_API 0x030f0000
-#endif
+// Need limited C API version 3.15 for PyType_FromSlots()
+#define Py_LIMITED_API 0x030f0000
 
 #include "parts.h"
 

--- a/Modules/_testlimitedcapi/sys.c
+++ b/Modules/_testlimitedcapi/sys.c
@@ -1,6 +1,8 @@
 #include "pyconfig.h"   // Py_GIL_DISABLED
-// Need limited C API version 3.15 for PySys_GetAttr() etc
-#if !defined(Py_GIL_DISABLED) && !defined(Py_LIMITED_API)
+#ifdef Py_GIL_DISABLED
+#  define Py_TARGET_ABI3T 0x030f0000
+#else
+   // Need limited C API version 3.15 for PySys_GetAttr() etc
 #  define Py_LIMITED_API 0x030f0000
 #endif
 #include "parts.h"

--- a/Modules/_testlimitedcapi/sys.c
+++ b/Modules/_testlimitedcapi/sys.c
@@ -1,10 +1,6 @@
-#include "pyconfig.h"   // Py_GIL_DISABLED
-#ifdef Py_GIL_DISABLED
-#  define Py_TARGET_ABI3T 0x030f0000
-#else
-   // Need limited C API version 3.15 for PySys_GetAttr() etc
-#  define Py_LIMITED_API 0x030f0000
-#endif
+// Need limited C API version 3.15 for PySys_GetAttr() etc
+#define Py_LIMITED_API 0x030f0000
+
 #include "parts.h"
 #include "util.h"
 

--- a/Modules/_testlimitedcapi/unicode.c
+++ b/Modules/_testlimitedcapi/unicode.c
@@ -1,5 +1,7 @@
 #include "pyconfig.h"   // Py_GIL_DISABLED
-#ifndef Py_GIL_DISABLED
+#ifdef Py_GIL_DISABLED
+#  define Py_TARGET_ABI3T 0x030f0000
+#else
    // Need limited C API 3.14 to test PyUnicode_Equal()
 #  define Py_LIMITED_API 0x030e0000
 #endif

--- a/Modules/_testlimitedcapi/vectorcall_limited.c
+++ b/Modules/_testlimitedcapi/vectorcall_limited.c
@@ -1,8 +1,10 @@
 /* Test Vectorcall in the limited API */
 
-// Need limited C API version 3.12 for PyObject_Vectorcall()
 #include "pyconfig.h"   // Py_GIL_DISABLED
-#if !defined(Py_GIL_DISABLED) && !defined(Py_LIMITED_API)
+#ifdef Py_GIL_DISABLED
+   // FIXME: use the Py_TARGET_ABI3T
+#else
+   // Need limited C API version 3.12 for PyObject_Vectorcall()
 #  define Py_LIMITED_API 0x030c0000
 #endif
 

--- a/Modules/_testlimitedcapi/vectorcall_limited.c
+++ b/Modules/_testlimitedcapi/vectorcall_limited.c
@@ -2,7 +2,7 @@
 
 #include "pyconfig.h"   // Py_GIL_DISABLED
 #ifdef Py_GIL_DISABLED
-   // FIXME: use the Py_TARGET_ABI3T
+   // Cannot test the limited C API
 #else
    // Need limited C API version 3.12 for PyObject_Vectorcall()
 #  define Py_LIMITED_API 0x030c0000

--- a/Modules/_testlimitedcapi/version.c
+++ b/Modules/_testlimitedcapi/version.c
@@ -1,8 +1,11 @@
 /* Test version macros in the limited API */
 
 #include "pyconfig.h"  // Py_GIL_DISABLED
-#ifndef Py_GIL_DISABLED
-#  define Py_LIMITED_API 0x030e0000  // Added in 3.14
+#ifdef Py_GIL_DISABLED
+#  define Py_TARGET_ABI3T 0x030f0000
+#else
+   // API added in 3.14
+#  define Py_LIMITED_API 0x030e0000
 #endif
 
 #include "parts.h"

--- a/Modules/_testlimitedcapi/version.c
+++ b/Modules/_testlimitedcapi/version.c
@@ -4,7 +4,7 @@
 #ifdef Py_GIL_DISABLED
 #  define Py_TARGET_ABI3T 0x030f0000
 #else
-   // API added in 3.14
+   // Need limited C API version 3.14 for Py_PACK_VERSION()
 #  define Py_LIMITED_API 0x030e0000
 #endif
 

--- a/Modules/_testlimitedcapi/weakref.c
+++ b/Modules/_testlimitedcapi/weakref.c
@@ -1,5 +1,7 @@
 #include "pyconfig.h"   // Py_GIL_DISABLED
-#ifndef Py_GIL_DISABLED
+#ifdef Py_GIL_DISABLED
+#  define Py_TARGET_ABI3T 0x030f0000
+#else
    // Need limited C API 3.5 for PyModule_AddFunctions()
 #  define Py_LIMITED_API 0x03050000
 #endif


### PR DESCRIPTION
The following files are not build with Py_TARGET_ABI3T:

* Modules/_testlimitedcapi.c
* Modules/_testlimitedcapi/heaptype_relative.c
* Modules/_testlimitedcapi/vectorcall_limited.c

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-155561 -->
* Issue: gh-155561
<!-- /gh-issue-number -->
