### PR TITLE
gh-110167: Document the increase of `test.support.LOOPBACK_TIMEOUT` to 10 seconds

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -285,7 +285,7 @@ The :mod:`!test.support` module defines the following constants:
    :meth:`~socket.socket.recv` and :meth:`~socket.socket.send` methods of
    :class:`socket.socket`.
 
-   Its default value is 5 seconds.
+   Its default value is 10 seconds.
 
    See also :data:`INTERNET_TIMEOUT`.
 


### PR DESCRIPTION
This has been changed in code long ago, make the documentation reflect the reality.


<!-- gh-issue-number: gh-110167 -->
* Issue: gh-110167
<!-- /gh-issue-number -->
