### PR TITLE
gh-155092: Improve `__repr__` string of all synchronize tools in `multiprocessing` module.

### DIFF
--- a/Lib/multiprocessing/synchronize.py
+++ b/Lib/multiprocessing/synchronize.py
@@ -125,6 +125,23 @@ class SemLock(object):
         return '%s-%s' % (process.current_process()._config['semprefix'],
                           next(SemLock._rand))
 
+    def _get_procname_and_count(self):
+        try:
+            if self._semlock._is_mine():
+                name = process.current_process().name
+                if threading.current_thread().name != 'MainThread':
+                    name += '|' + threading.current_thread().name
+                count = self._semlock._count()
+            elif not self._semlock._is_zero():
+                name, count = 'None', 0
+            elif self._semlock._count() > 0:
+                name, count = 'SomeOtherThread', 'nonzero'
+            else:
+                name, count = 'SomeOtherProcess', 'nonzero'
+        except Exception:
+            name, count = 'unknown', 'unknown'
+        return name, count
+
 #
 # Semaphore
 #
@@ -143,11 +160,12 @@ class Semaphore(SemLock):
         return self._semlock._get_value()
 
     def __repr__(self):
+        res = super().__repr__()
         try:
             value = self.get_value()
         except Exception:
             value = 'unknown'
-        return '<%s(value=%s)>' % (self.__class__.__name__, value)
+        return f'<{res[1:-1]} (value={value})>'
 
 #
 # Bounded semaphore
@@ -159,12 +177,13 @@ class BoundedSemaphore(Semaphore):
         SemLock.__init__(self, SEMAPHORE, value, value, ctx=ctx)
 
     def __repr__(self):
+        res = object.__repr__(self)
         try:
             value = self.get_value()
         except Exception:
             value = 'unknown'
-        return '<%s(value=%s, maxvalue=%s)>' % \
-               (self.__class__.__name__, value, self._semlock.maxvalue)
+        return f'<{res[1:-1]} (value={value}, ' \
+               f'maxvalue={self._semlock.maxvalue})>'
 
 #
 # Non-recursive lock
@@ -176,20 +195,9 @@ class Lock(SemLock):
         SemLock.__init__(self, SEMAPHORE, 1, 1, ctx=ctx)
 
     def __repr__(self):
-        try:
-            if self._semlock._is_mine():
-                name = process.current_process().name
-                if threading.current_thread().name != 'MainThread':
-                    name += '|' + threading.current_thread().name
-            elif not self._semlock._is_zero():
-                name = 'None'
-            elif self._semlock._count() > 0:
-                name = 'SomeOtherThread'
-            else:
-                name = 'SomeOtherProcess'
-        except Exception:
-            name = 'unknown'
-        return '<%s(owner=%s)>' % (self.__class__.__name__, name)
+        res = super().__repr__()
+        name, _ = self._get_procname_and_count()
+        return f'<{res[1:-1]} (owner={name})>'
 
 #
 # Recursive lock
@@ -201,21 +209,9 @@ class RLock(SemLock):
         SemLock.__init__(self, RECURSIVE_MUTEX, 1, 1, ctx=ctx)
 
     def __repr__(self):
-        try:
-            if self._semlock._is_mine():
-                name = process.current_process().name
-                if threading.current_thread().name != 'MainThread':
-                    name += '|' + threading.current_thread().name
-                count = self._semlock._count()
-            elif not self._semlock._is_zero():
-                name, count = 'None', 0
-            elif self._semlock._count() > 0:
-                name, count = 'SomeOtherThread', 'nonzero'
-            else:
-                name, count = 'SomeOtherProcess', 'nonzero'
-        except Exception:
-            name, count = 'unknown', 'unknown'
-        return '<%s(%s, %s)>' % (self.__class__.__name__, name, count)
+        res = super().__repr__()
+        name, count = self._get_procname_and_count()
+        return f'<{res[1:-1]} (owner={name}, count={count})>'
 
 #
 # Condition variable
@@ -251,12 +247,15 @@ class Condition(object):
         self.release = self._lock.release
 
     def __repr__(self):
+        res = super().__repr__()
         try:
             num_waiters = (self._sleeping_count.get_value() -
                            self._woken_count.get_value())
         except Exception:
             num_waiters = 'unknown'
-        return '<%s(%s, %s)>' % (self.__class__.__name__, self._lock, num_waiters)
+
+        lock_repr, _ = self._lock._get_procname_and_count()
+        return f'<{res[1:-1]} (lock={lock_repr}, waiters={num_waiters})>'
 
     def wait(self, timeout=None):
         assert self._lock._semlock._is_mine(), \
@@ -368,8 +367,10 @@ class Event(object):
             return False
 
     def __repr__(self):
+        res = super().__repr__()
         set_status = 'set' if self.is_set() else 'unset'
-        return f"<{type(self).__qualname__} at {id(self):#x} {set_status}>"
+        return f'<{res[1:-1]} ({set_status})>'
+
 #
 # Barrier
 #
@@ -409,3 +410,9 @@ class Barrier(threading.Barrier):
     @_count.setter
     def _count(self, value):
         self._array[1] = value
+
+    def __repr__(self):
+        res = object.__repr__(self)
+        if self.broken:
+            return f'<{res[1:-1]} (broken)>'
+        return f'<{res[1:-1]} (waiters={self.n_waiting}/{self.parties})>'

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -138,8 +138,11 @@ SHUTDOWN_TIMEOUT = support.SHORT_TIMEOUT
 
 WAIT_ACTIVE_CHILDREN_TIMEOUT = 5.0
 
-HAVE_GETVALUE = not getattr(_multiprocessing,
-                            'HAVE_BROKEN_SEM_GETVALUE', False)
+try:
+    HAVE_GETVALUE = not getattr(_multiprocessing,'flags') \
+                            .get('HAVE_BROKEN_SEM_GETVALUE', False)
+except:
+    HAVE_GETVALUE = True
 
 WIN32 = (sys.platform == "win32")
 
@@ -1545,7 +1548,7 @@ class _TestLock(BaseTestCase):
     def _acquire_event(lock, event):
         lock.acquire()
         event.set()
-        time.sleep(1.0)
+        time.sleep(0.1)
 
     @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
     def test_repr_lock(self):
@@ -1553,10 +1556,12 @@ class _TestLock(BaseTestCase):
             self.skipTest('test not appropriate for {}'.format(self.TYPE))
 
         lock = self.Lock()
-        self.assertEqual(f'<Lock(owner=None)>', repr(lock))
+        self.assertRegex(repr(lock), r"<*.Lock object at .* \(owner=None\)>")
 
         lock.acquire()
-        self.assertEqual(f'<Lock(owner=MainProcess)>', repr(lock))
+        self.assertRegex(repr(lock),
+                         r"<*.Lock object at .* "
+                         r"\(owner=MainProcess\)>")
         lock.release()
 
         tname = 'T1'
@@ -1566,16 +1571,21 @@ class _TestLock(BaseTestCase):
                              name=tname)
         t.start()
         time.sleep(0.1)
-        self.assertEqual(f'<Lock(owner=MainProcess|{tname})>', l[0])
+        self.assertRegex(repr(l[0]), "<*.Lock object at .* "
+                                    f"\\(owner=MainProcess\\|{tname}\\)>")
         lock.release()
+        t.join()
 
         t = threading.Thread(target=self._acquire,
                              args=(lock,),
                              name=tname)
         t.start()
         time.sleep(0.1)
-        self.assertEqual('<Lock(owner=SomeOtherThread)>', repr(lock))
+        self.assertRegex(repr(lock),
+                         r"<*.Lock object at .* "
+                         r"\(owner=SomeOtherThread\)>")
         lock.release()
+        t.join()
 
         pname = 'P1'
         l = multiprocessing.Manager().list()
@@ -1584,7 +1594,7 @@ class _TestLock(BaseTestCase):
                          name=pname)
         p.start()
         p.join()
-        self.assertEqual(f'<Lock(owner={pname})>', l[0])
+        self.assertRegex(l[0], f"<*.Lock object at .* \\(owner={pname}\\)>")
 
         lock = self.Lock()
         event = self.Event()
@@ -1593,8 +1603,10 @@ class _TestLock(BaseTestCase):
                          name='P2')
         p.start()
         event.wait()
-        self.assertEqual(f'<Lock(owner=SomeOtherProcess)>', repr(lock))
-        p.terminate()
+        self.assertRegex(repr(lock),
+                         f"<*.Lock object at .* "
+                         f"\\(owner=SomeOtherProcess\\)>")
+        p.join()
 
     def test_lock(self):
         lock = self.Lock()
@@ -1629,61 +1641,77 @@ class _TestLock(BaseTestCase):
         p.join()
 
     @staticmethod
-    def _acquire_release(lock, timeout, l=None, n=1):
+    def _acquire_release(rlock, timeout, l=None, n=1):
         for _ in range(n):
-            lock.acquire()
+            rlock.acquire()
         if l is not None:
-            l.append(repr(lock))
+            l.append(repr(rlock))
         time.sleep(timeout)
         for _ in range(n):
-            lock.release()
+            rlock.release()
 
     @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
     def test_repr_rlock(self):
         if self.TYPE != 'processes':
             self.skipTest('test not appropriate for {}'.format(self.TYPE))
 
-        lock = self.RLock()
-        self.assertEqual('<RLock(None, 0)>', repr(lock))
+        rlock = self.RLock()
+        self.assertRegex(repr(rlock),
+                         r"<*.RLock object at .* "
+                         r"\(owner=None, count=0\)>")
 
         n = 3
         for _ in range(n):
-            lock.acquire()
-        self.assertEqual(f'<RLock(MainProcess, {n})>', repr(lock))
+            rlock.acquire()
+        self.assertRegex(repr(rlock),
+                         f"<*.RLock object at .* "
+                         f"\\(owner=MainProcess, count={n}\\)>")
+
         for _ in range(n):
-            lock.release()
+            rlock.release()
 
         t, l = [], []
         for i in range(n):
             t.append(threading.Thread(target=self._acquire_release,
-                                      args=(lock, 0.1, l, i+1),
+                                      args=(rlock, 0.1, l, i+1),
                                       name=f'T{i+1}'))
             t[-1].start()
         for t_ in t:
             t_.join()
         for i in range(n):
-            self.assertIn(f'<RLock(MainProcess|T{i+1}, {i+1})>', l)
+            if i < len(l):
+                self.assertRegex(repr(l[i]),
+                                 f"<*.RLock object at .* "
+                                 f"\\(owner=MainProcess|T{i+1}, "
+                                 f"count=nonzero\\)>")
 
         rlock = self.RLock()
         t = threading.Thread(target=rlock.acquire)
         t.start()
         t.join()
-        self.assertEqual('<RLock(SomeOtherThread, nonzero)>', repr(rlock))
+        self.assertRegex(repr(rlock),
+                         r"<*.RLock object at .* "
+                         r"\(owner=SomeOtherThread, count=nonzero\)>")
 
         pname = 'P1'
+        rlock = self.RLock()
         l = multiprocessing.Manager().list()
         p = self.Process(target=self._acquire_release,
-                         args=(lock, 0.1, l),
+                         args=(rlock, 0.1, l),
                          name=pname)
         p.start()
         p.join()
-        self.assertEqual(f'<RLock({pname}, 1)>', l[0])
+        self.assertRegex(repr(l[0]),
+                         f"<*.RLock object at .* "
+                         f"\\(owner={pname}, count=1\\)>")
 
         rlock = self.RLock()
         p = self.Process(target=self._acquire, args=(rlock,))
         p.start()
         p.join()
-        self.assertEqual('<RLock(SomeOtherProcess, nonzero)>', repr(rlock))
+        self.assertRegex(repr(rlock),
+                         r"<*.RLock object at .* "
+                         r"\(owner=SomeOtherProcess, count=nonzero\)>")
 
     def test_rlock(self):
         lock = self.RLock()
@@ -1752,9 +1780,36 @@ class _TestSemaphore(BaseTestCase):
         sem = self.BoundedSemaphore(2)
         self._test_semaphore(sem)
         # Currently fails on OS/X
-        #if HAVE_GETVALUE:
-        #    self.assertRaises(ValueError, sem.release)
-        #    self.assertReturnsIfImplemented(2, get_value, sem)
+        if HAVE_GETVALUE:
+            self.assertRaises(ValueError, sem.release)
+            self.assertReturnsIfImplemented(2, get_value, sem)
+
+    @unittest.skipUnless(HAVE_GETVALUE, 'needs sem_getvalue')
+    def test_repr_semaphore(self):
+        if self.TYPE != 'processes':
+            self.skipTest('test not appropriate for {}'.format(self.TYPE))
+        n = 5
+        sem = self.Semaphore(n)
+        self.assertRegex(repr(sem),
+                         f"<*.Semaphore object at .* \\(value={n}\\)>")
+        sem.acquire()
+        self.assertRegex(repr(sem),
+                         f"<*.Semaphore object at .* \\(value={n-1}\\)>")
+
+    @unittest.skipUnless(HAVE_GETVALUE, 'needs sem_getvalue')
+    def test_repr_boundedsemaphore(self):
+        if self.TYPE != 'processes':
+            self.skipTest('test not appropriate for {}'.format(self.TYPE))
+        n = 5
+        bsem = self.BoundedSemaphore(n)
+        self.assertRegex(repr(bsem),
+                         f"<*.BoundedSemaphore object at .* "
+                         f"\\(value={n}, maxvalue={n}\\)>")
+        for _ in range(n):
+            bsem.acquire()
+        self.assertRegex(repr(bsem),
+                         f"<*.BoundedSemaphore object at .* "
+                         f"\\(value=0, maxvalue={n}\\)>")
 
     def test_timeout(self):
         if self.TYPE != 'processes':
@@ -1809,6 +1864,57 @@ class _TestCondition(BaseTestCase):
                 self.assertEqual(cond._wait_semaphore.get_value(), 0)
             except NotImplementedError:
                 pass
+
+    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    def test_repr_condition(self):
+        cond = self.Condition()
+        if self.TYPE == 'processes':
+            # on macOS, waiters can be 'unknown'.
+            self.assertRegex(repr(cond),
+                             r"<*.Condition object at .* "
+                             r"\(lock=None, waiters=.*\)>")
+            cond.acquire()
+            self.assertRegex(repr(cond),
+                             r"<*.Condition object at .* "
+                             r"\(lock=MainProcess, waiters=.*\)>")
+            cond.release()
+            self.assertRegex(repr(cond),
+                             r"<*.Condition object at .* "
+                             r"\(lock=None, waiters=.*\)>")
+
+        elif self.TYPE == 'managers':
+            self.assertRegex(repr(cond),
+                        r"ConditionProxy object, typeid 'Condition' at .*>")
+            cond.acquire()
+            print(cond)
+
+    @staticmethod
+    def _cond_wait(cond):
+        with cond:
+            cond.wait()
+
+    @unittest.skipUnless(HAVE_GETVALUE, 'needs sem_getvalue')
+    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    def test_repr_condition_waiters(self):
+        cond = self.Condition()
+        if self.TYPE == 'processes':
+            p = self.Process(target=self._cond_wait, args=(cond,))
+            p.start()
+            # No need to check _woken_count attr.
+            while cond._sleeping_count.get_value() == 0:
+                _wait()
+            self.assertRegex(repr(cond),
+                            r"<*.Condition object at .* "
+                            r"\(lock=None, waiters=1\)>")
+            with cond:
+                self.assertRegex(repr(cond),
+                                r"<*.Condition object at .* "
+                                r"\(lock=MainProcess, waiters=1\)>")
+                cond.notify(1)
+            p.join()
+            self.assertRegex(repr(cond),
+                            r"<*.Condition object at .* "
+                            r"\(lock=None, waiters=0\)>")
 
     @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
     def test_notify(self):
@@ -2131,18 +2237,20 @@ class _TestEvent(BaseTestCase):
         self.assertEqual(wait(), True)
         p.join()
 
-    def test_repr(self) -> None:
+    def test_repr_event(self) -> None:
         event = self.Event()
         if self.TYPE == 'processes':
-            self.assertRegex(repr(event), r"<Event at .* unset>")
+            self.assertRegex(repr(event), r"<*.Event object at .* \(unset\)>")
             event.set()
-            self.assertRegex(repr(event), r"<Event at .* set>")
+            self.assertRegex(repr(event), r"<*.Event object at .* \(set\)>")
             event.clear()
-            self.assertRegex(repr(event), r"<Event at .* unset>")
+            self.assertRegex(repr(event), r"<*.Event object at .* \(unset\)>")
         elif self.TYPE == 'manager':
-            self.assertRegex(repr(event), r"<EventProxy object, typeid 'Event' at .*")
+            self.assertRegex(repr(event),
+                             r"<EventProxy object, typeid 'Event' at .*")
             event.set()
-            self.assertRegex(repr(event), r"<EventProxy object, typeid 'Event' at .*")
+            self.assertRegex(repr(event),
+                             r"<EventProxy object, typeid 'Event' at .*")
 
 
 # Tests for Barrier - adapted from tests in test/lock_tests.py
@@ -2274,6 +2382,43 @@ class _TestBarrier(BaseTestCase):
             b.wait_for_finished()
         finally:
             b.close()
+
+    @staticmethod
+    def _barrier_wait(barrier):
+        try:
+            barrier.wait()
+        except threading.BrokenBarrierError:
+            pass
+
+    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    def test_repr_barrier(self):
+        if self.TYPE == 'processes':
+            self.assertRegex(repr(self.barrier),
+                        f"<*.Barrier object at .* \\(waiters=0/{self.N}\\)>")
+            self.barrier.abort()
+            self.assertRegex(repr(self.barrier),
+                            f"<*.Barrier object at .* \\(broken\\)>")
+            self.barrier.reset()
+            ps = []
+            for i in range(self.N-1):
+                p = self.Process(target=self._barrier_wait,
+                                 args=(self.barrier,))
+                p.start()
+                ps.append(p)
+            # wait for at least one processes waits
+            while self.barrier.n_waiting == 0:
+                _wait()
+            self.assertRegex(repr(self.barrier),
+                            f"<*.Barrier object at .* "
+                            f"\\(waiters={list(range(1, self.N))}/{self.N}\\)>")
+            self.barrier.wait()
+            for p in ps:
+                p.join()
+            self.assertRegex(repr(self.barrier),
+                        f"<*.Barrier object at .* \\(waiters=0/{self.N}\\)>")
+        elif self.TYPE == 'manager':
+            self.assertRegex(repr(self.barrier),
+                            r"<BarrierProxy object, typeid 'Barrier' at .*")
 
     @classmethod
     def multipass(cls, barrier, results, n):

--- a/Misc/NEWS.d/next/Library/2026-08-13-15-48-35.gh-issue-155092.ewdZ1k.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-13-15-48-35.gh-issue-155092.ewdZ1k.rst
@@ -1,1 +1,1 @@
-All synchronize tool classes from the :mod:`multiprocessing` module, as `[R]Lock`, `[Bounded]Semaphore`, `Condition`, `Event` and `Barrier`, include now a reference to their own unique identifier in their representation string.
+All synchronize tool classes from the :mod:`multiprocessing` module, as ``[R]Lock``, ``[Bounded]Semaphore``, ``Condition``, ``Event`` and ``Barrier``, include now a reference to their own unique identifier in their representation string.

--- a/Misc/NEWS.d/next/Library/2026-08-13-15-48-35.gh-issue-155092.ewdZ1k.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-13-15-48-35.gh-issue-155092.ewdZ1k.rst
@@ -1,0 +1,1 @@
+All synchronize tool classes from the :mod:`multiprocessing` module, as `[R]Lock`, `[Bounded]Semaphore`, `Condition`, `Event` and `Barrier`, include now a reference to their own unique identifier in their representation string.


### PR DESCRIPTION
`__repr__` of multiprocessing synchronize tools should include information about id (in hex form).
All `__repr__` are reviewed, results are:

- Add `__repr__` for `Barrier`, update `__repr__` for all other synchronize tools. 
- Add tests for `[Bounded]Semaphore`, `Barrier` and `Condition`,
- Update tests for `[R]Lock` and `Event`.

These updates assume that the #155540 PR has been applied


<!-- gh-issue-number: gh-155092 -->
* Issue: gh-155092
<!-- /gh-issue-number -->
