### PR TITLE
gh-155591: Fix flamegraph timing display

### DIFF
--- a/Lib/profiling/sampling/_flamegraph_assets/flamegraph.js
+++ b/Lib/profiling/sampling/_flamegraph_assets/flamegraph.js
@@ -255,12 +255,12 @@ function setupLogos() {
 // Status Bar
 // ============================================================================
 
-function updateStatusBar(nodeData, rootValue) {
+function updateStatusBar(nodeData, rootValue, sampleIntervalUsec) {
   const funcname = resolveString(nodeData.funcname) || resolveString(nodeData.name) || "--";
   const filename = resolveString(nodeData.filename) || "";
   const moduleName = resolveString(nodeData.module) || "";
   const lineno = nodeData.lineno;
-  const timeMs = (nodeData.value / 1000).toFixed(2);
+  const timeMs = (nodeData.value * sampleIntervalUsec / 1000).toFixed(2);
   const percent = rootValue > 0 ? ((nodeData.value / rootValue) * 100).toFixed(1) : "0.0";
 
   const brandEl = document.getElementById('status-brand');
@@ -313,6 +313,7 @@ function clearStatusBar() {
 
 function createPythonTooltip(data) {
   const pythonTooltip = flamegraph.tooltip.defaultFlamegraphTooltip();
+  const sampleIntervalUsec = data.stats.sample_interval_usec;
 
   pythonTooltip.show = function (d, element) {
     if (!this._tooltip) {
@@ -322,9 +323,9 @@ function createPythonTooltip(data) {
         .style("opacity", 0);
     }
 
-    const timeMs = (d.data.value / 1000).toFixed(2);
+    const timeMs = (d.data.value * sampleIntervalUsec / 1000).toFixed(2);
     const selfSamples = d.data.self || 0;
-    const selfMs = (selfSamples / 1000).toFixed(2);
+    const selfMs = (selfSamples * sampleIntervalUsec / 1000).toFixed(2);
     const percentage = ((d.data.value / data.value) * 100).toFixed(2);
     const relativePercentage = Math.min(100, ((d.data.value / (zoomedNodeValue ?? data.value)) * 100)).toFixed(2);
     const calls = d.data.calls || 0;
@@ -408,9 +409,9 @@ function createPythonTooltip(data) {
     // Differential stats section
     let diffSection = "";
     if (d.data.diff !== undefined && d.data.baseline !== undefined) {
-      const baselineSelf = (d.data.baseline / 1000).toFixed(2);
-      const currentSelf = ((d.data.self_time || 0) / 1000).toFixed(2);
-      const diffMs = (d.data.diff / 1000).toFixed(2);
+      const baselineSelf = (d.data.baseline * sampleIntervalUsec / 1000).toFixed(2);
+      const currentSelf = ((d.data.self_time || 0) * sampleIntervalUsec / 1000).toFixed(2);
+      const diffMs = (d.data.diff * sampleIntervalUsec / 1000).toFixed(2);
       const diffPct = d.data.diff_pct;
       const sign = d.data.diff >= 0 ? "+" : "";
       const diffClass = d.data.diff > 0 ? "regression" : (d.data.diff < 0 ? "improvement" : "neutral");
@@ -508,7 +509,7 @@ function createPythonTooltip(data) {
       .style("opacity", 1);
 
     // Update status bar
-    updateStatusBar(d.data, data.value);
+    updateStatusBar(d.data, data.value, sampleIntervalUsec);
   };
 
   pythonTooltip.hide = function () {

--- a/Lib/profiling/sampling/stack_collector.py
+++ b/Lib/profiling/sampling/stack_collector.py
@@ -70,7 +70,7 @@ class CollapsedStackCollector(StackTraceCollector):
 class FlamegraphCollector(StackTraceCollector):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.stats = {}
+        self.stats = {"sample_interval_usec": self.sample_interval_usec}
         self._root = {
             "samples": 0,
             "children": {},


### PR DESCRIPTION
Fixes #155591.

Fix the flamegraph tooltip and status bar to calculate timing correctly using the configured sampling interval. This corrects total, self, and differential timing values.

The results are still displayed in milliseconds. I'm not sure whether longer durations should instead be displayed in seconds or automatically switch units.

This change was made with assistance from OpenAI Codex.

<!-- gh-issue-number: gh-155591 -->
* Issue: gh-155591
<!-- /gh-issue-number -->
