### PR TITLE
gh-88580: Run profile scripts in __main__ namespace

### DIFF
--- a/Lib/profile.py
+++ b/Lib/profile.py
@@ -24,6 +24,7 @@
 
 
 import importlib.machinery
+import importlib.util
 import io
 import sys
 import time
@@ -602,12 +603,20 @@ def main():
                 code = compile(fp.read(), progname, 'exec')
             spec = importlib.machinery.ModuleSpec(name='__main__', loader=None,
                                                   origin=progname)
-            globs = {
-                '__spec__': spec,
+            module = importlib.util.module_from_spec(spec)
+            # Set __main__ so that importing __main__ in the profiled code will
+            # return the same namespace that the code is executing under.
+            sys.modules['__main__'] = module
+            # Ensure that we're using the same __dict__ instance as the module
+            # for the global variables so that updates to globals are reflected
+            # in the module's namespace.
+            globs = module.__dict__
+            globs.update({
+                '__spec__': None,
                 '__file__': spec.origin,
                 '__name__': spec.name,
                 '__package__': None,
-            }
+            })
         try:
             runctx(code, globs, None, options.outfile, options.sort)
         except BrokenPipeError as exc:

--- a/Lib/test/test_profile.py
+++ b/Lib/test/test_profile.py
@@ -120,6 +120,28 @@ class ProfileTest(unittest.TestCase):
         assert_python_ok('-m', self.profilermodule.__name__,
                          '-m', 'timeit', '-n', '1')
 
+    def test_script_with_deferred_dataclass_annotations(self):
+        # gh-88580: the profiled script must be available as __main__ so
+        # dataclasses can resolve string annotations in its global namespace.
+        with temp_dir() as tmpdir:
+            script = os.path.join(tmpdir, 'profile_dataclass.py')
+            with open(script, 'w', encoding='utf-8') as f:
+                f.write("""\
+from __future__ import annotations
+from dataclasses import dataclass, InitVar
+
+@dataclass
+class C:
+    value: InitVar[int]
+
+    def __post_init__(self, value):
+        assert value == 42
+
+C(42)
+""")
+
+            assert_python_ok('-m', self.profilermodule.__name__, script)
+
     def test_output_file_when_changing_directory(self):
         with temp_dir() as tmpdir, change_cwd(tmpdir):
             os.mkdir('dest')

--- a/Misc/NEWS.d/next/Library/2026-08-12-10-37-22.gh-issue-88580.HC3q9r.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-12-10-37-22.gh-issue-88580.HC3q9r.rst
@@ -1,0 +1,3 @@
+Fix the :mod:`profile` command-line interface to execute scripts in the actual
+``__main__`` module namespace. This fixes profiling dataclasses that use
+deferred :class:`~dataclasses.InitVar` annotations.


### PR DESCRIPTION
Fixes #88580.

`python -m profile` executed the target script in a standalone globals
dictionary while `sys.modules["__main__"]` still referred to the profiler.
Dataclasses resolving deferred `InitVar` annotations through the class module
therefore inspected the wrong namespace and generated an invalid constructor.

Create a real `__main__` module and execute the profiled script in its
namespace, matching direct script execution and `cProfile`. Add regression
coverage for the reported deferred-annotation case and a NEWS entry.

Tests:

- `make patchcheck`
- `./python -m test -v test_profile test_profiling.test_tracing_profiler`
- `./python -m test -v test_dataclasses test_pstats`
- `./python -m test -j8` (one unrelated macOS `test_utime_fd` timestamp failure;
  it passed on immediate isolated rerun)


<!-- gh-issue-number: gh-88580 -->
* Issue: gh-88580
<!-- /gh-issue-number -->
