### PR TITLE
gh-61366: Write session cookies in the curl and Wget format

### DIFF
--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -2109,7 +2109,9 @@ class MozillaCookieJar(FileCookieJar):
                 if cookie.expires is not None:
                     expires = str(cookie.expires)
                 else:
-                    expires = ""
+                    # curl and Wget use 0 for session cookies, and ignore
+                    # the line if this field is empty.
+                    expires = "0"
                 if cookie.value is None:
                     # cookies.txt regards 'Set-Cookie: foo' as a cookie
                     # with no name, whereas http.cookiejar regards it as a

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -2048,6 +2048,35 @@ class LWPCookieTests(unittest.TestCase):
             # we didn't have session cookies in the first place
         self.assertNotEqual(counter["session_before"], 0)
 
+    def test_save_session_cookies(self):
+        # Session cookies are saved with 0 in the expiration time field,
+        # as curl and Wget do (gh-61366).
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
+        expires = int(time.time() + 3600)
+        c = MozillaCookieJar()
+        c.set_cookie(Cookie(0, "perm", "bar", None, False,
+                            "www.foo.com", True, False, "/", False, False,
+                            expires, False, None, None, {}))
+        c.set_cookie(Cookie(0, "session", "bar", None, False,
+                            "www.foo.com", True, False, "/", False, False,
+                            None, True, None, None, {}))
+        c.save(filename, ignore_discard=True)
+
+        saved = {}
+        with open(filename) as f:
+            for line in f:
+                if line.strip() and not line.startswith("#"):
+                    fields = line.split("\t")
+                    saved[fields[5]] = fields[4]
+        self.assertEqual(saved, {"perm": str(expires), "session": "0"})
+
+        # The saved file can be read back.
+        c = MozillaCookieJar()
+        c.revert(filename, ignore_discard=True)
+        self.assertEqual(sorted(cookie.name for cookie in c),
+                         ["perm", "session"])
+
     def test_load_session_cookies(self):
         # curl and Wget write 0 in the expires field for session cookies,
         # while we write an empty field.  Both should be read (gh-61366).

--- a/Misc/NEWS.d/next/Library/2026-08-12-09-30-00.gh-issue-61366.Wr7cKm.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-12-09-30-00.gh-issue-61366.Wr7cKm.rst
@@ -1,0 +1,3 @@
+:meth:`http.cookiejar.MozillaCookieJar.save` now writes ``0`` in the
+expiration time field for session cookies, as curl and Wget do.  Previously
+this field was left empty, and such lines were ignored by curl and Wget.

--- a/Misc/NEWS.d/next/Library/2026-08-12-09-30-00.gh-issue-61366.Wr7cKm.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-12-09-30-00.gh-issue-61366.Wr7cKm.rst
@@ -1,3 +1,3 @@
-:meth:`http.cookiejar.MozillaCookieJar.save` now writes ``0`` in the
+:meth:`!http.cookiejar.MozillaCookieJar.save` now writes ``0`` in the
 expiration time field for session cookies, as curl and Wget do.  Previously
 this field was left empty, and such lines were ignored by curl and Wget.


### PR DESCRIPTION
Session cookies are now saved with `0` in the expiration time field, as curl and Wget do. Previously this field was left empty, and such lines are ignored by curl and Wget, so all session cookies were lost.

This is based on #11792, which adds reading such files, and should be merged after it. Unlike it, this change is not backported, because files written with `0` are not read by unpatched Python.

<!-- gh-issue-number: gh-61366 -->
* Issue: gh-61366
<!-- /gh-issue-number -->
