### PR TITLE
Skip more pyexpat tests based on compile-time expat version, not runtime

### DIFF
--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -1051,7 +1051,7 @@ class ParentParserLifetimeTest(unittest.TestCase):
         del subparser
 
     # gh-155485: GetReparseDeferralEnabled always returns False with Expat <2.6.0.
-    @unittest.skipIf(not expat.ParserCreate().GetReparseDeferralEnabled(),
+    @unittest.skipIf(not HAS_REPARSE_DEFERRAL,
                      "requires Python compiled with Expat >= 2.6.0")
     def test_subparser_inherits_reparse_deferral(self):
         for enabled in (True, False):

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -1095,9 +1095,11 @@ class ExternalEntityParserCreateErrorTest(unittest.TestCase):
 
 
 class ReparseDeferralTest(unittest.TestCase):
+    deferal_supported = expat.ParserCreate().GetReparseDeferralEnabled()
+
     def test_getter_setter_round_trip(self):
         parser = expat.ParserCreate()
-        enabled = (expat.version_info >= (2, 6, 0))
+        enabled = self.deferal_supported
 
         self.assertIs(parser.GetReparseDeferralEnabled(), enabled)
         parser.SetReparseDeferralEnabled(False)
@@ -1106,8 +1108,8 @@ class ReparseDeferralTest(unittest.TestCase):
         self.assertIs(parser.GetReparseDeferralEnabled(), enabled)
 
     def test_reparse_deferral_enabled(self):
-        if expat.version_info < (2, 6, 0):
-            self.skipTest(f'Expat {expat.version_info} does not '
+        if not self.deferal_supported:
+            self.skipTest(f'Expat < 2.6.0 does not '
                           'support reparse deferral')
 
         started = []
@@ -1137,7 +1139,7 @@ class ReparseDeferralTest(unittest.TestCase):
 
         parser = expat.ParserCreate()
         parser.StartElementHandler = start_element
-        if expat.version_info >= (2, 6, 0):
+        if self.deferal_supported:
             parser.SetReparseDeferralEnabled(False)
         self.assertFalse(parser.GetReparseDeferralEnabled())
 

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -19,6 +19,11 @@ from xml.parsers import expat
 from xml.parsers.expat import errors
 
 
+# pyexpat built with expat 2.6.0+ has support for reparse deferral
+# and defaults to enabled
+HAS_REPARSE_DEFERRAL = expat.ParserCreate().GetReparseDeferralEnabled()
+
+
 class SetAttributeTest(unittest.TestCase):
     def setUp(self):
         self.parser = expat.ParserCreate(namespace_separator='!')
@@ -1095,11 +1100,9 @@ class ExternalEntityParserCreateErrorTest(unittest.TestCase):
 
 
 class ReparseDeferralTest(unittest.TestCase):
-    deferal_supported = expat.ParserCreate().GetReparseDeferralEnabled()
-
     def test_getter_setter_round_trip(self):
         parser = expat.ParserCreate()
-        enabled = self.deferal_supported
+        enabled = HAS_REPARSE_DEFERRAL
 
         self.assertIs(parser.GetReparseDeferralEnabled(), enabled)
         parser.SetReparseDeferralEnabled(False)
@@ -1108,7 +1111,7 @@ class ReparseDeferralTest(unittest.TestCase):
         self.assertIs(parser.GetReparseDeferralEnabled(), enabled)
 
     def test_reparse_deferral_enabled(self):
-        if not self.deferal_supported:
+        if not HAS_REPARSE_DEFERRAL:
             self.skipTest(f'Expat < 2.6.0 does not '
                           'support reparse deferral')
 
@@ -1139,7 +1142,7 @@ class ReparseDeferralTest(unittest.TestCase):
 
         parser = expat.ParserCreate()
         parser.StartElementHandler = start_element
-        if self.deferal_supported:
+        if HAS_REPARSE_DEFERRAL:
             parser.SetReparseDeferralEnabled(False)
         self.assertFalse(parser.GetReparseDeferralEnabled())
 

--- a/Lib/test/test_sax.py
+++ b/Lib/test/test_sax.py
@@ -1216,8 +1216,8 @@ class ExpatReaderTest(XmlTestBase):
 
         self.assertEqual(result.getvalue(), start + b"<doc>text</doc>")
 
-    @unittest.skipIf(pyexpat.version_info < (2, 6, 0),
-                     f'Expat {pyexpat.version_info} does not '
+    @unittest.skipIf(not pyexpat.ParserCreate().GetReparseDeferralEnabled(),
+                     'Python compiled with Expat < 2.6.0 does not '
                      'support reparse deferral')
     def test_flush_reparse_deferral_enabled(self):
         result = BytesIO()

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1915,8 +1915,8 @@ class XMLPullParserTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "unknown event 'bogus'"):
             ET.XMLPullParser(events=(x.decode() for x in (b'start', b'end', b'bogus')))
 
-    @unittest.skipIf(pyexpat.version_info < (2, 6, 0),
-                     f'Expat {pyexpat.version_info} does not '
+    @unittest.skipIf(not pyexpat.ParserCreate().GetReparseDeferralEnabled(),
+                     'Python compiled with Expat < 2.6.0 does not '
                      'support reparse deferral')
     def test_flush_reparse_deferral_enabled(self):
         parser = ET.XMLPullParser(events=('start', 'end'))


### PR DESCRIPTION
This is a followup for GH-144739 and GH-155485

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
