### PR TITLE
gh-89735: Document requirements for the *headers* argument

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1050,6 +1050,10 @@ AbstractBasicAuthHandler Objects
    authenticate for, *req* should be the (failed) :class:`Request` object, and
    *headers* should be the error headers.
 
+   *headers* must be a mapping-like object with case-insensitive lookup
+   that implements the ``get_all()`` method,
+   such as :class:`email.message.Message` or :class:`wsgiref.headers.Headers`.
+
    *host* is either an authority (e.g. ``"python.org"``) or a URL containing an
    authority component (e.g. ``"https://python.org/"``). In either case, the
    authority must not contain a userinfo component (so, ``"python.org"`` and
@@ -1090,6 +1094,9 @@ AbstractDigestAuthHandler Objects
    is included in the request, *host* should be the host to authenticate to, *req*
    should be the (failed) :class:`Request` object, and *headers* should be the
    error headers.
+
+   *headers* must be a mapping-like object with case-insensitive lookup,
+   such as :class:`email.message.Message` or :class:`wsgiref.headers.Headers`.
 
 
 .. _http-digest-auth-handler:


### PR DESCRIPTION
`AbstractBasicAuthHandler.http_error_auth_reqed()` looks up `headers.get_all('www-authenticate')` and `AbstractDigestAuthHandler.http_error_auth_reqed()` looks up `headers.get('www-authenticate')`, both with a lowercase name.
A plain `dict` therefore does not work: it has no `get_all()`, and its lookup is case-sensitive, so the header is silently not found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-89735 -->
* Issue: gh-89735
<!-- /gh-issue-number -->
