### PR TITLE
gh-90982: Use the standard wording in the site.getsitepackages() versionchanged

### DIFF
--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -460,7 +460,7 @@ Module contents
    .. versionadded:: 3.2
 
    .. versionchanged:: 3.3
-      Add the optional *prefixes* argument.
+      Added the optional *prefixes* parameter.
 
 
 .. function:: getuserbase()


### PR DESCRIPTION
Follow-up to GH-31546: ``parameter`` rather than ``argument``, and ``Added`` rather than ``Add``, as used elsewhere in the documentation.

The same change is already included in the open backports GH-155643, GH-155644 and GH-155645, so this needs no backport of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-90982 -->
* Issue: gh-90982
<!-- /gh-issue-number -->
