### PR TITLE
gh-141174: Test `type_repr()` of `Template` with invalid syntax in `Interpolation`

### DIFF
--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1874,6 +1874,10 @@ class TestTypeRepr(unittest.TestCase):
             type_repr(Template("hi", Interpolation(42, "   "))),
             "Template('hi', Interpolation(42, '   ', None, ''))",
         )
+        self.assertEqual(
+            type_repr(Template("hi", Interpolation(42, "4!2"))),
+            "Template('hi', Interpolation(42, '4!2', None, ''))",
+        )
         # gh138558: perhaps in the future, we can improve this behavior:
         self.assertEqual(type_repr(Template(Interpolation(42, "99"))), "t'{99}'")
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Currently, there is no test in `test_annotationlib.py` of the following lines:

https://github.com/python/cpython/blob/025e7d278e29f3df2e95ed9daf9d9835760564c8/Lib/annotationlib.py#L643-L644

These ensure that a reasonable value is returned when stringifying a `Template` annotation containing invalid syntax.

This could be tested for both `get_annotations(format=Format.STRING)` and `type_repr()`. But, it's impossible from a syntactic t-string and only possbile through artificial `Template` construction, which is only currently tested within the `type_repr()` tests. So I've only added a test there. Happy to add them in other places if that's required.

<!-- gh-issue-number: gh-141174 -->
* Issue: gh-141174
<!-- /gh-issue-number -->
