### PR TITLE
gh-155432: redraw PyREPL after SIGCONT

### DIFF
--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -277,6 +277,7 @@ class UnixConsole(Console):
     def _sigcont_handler(self, signum, frame):
         self.restore()
         self.prepare()
+        self.event_queue.insert(Event("resize", ""))
 
     def __read(self, n: int) -> bytes:
         return os.read(self.input_fd, n)

--- a/Lib/test/test_pyrepl/test_unix_console.py
+++ b/Lib/test/test_pyrepl/test_unix_console.py
@@ -368,6 +368,21 @@ class TestConsole(TestCase):
         console.restore()
         con.restore()
 
+    def test_sigcont_redraws_prompt(self, _os_write):
+        console = unix_console([])
+        console.get_event = UnixConsole.get_event.__get__(console)
+        reader = self._prepare_reader_with_prompts(console)
+        reader.ps1 = reader.ps2 = ">>> "
+        reader.ps3 = reader.ps4 = "... "
+        reader.prepare()
+        reader.refresh()
+
+        console._sigcont_handler(signal.SIGCONT, None)
+        reader.handle1(block=False)
+
+        self.assertEqual(reader.screen, [">>> "])
+        console.restore()
+
     def test_getheightwidth_with_invalid_environ(self, _os_write):
         # gh-128636
         console = UnixConsole(term="xterm")

--- a/Misc/NEWS.d/next/Library/2026-08-13-09-19-29.gh-issue-155432.SXvWk4.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-13-09-19-29.gh-issue-155432.SXvWk4.rst
@@ -1,0 +1,2 @@
+Re-print the PyREPL prompt after the interpreter is resumed with ``fg``
+following suspension with ``Ctrl-Z``.

--- a/Misc/NEWS.d/next/Library/6afad9cc-730f-4b52-a3c1-95ac36e91146.gh-issue-155432.rst
+++ b/Misc/NEWS.d/next/Library/6afad9cc-730f-4b52-a3c1-95ac36e91146.gh-issue-155432.rst
@@ -1,2 +1,0 @@
-Re-print the PyREPL prompt after the interpreter is resumed with
-``fg`` following suspension with ``Ctrl-Z``.

--- a/Misc/NEWS.d/next/Library/6afad9cc-730f-4b52-a3c1-95ac36e91146.gh-issue-155432.rst
+++ b/Misc/NEWS.d/next/Library/6afad9cc-730f-4b52-a3c1-95ac36e91146.gh-issue-155432.rst
@@ -1,0 +1,2 @@
+Re-print the PyREPL prompt after the interpreter is resumed with
+``fg`` following suspension with ``Ctrl-Z``.


### PR DESCRIPTION
gh-155432: Re-print the PyREPL prompt when the process is resumed after Ctrl-Z.

After a suspended PyREPL is resumed with `fg`, the terminal is restored but the prompt is not redrawn until another input event causes a refresh.

This change queues the existing `resize` event from the `SIGCONT` handler so the normal PyREPL refresh path redraws the prompt.

A regression test verifies that the prompt is restored after processing the queued event.

Tests:
- `./python -m test test_pyrepl.test_unix_console -j1`
- `./python -m test test_pyrepl -j1`
- `./python -m compileall -q Lib/_pyrepl Lib/test/test_pyrepl`
- `git diff --check`

Closes issue: gh-155432