### PR TITLE
gh-141174: Test re-stringifying a `ForwardRef`

### DIFF
--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -2133,7 +2133,12 @@ class TestForwardRefClass(unittest.TestCase):
         self.assertIsNone(fr.__resolved_str_cache__)
 
         self.assertEqual(fr.evaluate(format=Format.STRING), "unknown | str | int | list[str] | tuple[int, ...]")
+
+        # Test that the cache is now set correctly
         self.assertEqual(fr.__resolved_str_cache__, "unknown | str | int | list[str] | tuple[int, ...]")
+
+        # Test that future evaluations return the same cache
+        self.assertIs(fr.evaluate(format=Format.STRING), fr.__resolved_str_cache__)
 
     def test_evaluate_forwardref_format(self):
         fr = ForwardRef("undef")


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Currently, every `ForwardRef.evaluate(format=Format.STRING)` test in `test_annotationlib` is done with an empty `__resolved_string_cache__`, so there is no test that re-evaluations are correct (or that they actually use the cache).

That is to say, the condition `self.__resolved_str_cache__ is None` is always true:

https://github.com/python/cpython/blob/025e7d278e29f3df2e95ed9daf9d9835760564c8/Lib/annotationlib.py#L244

Thus, this PR adds a simple test to re-stringify a stringified fwdref.

That said, I'm not 100% on whether the current test is correct: it's testing the behaviour that the cache has to be returned identically - which is the correct behaviour, and this test already tests the content of the cache - but I'm not sure if we want to cement that exact behaviour. So, happy to make it an equality (instead of identity) check if it's preferred.