### PR TITLE
[3.14] gh-154139: Document that curses is not thread-safe (GH-154173)

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -34,6 +34,18 @@ Linux and the BSD variants of Unix.
    Whenever the documentation mentions a *character string* it can be specified
    as a Unicode string or a byte string.
 
+.. note::
+
+   Whether curses may be used from several threads
+   depends on the underlying library and how it was built.
+   In many implementations, including the default build of ncurses,
+   the screen state is shared and not thread-safe;
+   since the blocking and refresh methods
+   (such as :meth:`~window.getch` and :meth:`~window.refresh`)
+   release the :term:`GIL`,
+   unsynchronized use from several threads can then crash the interpreter.
+   Serialize the calls.
+
 .. seealso::
 
    Module :mod:`curses.ascii`


### PR DESCRIPTION
Whether curses is thread-safe depends on the library and how it was built.
The blocking and refresh methods release the GIL, so with a non-reentrant curses, unsynchronized use from several threads can crash.

The reference to `window.use()` and `screen.use()` is omitted: they were added in 3.16.

(cherry picked from commit 1ed6b78232a8739aa3b1ee1ce7ce2e1d998e3607)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-154139 -->
* Issue: gh-154139
<!-- /gh-issue-number -->
