### PR TITLE
gh-149679: Document that cadata does not accept CRLs

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1617,7 +1617,8 @@ to speed up repeated connections from the same clients.
    :data:`CERT_NONE`.  At least one of *cafile* or *capath* must be specified.
 
    This method can also load certification revocation lists (CRLs) in PEM or
-   DER format. In order to make use of CRLs, :attr:`SSLContext.verify_flags`
+   DER format, but only through *cafile* or *capath* (not *cadata*).
+   In order to make use of CRLs, :attr:`SSLContext.verify_flags`
    must be configured properly.
 
    The *cafile* string, if present, is the path to a file of concatenated
@@ -1634,6 +1635,8 @@ to speed up repeated connections from the same clients.
    PEM-encoded certificates or a :term:`bytes-like object` of DER-encoded
    certificates. Like with *capath* extra lines around PEM-encoded
    certificates are ignored but at least one certificate must be present.
+   Unlike *cafile* and *capath*, *cadata* accepts certificates only; CRLs
+   supplied through *cadata* are rejected.
 
    .. versionchanged:: 3.4
       New optional argument *cadata*


### PR DESCRIPTION
This documents that `SSLContext.load_verify_locations()` accepts CRLs only through *cafile* or *capath*, not through *cadata*.

`cafile`/`capath` are passed to OpenSSL's `SSL_CTX_load_verify_locations`, which loads CRLs in addition to certificates. `cadata`, on the other hand, is handled by `_add_ca_certs` in `Modules/_ssl.c`, which reads X.509 certificates only (`d2i_X509_bio` / `PEM_read_bio_X509` + `X509_STORE_add_cert`). Supplying a CRL through `cadata` therefore raises `SSLError: "cadata does not contain a certificate"` rather than loading it.

The docs previously stated that the method "can also load certification revocation lists (CRLs)" without noting this restriction.


<!-- gh-issue-number: gh-149679 -->
* Issue: gh-149679
<!-- /gh-issue-number -->
