### PR TITLE
gh-155702: Fix sqlite3.Blob slice assignment with a step

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1396,6 +1396,18 @@ class BlobTests(unittest.TestCase):
         actual = self.cx.execute("select b from test").fetchone()[0]
         self.assertEqual(actual, expected)
 
+    def test_blob_set_slice_with_step_keeps_bytes_intact(self):
+        # The buffer used for the read-patch-write cycle must not be the
+        # bytes object read from the blob: for a single byte it is an
+        # immortal singleton.
+        old_byte = self.data[5]
+        self.blob[5:6:2] = b"\xab"
+        self.assertEqual(bytes([old_byte])[0], old_byte)
+        self.assertEqual(self.blob[5:6], b"\xab")
+        expected = self.data[:5] + b"\xab" + self.data[6:]
+        actual = self.cx.execute("select b from test").fetchone()[0]
+        self.assertEqual(actual, expected)
+
     def test_blob_set_empty_slice(self):
         self.blob[0:0] = b""
         self.assertEqual(self.blob[:], self.data)

--- a/Misc/NEWS.d/next/Library/2026-08-13-16-02-13.gh-issue-155702.Kb7Qm4.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-13-16-02-13.gh-issue-155702.Kb7Qm4.rst
@@ -1,0 +1,4 @@
+Fix :class:`sqlite3.Blob` slice assignment with a step.
+It patched the bytes object read from the blob,
+which for a single byte is an immortal singleton,
+so that the value of that byte was changed in the whole process.

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -139,26 +139,35 @@ read_single(pysqlite_Blob *self, Py_ssize_t offset)
     return PyLong_FromUnsignedLong((unsigned long)buf);
 }
 
-static PyObject *
-read_multiple(pysqlite_Blob *self, Py_ssize_t length, Py_ssize_t offset)
+static int
+inner_read(pysqlite_Blob *self, char *buf, Py_ssize_t length,
+           Py_ssize_t offset)
 {
     assert(length <= sqlite3_blob_bytes(self->blob));
     assert(offset < sqlite3_blob_bytes(self->blob));
 
+    int rc;
+    Py_BEGIN_ALLOW_THREADS
+    rc = sqlite3_blob_read(self->blob, buf, (int)length, (int)offset);
+    Py_END_ALLOW_THREADS
+
+    if (rc != SQLITE_OK) {
+        blob_seterror(self, rc);
+        return -1;
+    }
+    return 0;
+}
+
+static PyObject *
+read_multiple(pysqlite_Blob *self, Py_ssize_t length, Py_ssize_t offset)
+{
     PyBytesWriter *writer = PyBytesWriter_Create(length);
     if (writer == NULL) {
         return NULL;
     }
-    char *raw_buffer = PyBytesWriter_GetData(writer);
 
-    int rc;
-    Py_BEGIN_ALLOW_THREADS
-    rc = sqlite3_blob_read(self->blob, raw_buffer, (int)length, (int)offset);
-    Py_END_ALLOW_THREADS
-
-    if (rc != SQLITE_OK) {
+    if (inner_read(self, PyBytesWriter_GetData(writer), length, offset) < 0) {
         PyBytesWriter_Discard(writer);
-        blob_seterror(self, rc);
         return NULL;
     }
     return PyBytesWriter_Finish(writer);
@@ -553,14 +562,28 @@ ass_subscript_slice(pysqlite_Blob *self, PyObject *item, PyObject *value)
         rc = inner_write(self, vbuf.buf, len, start);
     }
     else {
-        PyObject *blob_bytes = read_multiple(self, stop - start, start);
-        if (blob_bytes != NULL) {
-            char *blob_buf = PyBytes_AS_STRING(blob_bytes);
-            for (Py_ssize_t i = 0, j = 0; i < len; i++, j += step) {
-                blob_buf[j] = ((char *)vbuf.buf)[i];
+        /* Read the affected region, patch it and write it back.  The
+           object returned by read_multiple() cannot be used as the buffer,
+           because for a single byte it is an immortal singleton. */
+        Py_ssize_t length = stop - start;
+        if (length <= 0) {
+            /* start > stop for a negative step; see gh-150449. */
+            PyErr_SetString(PyExc_ValueError, "size must be >= 0");
+        }
+        else {
+            char *buf = PyMem_Malloc(length);
+            if (buf == NULL) {
+                PyErr_NoMemory();
             }
-            rc = inner_write(self, blob_buf, stop - start, start);
-            Py_DECREF(blob_bytes);
+            else {
+                if (inner_read(self, buf, length, start) == 0) {
+                    for (Py_ssize_t i = 0, j = 0; i < len; i++, j += step) {
+                        buf[j] = ((char *)vbuf.buf)[i];
+                    }
+                    rc = inner_write(self, buf, length, start);
+                }
+                PyMem_Free(buf);
+            }
         }
     }
     PyBuffer_Release(&vbuf);


### PR DESCRIPTION
`ass_subscript_slice()` patched the bytes object read from the blob and wrote it back.
For a single byte that object is an immortal singleton, so the value of that byte was changed in the whole process.

It now reads into a plain buffer.
The raw read is factored out of `read_multiple()` into `inner_read()`, like the existing `inner_write()`.

The negative step case (gh-150449, GH-150450) still raises the same `ValueError` as before.


<!-- gh-issue-number: gh-155702 -->
* Issue: gh-155702
<!-- /gh-issue-number -->
