### PR TITLE
gh-155629: do not treat GNU header atime as a ustar path prefix

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1353,6 +1353,7 @@ class TarInfo(object):
         obj.gname = nts(buf[297:329], encoding, errors)
         obj.devmajor = nti(buf[329:337])
         obj.devminor = nti(buf[337:345])
+        magic = buf[257:265]
         prefix = nts(buf[345:500], encoding, errors)
 
         # Old V7 tar format represents a directory as a regular
@@ -1382,8 +1383,12 @@ class TarInfo(object):
         if obj.isdir():
             obj.name = obj.name.rstrip("/")
 
-        # Reconstruct a ustar longname.
-        if prefix and obj.type not in GNU_TYPES:
+        # Reconstruct a ustar longname. The prefix field is only defined
+        # by the ustar format; in the GNU and star formats this byte range
+        # is used for other data (e.g. atime and ctime), so it must not be
+        # interpreted as a path prefix unless the header magic identifies
+        # a ustar header.
+        if prefix and magic == POSIX_MAGIC and obj.type not in GNU_TYPES:
             obj.name = prefix + "/" + obj.name
         return obj
 

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1443,6 +1443,20 @@ class GNUReadTest(LongnameTest, ReadTest, unittest.TestCase):
 
         self.assertEqual(names, ["b" * 20, "a" * 120])
 
+    def test_gnu_atime_not_used_as_ustar_prefix(self):
+        # gh-155629: in an old-GNU header, bytes 345:357 hold the member's
+        # atime rather than a ustar path prefix. The atime must not be
+        # prepended to the member name.
+        member = tarfile.TarInfo("victim")
+        header = bytearray(member.tobuf(format=tarfile.GNU_FORMAT))
+        header[345:357] = b"00000000001\0"
+        header[148:156] = b" " * 8
+        header[148:156] = f"{sum(header):06o}\0 ".encode("ascii")
+
+        buf = io.BytesIO(bytes(header) + b"\0" * 1024)
+        with tarfile.open(fileobj=buf, mode="r:") as tar:
+            self.assertEqual(tar.getnames(), ["victim"])
+
 
 class PaxReadTest(LongnameTest, ReadTest, unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2026-08-13-12-00-00.gh-issue-155629.b8X6gH.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-13-12-00-00.gh-issue-155629.b8X6gH.rst
@@ -1,0 +1,4 @@
+When reading a GNU-format archive, the member's atime, which is stored
+in the byte range that the ustar format uses for the path prefix, is no
+longer mistaken for a ustar path prefix and prepended to the member
+name.


### PR DESCRIPTION
<!-- gh-issue-number: gh-155629 -->
* Issue: gh-155629
<!-- /gh-issue-number -->

When parsing an old-GNU header, the byte range at offset 345 is used for the member's atime rather than a ustar path prefix. The header magic is now checked before reconstructing a long name from the prefix field, so the atime is no longer prepended to the member name.

cc @woodruffw
