### PR TITLE
gh-109817: Do not copy all test cases into the worker process

### DIFF
--- a/Lib/test/libregrtest/runtests.py
+++ b/Lib/test/libregrtest/runtests.py
@@ -110,7 +110,10 @@ class RunTests:
         return RunTests(**state)
 
     def create_worker_runtests(self, **override) -> WorkerRunTests:
-        state = dataclasses.asdict(self)
+        # Drop the large fields *before* converting: asdict() copies them
+        # deeply, which is expensive when the whole run has many cases.
+        state = dataclasses.asdict(
+            dataclasses.replace(self, tests=(), case_groups=None))
         state.update(override)
         return WorkerRunTests(**state)
 


### PR DESCRIPTION
With `--single-process-per-case`, `tests` and `case_groups` contain all test cases of the whole run.  `create_worker_runtests()` copies them for every test case and serializes them as a single command line argument.

`./python -m test --single-process-per-case test_asyncio` failed with `OSError: [Errno 7] Argument list too long`.  The copying is also slow and holds the GIL: with `-j32`, the number of test cases executed in 75 seconds increased from 1066 to 3214.

The worker runs the tests it is given, so it needs neither.


<!-- gh-issue-number: gh-109817 -->
* Issue: gh-109817
<!-- /gh-issue-number -->
