### PR TITLE
Do not break long test names in the regrtest output

### DIFF
--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -128,7 +128,8 @@ def printlist(x, width=70, indent=4, file=None):
     blanks = ' ' * indent
     # Print the sorted list: 'x' may be a '--random' list or a set()
     print(textwrap.fill(' '.join(str(elt) for elt in sorted(x)), width,
-                        initial_indent=blanks, subsequent_indent=blanks),
+                        initial_indent=blanks, subsequent_indent=blanks,
+                        break_long_words=False, break_on_hyphens=False),
           file=file)
 
 


### PR DESCRIPTION
`printlist()` passes the joined test names to `textwrap.fill()`, which breaks words longer than the line width.  Test case identifiers are usually longer:

```
23 tests failed:
    test.test_os.test_posix.PosixTester.test_getgroups test.test_pyrep
    l.test_pyrepl.TestPyReplModuleCompleter.test_attribute_completion
```

A line break which replaced a space is indistinguishable from one inside a name, so the names cannot even be read back.
