### PR TITLE
gh-155727: Ignore internal imports in test_attribute_completion

### DIFF
--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1467,7 +1467,10 @@ class TestPyReplModuleCompleter(TestCase):
                         reader = self.prepare_reader(events, namespace={})
                         output = reader.readline()
                         self.assertEqual(output, expected)
-                        new_imports = sys.modules.keys() - _imported
+                        # The reader imports its own helpers lazily.
+                        new_imports = {name for name in
+                                       sys.modules.keys() - _imported
+                                       if not name.startswith('_pyrepl.')}
                         self.assertEqual(new_imports, expected_imports)
 
     @patch.dict(sys.modules)


### PR DESCRIPTION
Ignore `_pyrepl` submodules when comparing the modules imported while the reader runs.


<!-- gh-issue-number: gh-155727 -->
* Issue: gh-155727
<!-- /gh-issue-number -->
