### PR TITLE
gh-155731: Clean up files left by test_import

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -490,6 +490,7 @@ class ImportTests(unittest.TestCase):
                 forget(TESTFN)
                 unlink(source)
                 unlink(pyc)
+                rmtree('__pycache__')
 
         sys.path.insert(0, os.curdir)
         try:
@@ -668,6 +669,7 @@ class ImportTests(unittest.TestCase):
                   import importlib
             sys.argv.insert(0, C())
             """))
+        self.addCleanup(unlink, testfn)
         script_helper.assert_python_ok(testfn)
 
     @skip_if_dont_write_bytecode
@@ -2033,6 +2035,7 @@ class ImportTracebackTests(unittest.TestCase):
         # encode filenames, especially on Windows
         pyname = script_helper.make_script('', TESTFN_UNENCODABLE, 'pass')
         self.addCleanup(unlink, pyname)
+        self.addCleanup(rmtree, '__pycache__')
         name = pyname[:-3]
         script_helper.assert_python_ok("-c", "mod = __import__(%a)" % name,
                                        __isolated=False)


### PR DESCRIPTION
Remove the `__pycache__` directory created for a temporary module and the script left by `test_import_in_del_does_not_crash()`.

<!-- gh-issue-number: gh-155731 -->
* Issue: gh-155731
<!-- /gh-issue-number -->
