### PR TITLE
gh-58083: Expand the introduction of the cmd module

### DIFF
--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -13,6 +13,13 @@ command interpreters.  These are often useful for test harnesses, administrative
 tools, and prototypes that will later be wrapped in a more sophisticated
 interface.
 
+A command interpreter built with :class:`Cmd` presents the user with an
+interactive prompt, reads input one line at a time, and runs each command by
+calling the method whose name matches it.  For example, the ``help`` command is
+handled by a ``do_help()`` method.  Apart from the built-in ``help`` command,
+the interpreter's behavior is defined by the ``do_*`` methods you add in your
+own subclass.
+
 .. class:: Cmd(completekey='tab', stdin=None, stdout=None)
 
    A :class:`Cmd` instance or subclass instance is a line-oriented interpreter


### PR DESCRIPTION
Expand the introduction of the `cmd` module with a concrete description of how a `Cmd`-based interpreter works: it presents the user with an interactive prompt, reads input one line at a time, and runs each command by calling the matching `do_*` method. The previous introduction only described `cmd` abstractly as a "simple framework for writing line-oriented command interpreters", which did not convey what the module actually does or how it works. In the issue, a core developer agreed that expanding the introduction would be an improvement.

Closes #58083.


<!-- gh-issue-number: gh-58083 -->
* Issue: gh-58083
<!-- /gh-issue-number -->
