### PR TITLE
gh-155742: Use PyBytesWriter in xml.etree

### DIFF
--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3165,7 +3165,6 @@ makeuniversal(XMLParserObject* self, const char* string)
            necessary */
 
         PyObject* tag;
-        char* p;
         Py_ssize_t i;
 
         /* look for namespace separator */
@@ -3174,22 +3173,28 @@ makeuniversal(XMLParserObject* self, const char* string)
                 break;
         if (i != size) {
             /* convert to universal name */
-            tag = PyBytes_FromStringAndSize(NULL, size+1);
+            PyBytesWriter *writer = PyBytesWriter_Create(1 + size);
+            if (writer == NULL) {
+                Py_DECREF(key);
+                return NULL;
+            }
+            char *p = PyBytesWriter_GetData(writer);
+            p[0] = '{';
+            memcpy(p+1, string, size);
+            size++;
+
+            tag = PyBytesWriter_Finish(writer);
             if (tag == NULL) {
                 Py_DECREF(key);
                 return NULL;
             }
-            p = PyBytes_AS_STRING(tag);
-            p[0] = '{';
-            memcpy(p+1, string, size);
-            size++;
         } else {
             /* plain name; use key as tag */
             tag = Py_NewRef(key);
         }
 
         /* decode universal name */
-        p = PyBytes_AS_STRING(tag);
+        const char *p = PyBytes_AS_STRING(tag);
         value = PyUnicode_DecodeUTF8(p, size, "strict");
         Py_DECREF(tag);
         if (!value) {


### PR DESCRIPTION
Replace soft deprecated PyBytes_FromStringAndSize() with PyBytesWriter.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-155742 -->
* Issue: gh-155742
<!-- /gh-issue-number -->
