### PR TITLE
gh-155742: Use PyBytesWriter in codecs

### DIFF
--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -1446,7 +1446,8 @@ _PyCodec_SurrogateEscapeUnicodeEncodeError(PyObject *exc)
     }
     Py_DECREF(obj);
 
-    PyObject *res = PyBytesWriter_Finish(writer);  // can be NULL
+    PyObject *res = PyBytesWriter_Finish(writer);
+    // Py_BuildValue() propagates the exception if res is NULL
     return Py_BuildValue("(Nn)", res, end);
 }
 

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -1426,19 +1426,19 @@ _PyCodec_SurrogateEscapeUnicodeEncodeError(PyObject *exc)
         return NULL;
     }
 
-    PyObject *res = PyBytes_FromStringAndSize(NULL, slen);
-    if (res == NULL) {
+    PyBytesWriter *writer = PyBytesWriter_Create(slen);
+    if (writer == NULL) {
         Py_DECREF(obj);
         return NULL;
     }
 
-    char *outp = PyBytes_AsString(res);
+    char *outp = PyBytesWriter_GetData(writer);
     for (Py_ssize_t i = start; i < end; i++) {
         Py_UCS4 ch = PyUnicode_READ_CHAR(obj, i);
         if (ch < 0xdc80 || ch > 0xdcff) {
             /* Not a UTF-8b surrogate, fail with original exception. */
             Py_DECREF(obj);
-            Py_DECREF(res);
+            PyBytesWriter_Discard(writer);
             PyErr_SetObject(PyExceptionInstance_Class(exc), exc);
             return NULL;
         }
@@ -1446,6 +1446,7 @@ _PyCodec_SurrogateEscapeUnicodeEncodeError(PyObject *exc)
     }
     Py_DECREF(obj);
 
+    PyObject *res = PyBytesWriter_Finish(writer);  // can be NULL
     return Py_BuildValue("(Nn)", res, end);
 }
 


### PR DESCRIPTION
Replace soft deprecated PyBytes_FromStringAndSize() with PyBytesWriter.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-155742 -->
* Issue: gh-155742
<!-- /gh-issue-number -->
