### PR TITLE
[3.12] GH-155757: Set `--argv0` for wasmtime

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-08-13-12-57-27.gh-issue-155757._5cg0h.rst
+++ b/Misc/NEWS.d/next/Build/2026-08-13-12-57-27.gh-issue-155757._5cg0h.rst
@@ -1,3 +1,3 @@
-Set the `--argv0` argument to wasmtime for WASI builds so the test suite
+Set the ``--argv0`` argument to wasmtime for WASI builds so the test suite
 passes. Otherwise the calculated paths to the stdlib for frozen modules is
 incorrect.

--- a/Misc/NEWS.d/next/Build/2026-08-13-12-57-27.gh-issue-155757._5cg0h.rst
+++ b/Misc/NEWS.d/next/Build/2026-08-13-12-57-27.gh-issue-155757._5cg0h.rst
@@ -1,0 +1,3 @@
+Set the `--argv0` argument to wasmtime for WASI builds so the test suite
+passes. Otherwise the calculated paths to the stdlib for frozen modules is
+incorrect.

--- a/Tools/wasm/wasm_build.py
+++ b/Tools/wasm/wasm_build.py
@@ -318,6 +318,7 @@ WASI = Platform(
             "wasmtime run "
             "--wasm max-wasm-stack=8388608 "
             "--wasi preview2 "
+            "--argv0 /{relbuilddir}/python.wasm "
             "--dir {srcdir}::/ "
             "--env PYTHONPATH=/{relbuilddir}/build/lib.wasi-wasm32-{version}:/Lib"
         ),


### PR DESCRIPTION
Fixes an issue where frozen modules calculated the location of the stdlib incorrectly due to commit 03ab7b44788bfd6b8927e16bcdbd025aa08dce06 .

<!-- gh-issue-number: gh-155757 -->
* Issue: gh-155757
<!-- /gh-issue-number -->
