### PR TITLE
gh-155752: Do not crash when GenericAlias parameters change during substitution

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6054,9 +6054,9 @@ class GenericTests(BaseTestCase):
                     with self.assertRaises(TypeError):
                         a[int]
 
-    # gh-155752: GenericAlias parameters are cached before substitution, so
-    # an argument can gain __typing_subst__ after the tuple is calculated.
     def test_parameter_added_after_parameters_cached(self):
+        # gh-155752: GenericAlias parameters are cached before substitution, so
+        # an argument can gain __typing_subst__ after the tuple is calculated.
         class Parameter:
             pass
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6054,6 +6054,22 @@ class GenericTests(BaseTestCase):
                     with self.assertRaises(TypeError):
                         a[int]
 
+    # gh-155752: GenericAlias parameters are cached before substitution, so
+    # an argument can gain __typing_subst__ after the tuple is calculated.
+    def test_parameter_added_after_parameters_cached(self):
+        class Parameter:
+            pass
+
+        first = Parameter()
+        first.__typing_subst__ = lambda value: value
+        late = Parameter()
+        alias = types.GenericAlias(dict, (first, late))
+        self.assertEqual(alias.__parameters__, (first,))
+        late.__typing_subst__ = lambda value: value
+
+        with self.assertRaisesRegex(TypeError, "not found in __parameters__"):
+            alias[0]
+
     def test_return_non_tuple_while_unpacking(self):
         # GH-138497: GenericAlias objects didn't ensure that __typing_subst__ actually
         # returned a tuple

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-13-13-50-00.gh-issue-155752.Rp7K2x.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-13-13-50-00.gh-issue-155752.Rp7K2x.rst
@@ -1,0 +1,2 @@
+Fix a crash when a :class:`types.GenericAlias` argument gains a
+``__typing_subst__`` hook after the alias parameters have been cached.

--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -525,8 +525,18 @@ _Py_subs_parameters(PyObject *self, PyObject *args, PyObject *parameters, PyObje
         }
         if (subst) {
             Py_ssize_t iparam = tuple_index(parameters, nparams, arg);
-            assert(iparam >= 0);
-            arg = PyObject_CallOneArg(subst, argitems[iparam]);
+            if (iparam < 0) {
+                // __parameters__ may be stale if an argument gained
+                // __typing_subst__ after the tuple was computed.
+                PyErr_Format(PyExc_TypeError,
+                             "argument %R with __typing_subst__ was not found "
+                             "in __parameters__",
+                             arg);
+                arg = NULL;
+            }
+            else {
+                arg = PyObject_CallOneArg(subst, argitems[iparam]);
+            }
             Py_DECREF(subst);
         }
         else {


### PR DESCRIPTION
Fixes #155752

`_Py_subs_parameters()` assumed that every argument with a `__typing_subst__` attribute was present in the cached `__parameters__` tuple. However, `__typing_subst__` can be added to an argument after `__parameters__` has been cached, causing the lookup to return -1, which is subsequently looked up.

Check the lookup result before indexing the substitution arguments and raise `TypeError` when the changed argument is not in `__parameters__`.



<!-- gh-issue-number: gh-155752 -->
* Issue: gh-155752
<!-- /gh-issue-number -->
