### PR TITLE
gh-153400: Support os.getrandom() on old glibc versions

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-08-14-20-16-55.gh-issue-153400.9Oxi-N.rst
+++ b/Misc/NEWS.d/next/Build/2026-08-14-20-16-55.gh-issue-153400.9Oxi-N.rst
@@ -1,0 +1,1 @@
+Fall back to the kernel-provided __NR_getrandom in configure checks, os.getrandom(), and interpreter entropy handling when libc SYS_getrandom is not available.

--- a/Misc/NEWS.d/next/Build/2026-08-14-20-16-55.gh-issue-153400.9Oxi-N.rst
+++ b/Misc/NEWS.d/next/Build/2026-08-14-20-16-55.gh-issue-153400.9Oxi-N.rst
@@ -1,1 +1,1 @@
-Fall back to the kernel-provided __NR_getrandom in configure checks, os.getrandom(), and interpreter entropy handling when libc SYS_getrandom is not available.
+Support os.getrandom() when building Python with old glibc versions and recent Linux kernel (glibc 2.25 or older and Linux kernel 3.17 or newer). Get the syscall number from kernel headers, rather than glibc headers.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -17440,7 +17440,7 @@ os_getrandom_impl(PyObject *module, Py_ssize_t size, unsigned int flags)
 #ifdef HAVE_GETRANDOM
         n = getrandom(data, size, flags);
 #else
-        n = syscall(SYS_getrandom, data, size, flags);
+        n = syscall(__NR_getrandom, data, size, flags);
 #endif
         if (n < 0 && errno == EINTR) {
             if (PyErr_CheckSignals() < 0) {

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -160,6 +160,9 @@
 #ifdef HAVE_SYS_SYSCALL_H
 #  include <sys/syscall.h>        // syscall(), __NR_xxx syscall numbers
 #endif
+#if !defined(SYS_getrandom) && defined(__NR_getrandom)
+#  define SYS_getrandom __NR_getrandom
+#endif
 
 #ifdef HAVE_POSIX_SPAWN
 #  include <spawn.h>              // posix_spawn()
@@ -17440,7 +17443,7 @@ os_getrandom_impl(PyObject *module, Py_ssize_t size, unsigned int flags)
 #ifdef HAVE_GETRANDOM
         n = getrandom(data, size, flags);
 #else
-        n = syscall(__NR_getrandom, data, size, flags);
+        n = syscall(SYS_getrandom, data, size, flags);
 #endif
         if (n < 0 && errno == EINTR) {
             if (PyErr_CheckSignals() < 0) {

--- a/Python/bootstrap_hash.c
+++ b/Python/bootstrap_hash.c
@@ -23,7 +23,7 @@
 #    include <sys/random.h>       // getrandom()
 #  endif
 #  if !defined(HAVE_GETRANDOM) && defined(HAVE_GETRANDOM_SYSCALL)
-#    include <sys/syscall.h>      // SYS_getrandom
+#    include <sys/syscall.h>      // __NR_getrandom
 #  endif
 #endif
 
@@ -128,11 +128,11 @@ py_getrandom(void *buffer, Py_ssize_t size, int blocking, int raise)
 #else
         if (raise) {
             Py_BEGIN_ALLOW_THREADS
-            n = syscall(SYS_getrandom, dest, n, flags);
+            n = syscall(__NR_getrandom, dest, n, flags);
             Py_END_ALLOW_THREADS
         }
         else {
-            n = syscall(SYS_getrandom, dest, n, flags);
+            n = syscall(__NR_getrandom, dest, n, flags);
         }
 #  ifdef _Py_MEMORY_SANITIZER
         if (n > 0) {

--- a/Python/bootstrap_hash.c
+++ b/Python/bootstrap_hash.c
@@ -23,7 +23,10 @@
 #    include <sys/random.h>       // getrandom()
 #  endif
 #  if !defined(HAVE_GETRANDOM) && defined(HAVE_GETRANDOM_SYSCALL)
-#    include <sys/syscall.h>      // __NR_getrandom
+#    include <sys/syscall.h>      // __NR_getrandom, SYS_getrandom
+#    if !defined(SYS_getrandom) && defined(__NR_getrandom)
+#      define SYS_getrandom __NR_getrandom
+#    endif
 #  endif
 #endif
 
@@ -128,11 +131,11 @@ py_getrandom(void *buffer, Py_ssize_t size, int blocking, int raise)
 #else
         if (raise) {
             Py_BEGIN_ALLOW_THREADS
-            n = syscall(__NR_getrandom, dest, n, flags);
+            n = syscall(SYS_getrandom, dest, n, flags);
             Py_END_ALLOW_THREADS
         }
         else {
-            n = syscall(__NR_getrandom, dest, n, flags);
+            n = syscall(SYS_getrandom, dest, n, flags);
         }
 #  ifdef _Py_MEMORY_SANITIZER
         if (n > 0) {

--- a/configure
+++ b/configure
@@ -34096,7 +34096,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
         const size_t buflen = sizeof(buffer);
         const int flags = GRND_NONBLOCK;
         /* ignore the result, Python checks for ENOSYS and EAGAIN at runtime */
-        (void)syscall(SYS_getrandom, buffer, buflen, flags);
+        (void)syscall(__NR_getrandom, buffer, buflen, flags);
         return 0;
     }
 

--- a/configure
+++ b/configure
@@ -34091,12 +34091,16 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
     #include <sys/syscall.h>
     #include <linux/random.h>
 
+    #if !defined(SYS_getrandom) && defined(__NR_getrandom)
+    #  define SYS_getrandom __NR_getrandom
+    #endif
+
     int main(void) {
         char buffer[1];
         const size_t buflen = sizeof(buffer);
         const int flags = GRND_NONBLOCK;
         /* ignore the result, Python checks for ENOSYS and EAGAIN at runtime */
-        (void)syscall(__NR_getrandom, buffer, buflen, flags);
+        (void)syscall(SYS_getrandom, buffer, buflen, flags);
         return 0;
     }
 

--- a/configure
+++ b/configure
@@ -34261,7 +34261,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
     #include <stddef.h>
     #include <unistd.h>
     #include <sys/syscall.h>
-    #include <linux/random.h>
+    #include <linux/random.h>  // GRND_NONBLOCK
 
     #if !defined(SYS_getrandom) && defined(__NR_getrandom)
     #  define SYS_getrandom __NR_getrandom

--- a/configure.ac
+++ b/configure.ac
@@ -7872,7 +7872,7 @@ AC_LINK_IFELSE(
     #include <stddef.h>
     #include <unistd.h>
     #include <sys/syscall.h>
-    #include <linux/random.h>
+    #include <linux/random.h>  // GRND_NONBLOCK
 
     #if !defined(SYS_getrandom) && defined(__NR_getrandom)
     #  define SYS_getrandom __NR_getrandom

--- a/configure.ac
+++ b/configure.ac
@@ -7807,12 +7807,16 @@ AC_LINK_IFELSE(
     #include <sys/syscall.h>
     #include <linux/random.h>
 
+    #if !defined(SYS_getrandom) && defined(__NR_getrandom)
+    #  define SYS_getrandom __NR_getrandom
+    #endif
+
     int main(void) {
         char buffer[1];
         const size_t buflen = sizeof(buffer);
         const int flags = GRND_NONBLOCK;
         /* ignore the result, Python checks for ENOSYS and EAGAIN at runtime */
-        (void)syscall(__NR_getrandom, buffer, buflen, flags);
+        (void)syscall(SYS_getrandom, buffer, buflen, flags);
         return 0;
     }
   ]])

--- a/configure.ac
+++ b/configure.ac
@@ -7812,7 +7812,7 @@ AC_LINK_IFELSE(
         const size_t buflen = sizeof(buffer);
         const int flags = GRND_NONBLOCK;
         /* ignore the result, Python checks for ENOSYS and EAGAIN at runtime */
-        (void)syscall(SYS_getrandom, buffer, buflen, flags);
+        (void)syscall(__NR_getrandom, buffer, buflen, flags);
         return 0;
     }
   ]])


### PR DESCRIPTION
Fall back to the kernel-provided `__NR_getrandom` in configure checks, `os.getrandom()`, and interpreter entropy handling when libc `SYS_getrandom` is not available.

This makes `os.getrandom()` available when building against an older glibc that was itself built with kernel headers lacking the syscall, provided the current kernel headers define __NR_getrandom. This type of build is done in python-build-standalone, astral-sh/python-build-standalone#1188.

<!-- gh-issue-number: gh-153400 -->
* Issue: gh-153400
<!-- /gh-issue-number -->
