### PR TITLE
[3.15] gh-150449: Raise ValueError for sqlite3.Blob slices with a negative step

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1396,6 +1396,19 @@ class BlobTests(unittest.TestCase):
         actual = self.cx.execute("select b from test").fetchone()[0]
         self.assertEqual(actual, expected)
 
+    def test_blob_slice_with_negative_step(self):
+        # gh-150449: this used to raise SystemError
+        for sl in (slice(9, 0, -2), slice(None, None, -1), slice(9, None, -2)):
+            with self.subTest(slice=sl):
+                with self.assertRaises(ValueError):
+                    self.blob[sl]
+                with self.assertRaises(ValueError):
+                    self.blob[sl] = b"1" * len(self.data[sl])
+        # an empty slice selects nothing and is still allowed
+        self.assertEqual(self.blob[3:8:-1], b"")
+        self.blob[3:8:-1] = b""
+        self.assertEqual(self.blob[:], self.data)
+
     def test_blob_set_empty_slice(self):
         self.blob[0:0] = b""
         self.assertEqual(self.blob[:], self.data)

--- a/Misc/NEWS.d/next/Library/2026-08-14-09-28-21.gh-issue-150449.Nf3Qz1.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-14-09-28-21.gh-issue-150449.Nf3Qz1.rst
@@ -1,0 +1,3 @@
+Fix :class:`sqlite3.Blob` slices with a negative step.
+Reading or writing such a slice raised :exc:`SystemError`.
+It now raises :exc:`ValueError`.

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -441,6 +441,12 @@ subscript_slice(pysqlite_Blob *self, PyObject *item)
         return PyBytes_FromStringAndSize(NULL, 0);
     }
 
+    if (step < 0) {
+        PyErr_SetString(PyExc_ValueError,
+                        "Blob doesn't support slices with a negative step");
+        return NULL;
+    }
+
     if (step == 1) {
         return read_multiple(self, len, start);
     }
@@ -546,6 +552,13 @@ ass_subscript_slice(pysqlite_Blob *self, PyObject *item, PyObject *value)
     if (len == 0) {
         PyBuffer_Release(&vbuf);
         return 0;
+    }
+
+    if (step < 0) {
+        PyErr_SetString(PyExc_ValueError,
+                        "Blob doesn't support slices with a negative step");
+        PyBuffer_Release(&vbuf);
+        return -1;
     }
 
     int rc = -1;


### PR DESCRIPTION
Reading or writing a `Blob` slice with a negative step computed a negative length and failed with `SystemError`, which means an internal error.
It now raises `ValueError`.

Empty slices, which select nothing, are still allowed: `blob[3:8:-1]` returns `b""` and assigning `b""` to it is a no-op.

Support for negative steps is added in 3.16 by GH-150450.


<!-- gh-issue-number: gh-150449 -->
* Issue: gh-150449
<!-- /gh-issue-number -->
