### PR TITLE
gh-155781: Hold strong references to sqlite3 converters

### DIFF
--- a/Lib/test/test_free_threading/test_sqlite3.py
+++ b/Lib/test/test_free_threading/test_sqlite3.py
@@ -1,0 +1,54 @@
+import unittest
+
+from test import support
+from test.support import import_helper, threading_helper
+from test.support.threading_helper import run_concurrently
+
+
+sqlite3 = import_helper.import_module("sqlite3")
+
+
+NAME = "FREE_THREADING_RACE"
+NCOLUMNS = 64
+NITER = 3000
+QUERY = "select " + ", ".join(
+    f"'value' as 'c{i} [{NAME}]'" for i in range(NCOLUMNS)
+)
+
+
+@threading_helper.requires_working_threading()
+class TestSQLite3(unittest.TestCase):
+    def test_concurrent_converter_replacement(self):
+        # gh-155781: Converter lookups must retain a strong reference while
+        # another thread updates the public converter registry.
+        class Converter:
+            __slots__ = ("value",)
+
+            def __init__(self, value):
+                self.value = value
+
+            def __call__(self, value):
+                return self.value
+
+        def reader():
+            con = sqlite3.connect(":memory:",
+                                  detect_types=sqlite3.PARSE_COLNAMES)
+            try:
+                for _ in range(NITER):
+                    row = con.execute(QUERY).fetchone()
+                    self.assertEqual(len(row), NCOLUMNS)
+            finally:
+                con.close()
+
+        def mutator():
+            for i in range(NITER * NCOLUMNS):
+                sqlite3.register_converter(NAME, Converter(i))
+                if i % 3 == 0:
+                    sqlite3.converters.pop(NAME, None)
+
+        with support.swap_item(sqlite3.converters, NAME, Converter(0)):
+            run_concurrently([reader] * 8 + [mutator] * 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Misc/NEWS.d/next/Library/2026-08-14-11-12-18.gh-issue-155781.sqlite-converter.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-14-11-12-18.gh-issue-155781.sqlite-converter.rst
@@ -1,0 +1,3 @@
+Fix a possible crash in free-threaded builds when the :mod:`sqlite3`
+converter registry is modified concurrently while a cursor builds its row
+cast map.

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -223,8 +223,11 @@ _pysqlite_get_converter(pysqlite_state *state, const char *keystr,
         return NULL;
     }
 
-    retval = PyDict_GetItemWithError(state->converters, upcase_key);
+    int rc = PyDict_GetItemRef(state->converters, upcase_key, &retval);
     Py_DECREF(upcase_key);
+    if (rc < 0) {
+        return NULL;
+    }
 
     return retval;
 }
@@ -297,10 +300,12 @@ pysqlite_build_row_cast_map(pysqlite_Cursor* self)
         }
 
         if (!converter) {
-            converter = Py_None;
+            converter = Py_NewRef(Py_None);
         }
 
-        if (PyList_Append(self->row_cast_map, converter) != 0) {
+        int rc = PyList_Append(self->row_cast_map, converter);
+        Py_DECREF(converter);
+        if (rc != 0) {
             Py_CLEAR(self->row_cast_map);
             return -1;
         }

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -299,12 +299,9 @@ pysqlite_build_row_cast_map(pysqlite_Cursor* self)
             }
         }
 
-        if (!converter) {
-            converter = Py_NewRef(Py_None);
-        }
-
-        int rc = PyList_Append(self->row_cast_map, converter);
-        Py_DECREF(converter);
+        int rc = PyList_Append(self->row_cast_map,
+                               converter ? converter : Py_None);
+        Py_XDECREF(converter);
         if (rc != 0) {
             Py_CLEAR(self->row_cast_map);
             return -1;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

* Issue: gh-155781

Use `PyDict_GetItemRef()` when looking up registered SQLite converters so the converter remains alive until it has been added to the cursor's row cast map.

Update the caller's reference ownership and add a free-threading regression test that concurrently builds row cast maps and modifies the public converter registry.

Tests:

- `./python -m test -v test_free_threading.test_sqlite3`
- `./python -m test -v test_sqlite3`
- `make patchcheck`