### PR TITLE
gh-153309: Add HTTP QUERY method (RFC 10008) to http library

### DIFF
--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -289,7 +289,7 @@ HTTPConnection Objects
    but there is a request body, one of those
    header fields will be added automatically.  If
    *body* is ``None``, the Content-Length header is set to ``0`` for
-   methods that expect a body (``PUT``, ``POST``, and ``PATCH``).  If
+   methods that expect a body (``PUT``, ``POST``, ``PATCH``, and ``QUERY``).  If
    *body* is a string or a bytes-like object that is not also a
    :term:`file <file object>`, the Content-Length header is
    set to its length.  Any other type of *body* (files
@@ -334,6 +334,9 @@ HTTPConnection Objects
       The *encode_chunked* argument was added.
       No attempt is made to determine the Content-Length for file
       objects.
+
+   .. versionchanged:: next
+      ``QUERY`` was added to the methods that expect a body.
 
 .. method:: HTTPConnection.getresponse()
 

--- a/Doc/library/http.rst
+++ b/Doc/library/http.rst
@@ -194,6 +194,7 @@ Property             Indicates that           Details
        <HTTPMethod.PATCH>,
        <HTTPMethod.POST>,
        <HTTPMethod.PUT>,
+       <HTTPMethod.QUERY>,
        <HTTPMethod.TRACE>]
 
 .. _http-methods:
@@ -217,4 +218,5 @@ Method      Enum Name                           Details
 ``OPTIONS`` ``OPTIONS``                         HTTP Semantics :rfc:`9110`, Section 9.3.7
 ``TRACE``   ``TRACE``                           HTTP Semantics :rfc:`9110`, Section 9.3.8
 ``PATCH``   ``PATCH``                           HTTP/1.1 :rfc:`5789`
+``QUERY``   ``QUERY``                           The HTTP QUERY Method :rfc:`10008`
 =========== =================================== ==================================================================

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -305,6 +305,13 @@ gzip
   which is passed on to the constructor of the :class:`~gzip.GzipFile` class.
   (Contributed by Marin Misur in :gh:`91372`.)
 
+
+http
+----
+
+* Add the ``QUERY`` HTTP method (:rfc:`10008`) to :class:`~http.HTTPMethod`.
+  (Contributed by Michiel W. Beijen in :gh:`153309`.)
+
 io
 --
 

--- a/Lib/http/__init__.py
+++ b/Lib/http/__init__.py
@@ -192,6 +192,7 @@ class HTTPMethod:
 
         * RFC 9110: HTTP Semantics, obsoletes 7231, which obsoleted 2616
         * RFC 5789: PATCH Method for HTTP
+        * RFC 10008: The HTTP QUERY Method
     """
     def __new__(cls, value, description):
         obj = str.__new__(cls, value)
@@ -210,4 +211,5 @@ class HTTPMethod:
     PATCH = 'PATCH', 'Apply partial modifications to a target.'
     POST = 'POST', 'Perform target-specific processing with the request payload.'
     PUT = 'PUT', 'Replace the target with the request payload.'
+    QUERY = 'QUERY', 'Request that the target process the request payload in a safe and idempotent manner.'
     TRACE = 'TRACE', 'Perform a message loop-back test along the path to the target.'

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -167,7 +167,7 @@ _contains_disallowed_method_pchar_re = re.compile('[\x00-\x1f]')
 
 # We always set the Content-Length header for these methods because some
 # servers will otherwise respond with a 411
-_METHODS_EXPECTING_BODY = {'PATCH', 'POST', 'PUT'}
+_METHODS_EXPECTING_BODY = {'PATCH', 'POST', 'PUT', 'QUERY'}
 
 
 def _encode(data, name='data'):

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -179,7 +179,7 @@ class HeaderTests(TestCase):
         # Here, we're testing that methods expecting a body get a
         # content-length set to zero if the body is empty (either None or '')
         bodies = (None, '')
-        methods_with_body = ('PUT', 'POST', 'PATCH')
+        methods_with_body = ('PUT', 'POST', 'PATCH', 'QUERY')
         for method, body in itertools.product(methods_with_body, bodies):
             conn = client.HTTPConnection('example.com')
             conn.sock = FakeSocket(None)
@@ -527,6 +527,34 @@ class HttpMethodTests(TestCase):
                 conn = client.HTTPConnection('example.com')
                 conn.sock = FakeSocket(None)
                 conn.request(method=method, url="/")
+
+    def test_query_request(self):
+        # QUERY (RFC 10008) is sent with a body, like PUT/POST/PATCH.
+        conn = client.HTTPConnection('example.com')
+        conn.sock = FakeSocket(None)
+        conn.request('QUERY', '/contacts', body='name=python',
+                     headers={'Content-Type': 'application/x-www-form-urlencoded'})
+        self.assertEqual(conn.sock.data,
+                         b'QUERY /contacts HTTP/1.1\r\n'
+                         b'Host: example.com\r\n'
+                         b'Accept-Encoding: identity\r\n'
+                         b'Content-Length: 11\r\n'
+                         b'Content-Type: application/x-www-form-urlencoded\r\n'
+                         b'\r\n'
+                         b'name=python')
+
+    def test_query_request_no_body(self):
+        # A QUERY without a body still gets Content-Length: 0, since some
+        # servers respond with 411 otherwise.
+        conn = client.HTTPConnection('example.com')
+        conn.sock = FakeSocket(None)
+        conn.request('QUERY', '/contacts')
+        self.assertEqual(conn.sock.data,
+                         b'QUERY /contacts HTTP/1.1\r\n'
+                         b'Host: example.com\r\n'
+                         b'Accept-Encoding: identity\r\n'
+                         b'Content-Length: 0\r\n'
+                         b'\r\n')
 
 
 class TransferEncodingTest(TestCase):

--- a/Lib/wsgiref/validate.py
+++ b/Lib/wsgiref/validate.py
@@ -334,7 +334,7 @@ def check_environ(environ):
 
     # @@: these need filling out:
     if environ['REQUEST_METHOD'] not in (
-        'GET', 'HEAD', 'POST', 'OPTIONS', 'PATCH', 'PUT', 'DELETE', 'TRACE'):
+        'GET', 'HEAD', 'POST', 'OPTIONS', 'PATCH', 'PUT', 'DELETE', 'QUERY', 'TRACE'):
         warnings.warn(
             "Unknown REQUEST_METHOD: %r" % environ['REQUEST_METHOD'],
             WSGIWarning)

--- a/Misc/NEWS.d/next/Library/2026-07-08-09-05-01.gh-issue-153309.g94LSO.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-08-09-05-01.gh-issue-153309.g94LSO.rst
@@ -1,0 +1,1 @@
+:mod:`http`: Add the HTTP QUERY method (:rfc:`10008`) to :class:`~http.HTTPMethod`.


### PR DESCRIPTION
RFC 10008: The HTTP QUERY Method is now a finalized [RFC](https://www.rfc-editor.org/info/rfc10008/) on the Standards track, and the method name has been added to the [IANA registry](https://www.iana.org/assignments/http-methods/http-methods.xhtml)

Add it to http library HTTPMethod enum, too

<!-- gh-issue-number: gh-153309 -->
* Issue: gh-153309
<!-- /gh-issue-number -->


This is the second try of #153310