### PR TITLE
gh-155799: Fix incorrect anchor links

### DIFF
--- a/Doc/c-api/memoryview.rst
+++ b/Doc/c-api/memoryview.rst
@@ -2,11 +2,11 @@
 
 .. _memoryview-objects:
 
-.. index::
-   pair: object; memoryview
-
 MemoryView objects
 ------------------
+
+.. index::
+   pair: object; memoryview
 
 A :class:`memoryview` object exposes the C level :ref:`buffer interface
 <bufferobjects>` as a Python object which can then be passed around like

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -136,12 +136,12 @@ exception.
 
 .. _private-name-mangling:
 
+Private name mangling
+^^^^^^^^^^^^^^^^^^^^^
+
 .. index::
    pair: name; mangling
    pair: private; names
-
-Private name mangling
-^^^^^^^^^^^^^^^^^^^^^
 
 When an identifier that textually occurs in a class definition begins with two
 or more underscore characters and does not end in two or more underscores, it
@@ -2669,12 +2669,12 @@ expression. (To create an empty tuple, use an empty pair of parentheses:
 
 .. _iterable-unpacking:
 
+Iterable unpacking
+------------------
+
 .. index::
    pair: iterable; unpacking
    single: * (asterisk); in expression lists
-
-Iterable unpacking
-------------------
 
 In an expression list or tuple, list or set display, any expression
 may be prefixed with an asterisk (``*``).


### PR DESCRIPTION
Fixed by swapping the heading and index directive.

This has resolved `#private-name-mangling` and `#memoryview-objects`.

However I cannot see why `#identifiers-names` is still wrong. It is identical to the "Literals" heading which is correct.


<!-- gh-issue-number: gh-155799 -->
* Issue: gh-155799
<!-- /gh-issue-number -->
