### PR TITLE
[3.13] gh-154753: Update references to moved files in the docs (GH-155553)

### DIFF
--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -1405,7 +1405,7 @@ Finally it should be mentioned that Capsules offer additional functionality,
 which is especially useful for memory allocation and deallocation of the pointer
 stored in a Capsule. The details are described in the Python/C API Reference
 Manual in the section :ref:`capsules` and in the implementation of Capsules (files
-:file:`Include/pycapsule.h` and :file:`Objects/pycapsule.c` in the Python source
+:file:`Include/pycapsule.h` and :file:`Objects/capsule.c` in the Python source
 code distribution).
 
 .. rubric:: Footnotes

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1660,8 +1660,8 @@ always available. Unless explicitly noted otherwise, all variables are read-only
       The interpreter is about to execute a new line of code or re-execute the
       condition of a loop.  The local trace function is called; *arg* is
       ``None``; the return value specifies the new local trace function.  See
-      :file:`Objects/lnotab_notes.txt` for a detailed explanation of how this
-      works.
+      :attr:`~codeobject.co_lnotab` for information about the mapping from
+      bytecode offsets to line numbers.
       Per-line events may be disabled for a frame by setting
       :attr:`~frame.f_trace_lines` to :const:`False` on that
       :ref:`frame <frame-objects>`.

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1660,8 +1660,8 @@ always available. Unless explicitly noted otherwise, all variables are read-only
       The interpreter is about to execute a new line of code or re-execute the
       condition of a loop.  The local trace function is called; *arg* is
       ``None``; the return value specifies the new local trace function.  See
-      :attr:`~codeobject.co_lnotab` for information about the mapping from
-      bytecode offsets to line numbers.
+      :file:`Objects/lnotab_notes.txt` for a detailed explanation of how this
+      works.
       Per-line events may be disabled for a frame by setting
       :attr:`~frame.f_trace_lines` to :const:`False` on that
       :ref:`frame <frame-objects>`.


### PR DESCRIPTION
(cherry picked from commit 58a620ae485c967f976fa6ea9082396aa5411389)

Co-authored-by: Bhuvansh [[bhuvanshkataria@gmail.com](mailto:bhuvanshkataria@gmail.com)](mailto:bhuvanshkataria@gmail.com)

<!-- gh-issue-number: gh-154753 -->

* Issue: gh-154753

<!-- /gh-issue-number -->

Backport the applicable documentation fixes from GH-155553 to the 3.13 branch.

The `Platforms/` path changes are intentionally not included because 3.13 still uses the pre-reorganization Android and Apple source tree layout.

The backport updates the stale Capsule implementation reference and replaces the removed `Objects/lnotab_notes.txt` reference with the existing `codeobject.co_lnotab` documentation.