### PR TITLE
gh-155819: Add `const` qualifier to `Py_buffer.format`

### DIFF
--- a/Include/pybuffer.h
+++ b/Include/pybuffer.h
@@ -25,7 +25,7 @@ typedef struct {
                              pointed to by strides in simple case.*/
     int readonly;
     int ndim;
-    char *format;
+    const char *format;
     Py_ssize_t *shape;
     Py_ssize_t *strides;
     Py_ssize_t *suboffsets;

--- a/Misc/NEWS.d/next/C_API/2026-08-14-20-39-52.gh-issue-155819.rnxJf1.rst
+++ b/Misc/NEWS.d/next/C_API/2026-08-14-20-39-52.gh-issue-155819.rnxJf1.rst
@@ -1,0 +1,3 @@
+The member ``format`` of ``Py_buffer`` is now of type ``const char *``
+rather than of type ``char *``.  Contributed by High Performance Kernels
+LLC.

--- a/Modules/_testbuffer.c
+++ b/Modules/_testbuffer.c
@@ -165,7 +165,7 @@ ndbuf_free(ndbuf_t *ndbuf)
     Py_buffer *base = &ndbuf->base;
 
     PyMem_XFree(ndbuf->data);
-    PyMem_XFree(base->format);
+    PyMem_XFree((void*)base->format);
     PyMem_XFree(base->shape);
     PyMem_XFree(base->strides);
     PyMem_XFree(base->suboffsets);
@@ -666,7 +666,7 @@ ndarray_as_list(NDArrayObject *nd)
     Py_ssize_t simple_strides[1];
     char *item = NULL;
     PyObject *format;
-    char *fmt = base->format;
+    const char *fmt = base->format;
 
     base = &nd->head->base;
 

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -2907,7 +2907,7 @@ array_buffer_getbuf(PyObject *op, Py_buffer *view, int flags)
     view->format = NULL;
     view->internal = NULL;
     if ((flags & PyBUF_FORMAT) == PyBUF_FORMAT) {
-        view->format = (char *)self->ob_descr->typecode;
+        view->format = self->ob_descr->typecode;
     }
 
     self->ob_exports++;

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -123,7 +123,7 @@ mbuf_dealloc(PyObject *_self)
     assert(self->exports == 0);
     mbuf_release(self);
     if (self->flags&_Py_MANAGED_BUFFER_FREE_FORMAT)
-        PyMem_Free(self->master.format);
+        PyMem_Free((void*)self->master.format);
     PyObject_GC_Del(self);
 }
 

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -1340,7 +1340,7 @@ cast_to_1D(PyMemoryViewObject *mv, PyObject *format)
         goto out;
     }
 
-    view->format = (char *)get_native_fmtstr(PyBytes_AS_STRING(asciifmt));
+    view->format = get_native_fmtstr(PyBytes_AS_STRING(asciifmt));
     if (view->format == NULL) {
         /* NOT_REACHED: get_native_fmtchar() already validates the format. */
         PyErr_SetString(PyExc_RuntimeError,


### PR DESCRIPTION
The member `format` of `Py_buffer` is changed to type `const char *` rather than type `char *`.

<!-- gh-issue-number: gh-155819 -->
* Issue: gh-155819
<!-- /gh-issue-number -->
