### PR TITLE
gh-155811: Add a seqcount to `gc_stats` to prevent torn reads

### DIFF
--- a/Include/internal/pycore_interp_structs.h
+++ b/Include/internal/pycore_interp_structs.h
@@ -219,6 +219,7 @@ struct gc_old_stats_buffer {
 struct gc_stats {
     struct gc_young_stats_buffer young;
     struct gc_old_stats_buffer old[2];
+    uint32_t update_seq;
 };
 
 struct _gc_runtime_state {

--- a/Misc/NEWS.d/next/Library/2026-08-15-10-20-40.gh-issue-155811.knP-YB.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-15-10-20-40.gh-issue-155811.knP-YB.rst
@@ -1,0 +1,3 @@
+Add a sequence counter to GC statistics to prevent :mod:`!_remote_debugging`
+returning inconsistent snapshots caused by non-atomic reads. Patch by Maurycy
+Pawłowski-Wieroński.

--- a/Modules/_remote_debugging/gc_stats.c
+++ b/Modules/_remote_debugging/gc_stats.c
@@ -103,11 +103,35 @@ get_gc_stats_from_interpreter_state(RuntimeOffsets *offsets,
     }
 
     struct gc_stats stats;
+    uintptr_t sequence_address = gc_stats_addr
+        + offsetof(struct gc_stats, update_seq);
+    uint32_t before;
+    if (_Py_RemoteDebug_ReadRemoteMemory(&offsets->handle,
+                                         sequence_address,
+                                         sizeof(before), &before) < 0) {
+        set_exception_cause(offsets, PyExc_RuntimeError,
+                            "Failed to read GC update sequence");
+        return -1;
+    }
     if (_Py_RemoteDebug_ReadRemoteMemory(&offsets->handle,
                                          gc_stats_addr,
                                          sizeof(stats),
                                          &stats) < 0) {
         set_exception_cause(offsets, PyExc_RuntimeError, "Failed to read GC state");
+        return -1;
+    }
+
+    uint32_t after;
+    if (_Py_RemoteDebug_ReadRemoteMemory(&offsets->handle,
+                                         sequence_address,
+                                         sizeof(after), &after) < 0) {
+        set_exception_cause(offsets, PyExc_RuntimeError,
+                            "Failed to read GC update sequence");
+        return -1;
+    }
+    if (before != after || before != stats.update_seq || (after & 1)) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "GC stats changed while being read; retry later");
         return -1;
     }
 

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1399,6 +1399,12 @@ gc_get_prev_stats(GCState *gcstate, int gen)
 static void
 add_stats(GCState *gcstate, int gen, struct gc_generation_stats *stats)
 {
+    struct gc_stats *generation_stats = gcstate->generation_stats;
+    uint32_t seq = _Py_atomic_load_uint32(&generation_stats->update_seq);
+    assert((seq & 1) == 0);
+    _Py_atomic_store_uint32(&generation_stats->update_seq, seq + 1);
+    _Py_atomic_fence_seq_cst();
+
     struct gc_generation_stats *prev_stats = gc_get_prev_stats(gcstate, gen);
     struct gc_generation_stats *cur_stats = gc_get_stats(gcstate, gen);
 
@@ -1412,9 +1418,8 @@ add_stats(GCState *gcstate, int gen, struct gc_generation_stats *stats)
 
     cur_stats->duration += stats->duration;
     cur_stats->heap_size = stats->heap_size;
-    /* Publish ts_stop last so remote readers do not select a partially
-       updated stats record as the latest collection. */
     cur_stats->ts_stop = stats->ts_stop;
+    _Py_atomic_store_uint32(&generation_stats->update_seq, seq + 2);
 }
 
 /* This is the main function.  Read this to understand how the

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1400,9 +1400,10 @@ static void
 add_stats(GCState *gcstate, int gen, struct gc_generation_stats *stats)
 {
     struct gc_stats *generation_stats = gcstate->generation_stats;
-    uint32_t seq = _Py_atomic_load_uint32(&generation_stats->update_seq);
+    uint32_t seq = _Py_atomic_load_uint32_relaxed(&generation_stats->update_seq);
     assert((seq & 1) == 0);
-    _Py_atomic_store_uint32(&generation_stats->update_seq, seq + 1);
+    /* Odd seq tells the reader that an update is in progress. */
+    _Py_atomic_store_uint32_relaxed(&generation_stats->update_seq, seq + 1);
     _Py_atomic_fence_seq_cst();
 
     struct gc_generation_stats *prev_stats = gc_get_prev_stats(gcstate, gen);
@@ -1419,7 +1420,7 @@ add_stats(GCState *gcstate, int gen, struct gc_generation_stats *stats)
     cur_stats->duration += stats->duration;
     cur_stats->heap_size = stats->heap_size;
     cur_stats->ts_stop = stats->ts_stop;
-    _Py_atomic_store_uint32(&generation_stats->update_seq, seq + 2);
+    _Py_atomic_store_uint32_release(&generation_stats->update_seq, seq + 2);
 }
 
 /* This is the main function.  Read this to understand how the

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -2283,6 +2283,11 @@ gc_collect_main(PyThreadState *tstate, int generation, _PyGC_Reason reason)
 
     /* Update stats. */
     PyMutex_Lock(&gcstate->stats_mutex);
+    struct gc_stats *generation_stats = gcstate->generation_stats;
+    uint32_t seq = _Py_atomic_load_uint32(&generation_stats->update_seq);
+    assert((seq & 1) == 0);
+    _Py_atomic_store_uint32(&generation_stats->update_seq, seq + 1);
+    _Py_atomic_fence_seq_cst();
     struct gc_generation_stats *stats = get_stats(gcstate, generation);
     stats->ts_start = start;
     stats->ts_stop = stop;
@@ -2291,6 +2296,7 @@ gc_collect_main(PyThreadState *tstate, int generation, _PyGC_Reason reason)
     stats->uncollectable += n;
     stats->duration += duration;
     stats->candidates += state.candidates;
+    _Py_atomic_store_uint32(&generation_stats->update_seq, seq + 2);
     PyMutex_Unlock(&gcstate->stats_mutex);
 
     GC_STAT_ADD(generation, objects_collected, m);

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -2284,9 +2284,10 @@ gc_collect_main(PyThreadState *tstate, int generation, _PyGC_Reason reason)
     /* Update stats. */
     PyMutex_Lock(&gcstate->stats_mutex);
     struct gc_stats *generation_stats = gcstate->generation_stats;
-    uint32_t seq = _Py_atomic_load_uint32(&generation_stats->update_seq);
+    uint32_t seq = _Py_atomic_load_uint32_relaxed(&generation_stats->update_seq);
     assert((seq & 1) == 0);
-    _Py_atomic_store_uint32(&generation_stats->update_seq, seq + 1);
+    /* Odd seq tells the reader that an update is in progress. */
+    _Py_atomic_store_uint32_relaxed(&generation_stats->update_seq, seq + 1);
     _Py_atomic_fence_seq_cst();
     struct gc_generation_stats *stats = get_stats(gcstate, generation);
     stats->ts_start = start;
@@ -2296,7 +2297,7 @@ gc_collect_main(PyThreadState *tstate, int generation, _PyGC_Reason reason)
     stats->uncollectable += n;
     stats->duration += duration;
     stats->candidates += state.candidates;
-    _Py_atomic_store_uint32(&generation_stats->update_seq, seq + 2);
+    _Py_atomic_store_uint32_release(&generation_stats->update_seq, seq + 2);
     PyMutex_Unlock(&gcstate->stats_mutex);
 
     GC_STAT_ADD(generation, objects_collected, m);


### PR DESCRIPTION
See #155811 for the context.

tl;dr `get_gc_stats` reads the stats without pausing the target (by design), so it can return torn data.

The PR adds a seqcount to `gc_stats` atomically increased by the writer around the stats update on every collection, where odd means it's in progress.

[gcmon](https://github.com/sergey-miryanov/gcmon) is the main consumer.

There's no retry, as per https://github.com/python/cpython/issues/155811#issuecomment-5297952225. It's not needed. `gc.collect()` does not happen that often:

```bash
2026-08-15T10:53:48.504627000+0200 maurycy@gimel /Users/maurycy/work/cpython (gc-mon-seq 1291568?) % sudo ./python.exe gc_seq_collision.py 
successes=1966598 failures=191
GC stats changed while being read; retry later
```

For:

```python
import subprocess
import sys
import time

import _remote_debugging

target = """
import gc
import os
import time

print(os.getpid(), flush=True)
while True:
    gc.collect(0)
    time.sleep(0.01)
"""

p = subprocess.Popen(
    [sys.executable, "-c", target],
    stdout=subprocess.PIPE,
    text=True,
)
try:
    pid = int(p.stdout.readline())
    monitor = _remote_debugging.GCMonitor(pid, debug=True)
    successes = 0
    failures = 0
    messages = set()
    deadline = time.monotonic() + 10.0
    while time.monotonic() < deadline:
        try:
            monitor.get_gc_stats(all_interpreters=False)
            successes += 1
        except RuntimeError as exc:
            failures += 1
            messages.add(str(exc))
    print(f"successes={successes} failures={failures}")
    for message in sorted(messages):
        print(message)
finally:
    p.terminate()
    p.wait()
```

I'm not sure what's optimal non-hacky test. We haven't had one in #152448. To be honest, it's implicitly tested by the current happy-path tests in `test_gc_stats`.

<!-- gh-issue-number: gh-155811 -->
* Issue: gh-155811
<!-- /gh-issue-number -->
