### PR TITLE
gh-155836: Fix IPv6Address.reverse_pointer for addresses with a scope id

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1930,7 +1930,11 @@ class _BaseV6:
         This implements the method described in RFC3596 2.5.
 
         """
-        reverse_chars = self.exploded[::-1].replace(':', '')
+        exploded = self.exploded
+        scope_id = getattr(self, '_scope_id', None)
+        if scope_id:
+            exploded = exploded.replace('%' + scope_id, '', 1)
+        reverse_chars = exploded[::-1].replace(':', '')
         return '.'.join(reverse_chars) + '.ip6.arpa'
 
     @staticmethod

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -2763,6 +2763,14 @@ class IpaddrUnitTest(unittest.TestCase):
                     '2.0.0.0.1.0.0.0.0.0.0.0.1.2.3.4.'
                     'ip6.arpa'
                 )
+             ),
+            # a scope id is not part of the pointer name
+            (
+                'fe80::1%eth0', (
+                    '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.'
+                    '0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f.'
+                    'ip6.arpa'
+                )
              )
         ]:
             with self.subTest('ipv6_reverse_pointer', addr=addr_v6):

--- a/Misc/NEWS.d/next/Library/2026-08-15-10-00-00.gh-issue-155836.Rv6Ptr.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-15-10-00-00.gh-issue-155836.Rv6Ptr.rst
@@ -1,0 +1,3 @@
+Fix :attr:`ipaddress.IPv6Address.reverse_pointer` returning an invalid name
+for an address carrying a scope id; the scope id is no longer spliced into the
+reverse DNS pointer.


### PR DESCRIPTION
``_reverse_pointer`` derives from ``self.exploded``, which since gh-88178
carries the ``%scope_id`` suffix. Strip the scope id before building the
pointer so it is not spliced into the reversed nibbles.


<!-- gh-issue-number: gh-155836 -->
* Issue: gh-155836
<!-- /gh-issue-number -->
