### PR TITLE
gh-155850: Fix array unpickling of odd-length 'w' arrays across endianness

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -254,20 +254,26 @@ class ArrayReconstructorTest(unittest.TestCase):
         self.assertEqual(b_be.tolist(), [1.5])
 
     def test_unicode(self):
-        teststr = "Bonne Journ\xe9e \U0002030a\U00020347"
         testcases = (
             (UTF16_LE, "UTF-16-LE"),
             (UTF16_BE, "UTF-16-BE"),
             (UTF32_LE, "UTF-32-LE"),
             (UTF32_BE, "UTF-32-BE")
         )
-        for testcase in testcases:
-            mformat_code, encoding = testcase
-            a = array.array('w', teststr)
-            b = array_reconstructor(
-                array.array, 'w', mformat_code, teststr.encode(encoding))
-            self.assertEqual(a, b,
-                msg="{0!r} != {1!r}; testcase={2!r}".format(a, b, testcase))
+        # An even and an odd number of code points: the reconstructor's
+        # slow-path length check used a wrong item size for UTF-16/UTF-32,
+        # which rejected odd-length input.
+        for teststr in ("Bonne Journ\xe9e \U0002030a\U00020347",
+                        "Bonne Journ\xe9e \U0002030a\U00020347!"):
+            for testcase in testcases:
+                mformat_code, encoding = testcase
+                a = array.array('w', teststr)
+                b = array_reconstructor(
+                    array.array, 'w', mformat_code, teststr.encode(encoding))
+                self.assertEqual(
+                    a, b,
+                    msg="{0!r} != {1!r}; testcase={2!r}".format(
+                        a, b, testcase))
 
 
 class BaseTest:

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -260,9 +260,7 @@ class ArrayReconstructorTest(unittest.TestCase):
             (UTF32_LE, "UTF-32-LE"),
             (UTF32_BE, "UTF-32-BE")
         )
-        # An even and an odd number of code points: the reconstructor's
-        # slow-path length check used a wrong item size for UTF-16/UTF-32,
-        # which rejected odd-length input.
+        # An even and an odd length; odd lengths were wrongly rejected.
         for teststr in ("Bonne Journ\xe9e \U0002030a\U00020347",
                         "Bonne Journ\xe9e \U0002030a\U00020347!"):
             for testcase in testcases:

--- a/Misc/NEWS.d/next/Library/2026-08-15-15-00-00.gh-issue-155850.ArrUtf.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-15-15-00-00.gh-issue-155850.ArrUtf.rst
@@ -1,0 +1,3 @@
+Fix :mod:`array` unpickling of an odd-length ``'w'`` array pickled on a
+machine of the opposite endianness; a wrong item size for the UTF-16 and
+UTF-32 machine formats made it raise :exc:`ValueError`.

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -2050,10 +2050,10 @@ static const struct mformatdescr {
     {4, 0, 1},                  /* 15: IEEE_754_FLOAT_BE */
     {8, 0, 0},                  /* 16: IEEE_754_DOUBLE_LE */
     {8, 0, 1},                  /* 17: IEEE_754_DOUBLE_BE */
-    {4, 0, 0},                  /* 18: UTF16_LE */
-    {4, 0, 1},                  /* 19: UTF16_BE */
-    {8, 0, 0},                  /* 20: UTF32_LE */
-    {8, 0, 1},                  /* 21: UTF32_BE */
+    {2, 0, 0},                  /* 18: UTF16_LE */
+    {2, 0, 1},                  /* 19: UTF16_BE */
+    {4, 0, 0},                  /* 20: UTF32_LE */
+    {4, 0, 1},                  /* 21: UTF32_BE */
     {8, 0, 0},                  /* 22: IEEE_754_FLOAT_COMPLEX_LE */
     {8, 0, 1},                  /* 23: IEEE_754_FLOAT_COMPLEX_BE */
     {16, 0, 0},                 /* 24: IEEE_754_DOUBLE_COMPLEX_LE */


### PR DESCRIPTION
`mformat_descriptors` stores the byte size of one item, but the UTF-16 rows
said 4 (actual: 2) and the UTF-32 rows said 8 (actual: 4). The field's only
consumer is the length check on the cross-endian unpickling path, so an
odd-length ``'w'`` array pickled on an opposite-endian machine was rejected
with `ValueError: string length not a multiple of item size`. The existing
`test_unicode` used an even-length string; it now also covers an odd length.


<!-- gh-issue-number: gh-155850 -->
* Issue: gh-155850
<!-- /gh-issue-number -->
