### PR TITLE
gh-155852: Do not cancel remaining Executor.map calls on a callable's TimeoutError

### DIFF
--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -310,7 +310,11 @@ def _result_or_cancel(fut, timeout=None):
     try:
         try:
             return (fut.result(timeout), None)
-        except TimeoutError:
+        except TimeoutError as exc:
+            if fut.done():
+                # The future already finished, so this is the callable's own
+                # TimeoutError, not the map() timeout waiting for the future.
+                return (None, exc)
             raise
         except BaseException as exc:
             return (None, exc)

--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -309,21 +309,14 @@ def wait(fs, timeout=None, return_when=ALL_COMPLETED):
 def _result_or_cancel(fut, timeout=None):
     try:
         try:
-            if timeout is not None:
-                # Wait out the timeout separately from retrieving the result, so
-                # that a TimeoutError raised by the call is not mistaken for the
-                # map() timeout.  Future.exception() raises TimeoutError only
-                # when the wait itself times out, never for the call's own.
-                try:
-                    fut.exception(timeout)
-                except TimeoutError:
-                    raise
-                except CancelledError:
-                    pass
-            try:
-                return (fut.result(), None)
-            except BaseException as exc:
+            # fut.exception() returns the call's own error but raises
+            # TimeoutError only for a map() timeout.
+            exc = fut.exception(timeout)
+            if exc is not None:
                 return (None, exc)
+            return (fut.result(), None)
+        except CancelledError as exc:
+            return (None, exc)
         finally:
             fut.cancel()
     finally:

--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -309,15 +309,21 @@ def wait(fs, timeout=None, return_when=ALL_COMPLETED):
 def _result_or_cancel(fut, timeout=None):
     try:
         try:
-            return (fut.result(timeout), None)
-        except TimeoutError as exc:
-            if fut.done():
-                # The future already finished, so this is the callable's own
-                # TimeoutError, not the map() timeout waiting for the future.
+            if timeout is not None:
+                # Wait out the timeout separately from retrieving the result, so
+                # that a TimeoutError raised by the call is not mistaken for the
+                # map() timeout.  Future.exception() raises TimeoutError only
+                # when the wait itself times out, never for the call's own.
+                try:
+                    fut.exception(timeout)
+                except TimeoutError:
+                    raise
+                except CancelledError:
+                    pass
+            try:
+                return (fut.result(), None)
+            except BaseException as exc:
                 return (None, exc)
-            raise
-        except BaseException as exc:
-            return (None, exc)
         finally:
             fut.cancel()
     finally:

--- a/Lib/test/test_concurrent_futures/executor.py
+++ b/Lib/test/test_concurrent_futures/executor.py
@@ -29,7 +29,6 @@ def raiser(exception, msg='std'):
     raise exception(msg)
 
 
-# Used in test_map_timeout_from_callable
 def timeout_on_one(x):
     if x == 1:
         raise TimeoutError
@@ -96,13 +95,17 @@ class ExecutorTest:
 
     @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
     def test_map_timeout_from_callable(self):
-        # A TimeoutError from the callable is not the map() timeout.
-        i = self.executor.map(timeout_on_one, [0, 1, 2, 3])
-        self.assertEqual(next(i), 0)
-        self.assertRaises(TimeoutError, next, i)
-        self.assertEqual(next(i), 2)
-        self.assertEqual(next(i), 3)
-        self.assertRaises(StopIteration, next, i)
+        # A TimeoutError from the callable is not the map() timeout, whether
+        # or not a map() timeout is set.
+        for timeout in (None, support.SHORT_TIMEOUT):
+            with self.subTest(timeout=timeout):
+                i = self.executor.map(timeout_on_one, [0, 1, 2, 3],
+                                      timeout=timeout)
+                self.assertEqual(next(i), 0)
+                self.assertRaises(TimeoutError, next, i)
+                self.assertEqual(next(i), 2)
+                self.assertEqual(next(i), 3)
+                self.assertRaises(StopIteration, next, i)
 
     @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
     @support.requires_resource('walltime')

--- a/Lib/test/test_concurrent_futures/executor.py
+++ b/Lib/test/test_concurrent_futures/executor.py
@@ -96,9 +96,7 @@ class ExecutorTest:
 
     @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
     def test_map_timeout_from_callable(self):
-        # A TimeoutError raised by the mapped callable must not be treated as a
-        # map() timeout: the remaining calls keep running, like any other
-        # exception.
+        # A TimeoutError from the callable is not the map() timeout.
         i = self.executor.map(timeout_on_one, [0, 1, 2, 3])
         self.assertEqual(next(i), 0)
         self.assertRaises(TimeoutError, next, i)

--- a/Lib/test/test_concurrent_futures/executor.py
+++ b/Lib/test/test_concurrent_futures/executor.py
@@ -29,6 +29,13 @@ def raiser(exception, msg='std'):
     raise exception(msg)
 
 
+# Used in test_map_timeout_from_callable
+def timeout_on_one(x):
+    if x == 1:
+        raise TimeoutError
+    return x
+
+
 class FalseyBoolException(Exception):
     def __bool__(self):
         return False
@@ -85,6 +92,18 @@ class ExecutorTest:
         self.assertEqual(next(i), (1, 2))
         self.assertEqual(next(i), (1, 0))
         self.assertRaises(StopIteration, next, i)
+        self.assertRaises(StopIteration, next, i)
+
+    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    def test_map_timeout_from_callable(self):
+        # A TimeoutError raised by the mapped callable must not be treated as a
+        # map() timeout: the remaining calls keep running, like any other
+        # exception.
+        i = self.executor.map(timeout_on_one, [0, 1, 2, 3])
+        self.assertEqual(next(i), 0)
+        self.assertRaises(TimeoutError, next, i)
+        self.assertEqual(next(i), 2)
+        self.assertEqual(next(i), 3)
         self.assertRaises(StopIteration, next, i)
 
     @warnings_helper.ignore_fork_in_thread_deprecation_warnings()

--- a/Misc/NEWS.d/next/Library/2026-08-15-16-00-00.gh-issue-155852.MapTmo.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-15-16-00-00.gh-issue-155852.MapTmo.rst
@@ -1,3 +1,0 @@
-Fix :meth:`concurrent.futures.Executor.map` cancelling the remaining calls when
-the mapped callable raises :exc:`TimeoutError`; such an exception is now
-propagated like any other, without stopping the iteration.

--- a/Misc/NEWS.d/next/Library/2026-08-15-16-00-00.gh-issue-155852.MapTmo.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-15-16-00-00.gh-issue-155852.MapTmo.rst
@@ -1,0 +1,3 @@
+Fix :meth:`concurrent.futures.Executor.map` cancelling the remaining calls when
+the mapped callable raises :exc:`TimeoutError`; such an exception is now
+propagated like any other, without stopping the iteration.


### PR DESCRIPTION
``_result_or_cancel`` re-raised :exc:`TimeoutError` to surface a
``map(timeout=...)`` wait timeout, but a :exc:`TimeoutError` raised by the
callable is the same type, so it aborted ``map()`` and cancelled the remaining
calls -- unlike every other exception since gh-108518. A wait timeout only
happens while the future is still running, so a ``TimeoutError`` from an
already-finished future is the callable's own and is now returned like any
other exception.


<!-- gh-issue-number: gh-155852 -->
* Issue: gh-155852
<!-- /gh-issue-number -->
