### PR TITLE
gh-140866: Document dict view `==` excludes non-set iterables

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5715,6 +5715,13 @@ available (for example, ``==``, ``<``, or ``^``).  While using set operators,
 set-like views accept any iterable as the other operand,
 unlike sets which only accept sets as the input.
 
+Equality (``==``) is an exception to this rule: a set-like view compares equal
+only to another object that is itself set-like (another set-like view, a
+:class:`set`, or a :class:`frozenset`).  Comparing a set-like view to a
+:class:`list`, :class:`tuple`, or other non-set iterable always returns
+``False``, even if the elements match, because such objects are never
+instances of :class:`collections.abc.Set`.
+
 An example of dictionary view usage::
 
    >>> dishes = {'eggs': 2, 'sausage': 1, 'bacon': 1, 'spam': 500}
@@ -5747,6 +5754,13 @@ An example of dictionary view usage::
    >>> keys ^ {'sausage', 'juice'} == {'juice', 'sausage', 'bacon', 'spam'}
    True
    >>> keys | ['juice', 'juice', 'juice'] == {'bacon', 'spam', 'juice'}
+   True
+
+   >>> # unlike other set operators, == does not accept arbitrary iterables:
+   >>> # a list is never equal to a set-like view, regardless of its elements
+   >>> keys == ['bacon', 'spam']
+   False
+   >>> keys == {'bacon', 'spam'}
    True
 
    >>> # get back a read-only proxy for the original dictionary

--- a/Misc/NEWS.d/next/Documentation/2026-08-15-16-12-06.gh-issue-140866.E7AH8z.rst
+++ b/Misc/NEWS.d/next/Documentation/2026-08-15-16-12-06.gh-issue-140866.E7AH8z.rst
@@ -1,0 +1,5 @@
+Clarify that equality comparisons (``==``) between set-like dictionary views
+(:meth:`dict.keys` and :meth:`dict.items`) and non-set iterables such as
+:class:`list` or :class:`tuple` always return ``False``, unlike other
+set-like operators (``&``, ``|``, ``^``) which accept any iterable as the
+other operand.


### PR DESCRIPTION
`collections.abc.Set.__eq__` only returns a real comparison when the other
operand is itself a `Set` instance, so `dict.keys()` / `dict.items()` views
compare equal to another set-like view, `set`, or `frozenset`, but always
compare unequal to a `list` or `tuple` of the same elements — even though the
docs say set-like views "accept any iterable as the other operand" for set
operators like `&`, `|`, and `^`. That sentence doesn't carry over to `==`,
and the docs never said so, which is why users keep reporting it as a bug.

This documents the exception right next to the existing sentence, and
extends the existing dictionary-view doctest example with two lines
demonstrating the asymmetry (`keys == ['bacon', 'spam']` is `False`, but
`keys == {'bacon', 'spam'}` is `True`).

Verified locally: the extended doctest block passes (10/10 examples), and a
full Sphinx build of `library/stdtypes.rst` (`sphinx-build -W --keep-going`)
produces no new warnings.

Fixes #140866


<!-- gh-issue-number: gh-140866 -->
* Issue: gh-140866
<!-- /gh-issue-number -->
