### PR TITLE
gh-155860: Reject a detached window in panel.replace()

### DIFF
--- a/Doc/library/curses.panel.rst
+++ b/Doc/library/curses.panel.rst
@@ -116,6 +116,8 @@ Panel objects
 .. method:: panel.replace(win)
 
    Change the window associated with the panel to the window *win*.
+   Raise :exc:`curses.panel.error` if *win* has been detached from its
+   screen by :meth:`screen.close() <curses.screen.close>`.
 
 
 .. method:: panel.set_userptr(obj)

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -3079,6 +3079,22 @@ class ScreenTests(NewtermTestBase):
         # close() is idempotent.
         screen.close()
 
+    @requires_curses_func('panel')
+    def test_close_then_panel_replace(self):
+        # A detached window has no underlying curses window, so replace()
+        # must reject it.  It used to be accepted, and the panel then
+        # crashed inside curses on its next use.
+        s = self.make_pty()
+        screen = curses.newterm('xterm', s, s)
+        win = screen.stdscr
+        panel = curses.panel.new_panel(curses.newwin(3, 6, 0, 0))
+        # Drop the panel from the global stack before later tests inspect it.
+        self.addCleanup(gc_collect)
+        screen.close()
+        self.assertRaises(curses.panel.error, panel.replace, win)
+        # The panel kept its own window, so it still works.
+        panel.move(1, 1)
+
     @unittest.skipUnless(hasattr(curses, 'new_prescr'),
                          'requires curses.new_prescr()')
     def test_new_prescr(self):

--- a/Modules/_curses_panel.c
+++ b/Modules/_curses_panel.c
@@ -594,6 +594,12 @@ _curses_panel_panel_replace_impl(PyCursesPanelObject *self,
         return NULL;
     }
 
+    if (win->win == NULL) {
+        _curses_panel_state *state = get_curses_panel_state_by_panel(self);
+        PyErr_SetString(state->error, "the window has been detached");
+        return NULL;
+    }
+
     int rtn = replace_panel(self->pan, win->win);
     if (rtn == ERR) {
         curses_panel_panel_set_error(self, "replace_panel", "replace");


### PR DESCRIPTION
Reject a window detached by `curses.screen.close()` in `panel.replace()`, raising `curses.panel.error` the way `new_panel()` already does, and add a regression test. `new_panel()` needs no change: it already rejects that window.

```
$ ./python -m test test_curses -u curses
Total tests: run=169 skipped=3
Result: SUCCESS
```

No NEWS entry: `screen.close()` is new in 3.16 and unreleased, so no released version can reach the crash.

<!-- gh-issue-number: gh-155860 -->
* Issue: gh-155860
<!-- /gh-issue-number -->
