### PR TITLE
gh-155864: Keep the module's current screen in step with use_screen()

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -3056,6 +3056,33 @@ class ScreenTests(NewtermTestBase):
         win.addstr(0, 0, 'still alive')
         win.refresh()
 
+    @unittest.skipUnless(hasattr(curses.screen, 'use'),
+                         'requires curses.screen.use()')
+    def test_window_made_in_use_keeps_its_screen_alive(self):
+        # use() makes its screen current for the callback, so a window created
+        # there belongs to that screen and must keep it alive, not the screen
+        # that was current before.
+        s = self.make_pty()
+        s2 = self.make_pty()
+        a = curses.newterm('xterm', s, s)
+        b = curses.newterm('xterm', s2, s2)   # current screen is b
+        win = a.use(lambda scr: curses.newwin(3, 3))
+        del a
+        gc_collect()
+        win.addstr(0, 0, 'x')
+        b.stdscr.refresh()
+
+    @unittest.skipUnless(hasattr(curses.screen, 'use'),
+                         'requires curses.screen.use()')
+    def test_initscr_in_use_returns_its_screen(self):
+        # initscr() returns the standard window of the current screen, and
+        # inside use() that is the used screen.
+        s = self.make_pty()
+        s2 = self.make_pty()
+        a = curses.newterm('xterm', s, s)
+        b = curses.newterm('xterm', s2, s2)   # current screen is b
+        self.assertIs(a.use(lambda scr: curses.initscr()), a.stdscr)
+
     def test_screen_freed(self):
         # Dropping all references to a (non-current) screen and its windows
         # frees it without error.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -5303,8 +5303,8 @@ static PyObject *
 PyCursesScreen_use(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     PyCursesScreenObject *so = _PyCursesScreenObject_CAST(self);
+    cursesmodule_state *state = get_cursesmodule_state_by_cls(Py_TYPE(self));
     if (so->screen == NULL) {
-        cursesmodule_state *state = get_cursesmodule_state_by_cls(Py_TYPE(self));
         PyErr_SetString(state->error, "the screen has been deleted");
         return NULL;
     }
@@ -5313,7 +5313,10 @@ PyCursesScreen_use(PyObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
     }
     curses_use_data data = {self, func, extra, kwargs, NULL};
+    PyObject *prev = state->topscreen;
+    state->topscreen = Py_NewRef(self);
     use_screen(so->screen, curses_use_screen_cb, &data);
+    Py_SETREF(state->topscreen, prev);
     Py_DECREF(extra);
     return data.result;
 }


### PR DESCRIPTION
Point `state->topscreen` at the used screen for the duration of the `screen.use()` callback and restore it afterwards, which is what `use_screen()` itself does around `set_term()`. Add regression tests for the window ownership and for `initscr()` inside `use()`.

The restore also undoes a `set_term()` performed inside the callback, which ncurses already reverts but the module did not.

```
$ ./python -m test test_curses -u curses
Total tests: run=170 skipped=3
Result: SUCCESS
```

No NEWS entry: `newterm()` and `screen.use()` are new in 3.16 and unreleased.

<!-- gh-issue-number: gh-155864 -->
* Issue: gh-155864
<!-- /gh-issue-number -->
