### PR TITLE
gh-155869: Fix data loss in `dbm.dumb.reorganize()`

### DIFF
--- a/Lib/dbm/dumb.py
+++ b/Lib/dbm/dumb.py
@@ -311,6 +311,7 @@ class _Database(collections.abc.MutableMapping):
                 reorganize_pos += blocks_occupied * _BLOCKSIZE
 
             f.truncate(reorganize_pos)
+        self._modified = True
         # Commit changes to index, which were not in-place.
         self._commit()
 

--- a/Lib/test/test_dbm_dumb.py
+++ b/Lib/test/test_dbm_dumb.py
@@ -114,6 +114,16 @@ class DumbDBMTestCase(unittest.TestCase):
         with contextlib.closing(dumbdbm.open(_fname)) as f:
             self.assertEqual(f[b'1'], b'hello2')
 
+    def test_reorganize_persists_changed_offsets(self):
+        with dumbdbm.open(_fname, 'n') as f:
+            f[b'deleted'] = b'x'
+            f[b'retained'] = b'value'
+            del f[b'deleted']
+            f.reorganize()
+
+        with dumbdbm.open(_fname, 'r') as f:
+            self.assertEqual(f[b'retained'], b'value')
+
     def test_str_read(self):
         self.init_db()
         with contextlib.closing(dumbdbm.open(_fname, 'r')) as f:

--- a/Misc/NEWS.d/next/Library/2026-08-15-21-55-31.gh-issue-155869.yRUnQW.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-15-21-55-31.gh-issue-155869.yRUnQW.rst
@@ -1,0 +1,2 @@
+Fix :meth:`!reorganize` in :mod:`dbm.dumb` failing to persist updated value
+offsets, which could cause data loss after reopening the database.


### PR DESCRIPTION
`dbm.dumb.reorganize()` can move values without persisting their new offsets. Persist the changed index and add a regression test.

<!-- gh-issue-number: gh-155869 -->
* Issue: gh-155869
<!-- /gh-issue-number -->
