### PR TITLE
gh-139103: Defer reference count mutable class attributes

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-15-23-32-52.gh-issue-139103.d8pm7q.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-15-23-32-52.gh-issue-139103.d8pm7q.rst
@@ -1,0 +1,1 @@
+Enable deferred reference counting for mutable class attributes to improve free-threading scaling

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1216,6 +1216,9 @@ specialize_class_load_attr(PyObject *owner, _Py_CODEUNIT *instr,
             // special case for enums which has Py_TYPE(descr) == cls
             // so guarding on type version is sufficient
             if (Py_TYPE(descr) != cls) {
+#ifdef Py_GIL_DISABLED
+                maybe_enable_deferred_ref_count(descr);
+#endif
                 SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_ATTR_MUTABLE_CLASS);
                 Py_XDECREF(descr);
                 return -1;

--- a/Tools/ftscalingbench/ftscalingbench.py
+++ b/Tools/ftscalingbench/ftscalingbench.py
@@ -326,6 +326,25 @@ def enum_attr():
         MyEnum.Z
 
 
+class _SharedAttrValue:
+    pass
+
+class MyClassWithSharedAttr:
+    # A class attribute whose value is an instance of a *different* class.
+    # Reading it from multiple threads did not scale because LOAD_ATTR_CLASS
+    # cannot specialize this case (the value's type is not the owner class),
+    # leaving the shared value's reference count contended on every read.
+    attr = _SharedAttrValue()
+
+@register_benchmark
+def class_attribute():
+    obj = MyClassWithSharedAttr
+    for _ in range(1000 * WORK_SCALE):
+        obj.attr
+        obj.attr
+        obj.attr
+
+
 def bench_one_thread(func):
     t0 = time.perf_counter_ns()
     func()


### PR DESCRIPTION
Mutable class attributes would not scale with more threads, adding defered reference counting to resolve it.

./python_main.exe Tools/ftscalingbench/ftscalingbench.py class_attribute Running benchmarks with 18 threads
class_attribute            6.3x slower

./python.exe Tools/ftscalingbench/ftscalingbench.py class_attribute Running benchmarks with 18 threads
class_attribute            8.0x faster

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-139103 -->
* Issue: gh-139103
<!-- /gh-issue-number -->
