### PR TITLE
gh-155877: Reject an embedded NUL in curses cell text

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -895,6 +895,25 @@ class TestCurses(unittest.TestCase):
                 self.assertRaises(ValueError, stdscr.insstr, arg)
                 self.assertRaises(ValueError, stdscr.insnstr, arg, 1)
 
+    def test_cell_embedded_null_chars(self):
+        # A cell cannot hold a NUL: setcchar() keeps only the text before it,
+        # so reject it instead of silently truncating the cell.
+        stdscr = self.stdscr
+        for text in ['a\0', '\0', 'a\0\u0301', 'a\0b']:
+            with self.subTest(text=text):
+                self.assertRaises(ValueError, curses.complexchar, text)
+                self.assertRaises(ValueError, curses.complexstr, text)
+                self.assertRaises(ValueError, curses.complexstr, [text])
+        if WIDE_BUILD:
+            self.assertRaises(ValueError, stdscr.addch, 'a\0\u0301')
+        # A lone NUL is still written as a character, like addch(0).
+        stdscr.erase()
+        stdscr.addch(0, 0, 0)
+        expected = stdscr.instr(0, 0, 4)
+        stdscr.erase()
+        stdscr.addch(0, 0, '\0')
+        self.assertEqual(stdscr.instr(0, 0, 4), expected)
+
     def test_add_string_behavior(self):
         # addstr() advances the cursor past the written text; addnstr()
         # writes at most n characters.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -561,6 +561,10 @@ PyCurses_ConvertToWideCell(PyObject *obj, wchar_t *wch)
        setcchar() would silently drop a trailing spacing character, or fail
        with a generic error for a control-character base. */
     if (nch > 1) {
+        if (wmemchr(wch, L'\0', nch) != NULL) {
+            PyErr_SetString(PyExc_ValueError, "embedded null character");
+            return -1;
+        }
         int bad = wcwidth(wch[0]) < 0;
         for (Py_ssize_t i = 1; !bad && i < nch; i++) {
             bad = wcwidth(wch[i]) != 0;
@@ -835,6 +839,10 @@ static int
 curses_cell_pack(cursesmodule_state *state, curses_cell_t *cell,
                  PyObject *text, attr_t attr, int pair, const char *funcname)
 {
+    if (PyUnicode_FindChar(text, 0, 0, PyUnicode_GET_LENGTH(text), 1) >= 0) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
+        return -1;
+    }
 #ifdef HAVE_NCURSESW
     wchar_t wstr[CCHARW_MAX + 1];
     if (PyCurses_ConvertToWideCell(text, wstr) < 0) {
@@ -1318,6 +1326,10 @@ static PyObject *
 complexstr_from_string(cursesmodule_state *state, PyObject *str,
                        attr_t attr, int pair)
 {
+    if (PyUnicode_FindChar(str, 0, 0, PyUnicode_GET_LENGTH(str), 1) >= 0) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
+        return NULL;
+    }
 #ifdef HAVE_NCURSESW
     Py_ssize_t n;
     wchar_t *wbuf = PyUnicode_AsWideCharString(str, &n);


### PR DESCRIPTION
`curses.complexchar()` and `curses.complexstr()` now reject a text containing a NUL, and the shared cell converter rejects a NUL inside a multi-character cell, so `window.addch()` and its siblings no longer keep only the text before it. A lone NUL is still written like `addch(0)`.

```
$ ./python -m test test_curses -u curses -v -m test_cell_embedded_null_chars
test_cell_embedded_null_chars (test.test_curses.TestCurses.test_cell_embedded_null_chars) ... ok
Total tests: run=1 (filtered)
Result: SUCCESS

$ ./python -m test test_curses -u curses
Total tests: run=169 skipped=3
Result: SUCCESS
```

No NEWS entry: the cell API has not been released.


<!-- gh-issue-number: gh-155877 -->
* Issue: gh-155877
<!-- /gh-issue-number -->
