### PR TITLE
gh-100900: Quote non-ASCII display names containing specials in formataddr

### DIFF
--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -101,6 +101,10 @@ def formataddr(pair, charset='utf-8', *, strict=True):
                 from email.charset import Charset
                 charset = Charset(charset)
             encoded_name = charset.header_encode(name)
+            if specialsre.search(encoded_name):
+                # Not RFC 2047-encoded, so quote it like the ASCII branch
+                # below to keep specials from leaking into the header.
+                encoded_name = '"' + escapesre.sub(r'\\\g<0>', encoded_name) + '"'
             return "%s <%s>" % (encoded_name, address)
         else:
             quotes = ''

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3308,6 +3308,32 @@ class TestMiscellaneous(TestEmailBase):
         # formataddr() quotes the name if there's a dot in it
         self.assertEqual(utils.formataddr((a, b)), y)
 
+    def test_formataddr_non_ascii_name_with_specials(self):
+        # gh-100900: when the charset is configured not to RFC 2047-encode the
+        # display name, formataddr() must still quote a non-ASCII name that
+        # contains specials, the same way its ASCII branch does, so the result
+        # round-trips through getaddresses() instead of splitting on the comma.
+        from email import charset as _charset
+        sentinel = object()
+        previous = _charset.CHARSETS.get('utf-8', sentinel)
+        def restore():
+            if previous is sentinel:
+                _charset.CHARSETS.pop('utf-8', None)
+            else:
+                _charset.CHARSETS['utf-8'] = previous
+        self.addCleanup(restore)
+        _charset.add_charset('utf-8', None)  # do not RFC 2047-encode the name
+        formatted = utils.formataddr(('Fôo, Bar', 'a@b.com'))
+        self.assertEqual(formatted, '"Fôo, Bar" <a@b.com>')
+        self.assertEqual(utils.getaddresses([formatted]),
+                         [('Fôo, Bar', 'a@b.com')])
+        # A non-ASCII name without specials is still emitted unquoted.
+        self.assertEqual(utils.formataddr(('Fôo Bar', 'a@b.com')),
+                         'Fôo Bar <a@b.com>')
+        # The ASCII branch is unchanged.
+        self.assertEqual(utils.formataddr(('Foo, Bar', 'a@b.com')),
+                         '"Foo, Bar" <a@b.com>')
+
     def test_parseaddr_preserves_quoted_pairs_in_addresses(self):
         # issue 10005.  Note that in the third test the second pair of
         # backslashes is not actually a quoted pair because it is not inside a

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3309,30 +3309,22 @@ class TestMiscellaneous(TestEmailBase):
         self.assertEqual(utils.formataddr((a, b)), y)
 
     def test_formataddr_non_ascii_name_with_specials(self):
-        # gh-100900: when the charset is configured not to RFC 2047-encode the
-        # display name, formataddr() must still quote a non-ASCII name that
-        # contains specials, the same way its ASCII branch does, so the result
-        # round-trips through getaddresses() instead of splitting on the comma.
-        from email import charset as _charset
-        sentinel = object()
-        previous = _charset.CHARSETS.get('utf-8', sentinel)
-        def restore():
-            if previous is sentinel:
-                _charset.CHARSETS.pop('utf-8', None)
-            else:
-                _charset.CHARSETS['utf-8'] = previous
-        self.addCleanup(restore)
-        _charset.add_charset('utf-8', None)  # do not RFC 2047-encode the name
-        formatted = utils.formataddr(('Fôo, Bar', 'a@b.com'))
+        # gh-100900: with a charset that doesn't RFC 2047-encode the name,
+        # formataddr() must still quote a non-ASCII name containing specials
+        # so it round-trips through getaddresses().
+        charset = Charset('utf-8')
+        charset.header_encoding = None
+        formatted = utils.formataddr(('Fôo, Bar', 'a@b.com'), charset)
         self.assertEqual(formatted, '"Fôo, Bar" <a@b.com>')
-        self.assertEqual(utils.getaddresses([formatted]),
-                         [('Fôo, Bar', 'a@b.com')])
-        # A non-ASCII name without specials is still emitted unquoted.
-        self.assertEqual(utils.formataddr(('Fôo Bar', 'a@b.com')),
+        self.assertEqual(utils.getaddresses([formatted]), [('Fôo, Bar', 'a@b.com')])
+        # " and \ in the name are escaped within the quotes.
+        name = 'Fô"o\\Bar'
+        formatted = utils.formataddr((name, 'a@b.com'), charset)
+        self.assertEqual(formatted, '"Fô\\"o\\\\Bar" <a@b.com>')
+        self.assertEqual(utils.getaddresses([formatted]), [(name, 'a@b.com')])
+        # A non-ASCII name without specials is emitted unquoted.
+        self.assertEqual(utils.formataddr(('Fôo Bar', 'a@b.com'), charset),
                          'Fôo Bar <a@b.com>')
-        # The ASCII branch is unchanged.
-        self.assertEqual(utils.formataddr(('Foo, Bar', 'a@b.com')),
-                         '"Foo, Bar" <a@b.com>')
 
     def test_parseaddr_preserves_quoted_pairs_in_addresses(self):
         # issue 10005.  Note that in the third test the second pair of

--- a/Misc/NEWS.d/next/Library/2026-08-16-02-24-32.gh-issue-100900.y7FWJM.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-16-02-24-32.gh-issue-100900.y7FWJM.rst
@@ -1,0 +1,4 @@
+Fix :func:`email.utils.formataddr` failing to quote a non-ASCII display name
+that contains special characters when the charset is configured not to
+RFC 2047-encode it, which broke round-tripping through
+:func:`~email.utils.getaddresses`.  Patch by Nikolaus Schuetz.


### PR DESCRIPTION
`formataddr` quotes an ASCII display name that contains specials (e.g. a comma in a `"Last, First"` name), but the non-ASCII branch returned `charset.header_encode(name)` unquoted. When the charset is configured not to RFC 2047-encode the name (e.g. `add_charset('utf-8', None)`), `header_encode` is a no-op, so a comma in the name is emitted bare and the header parses back as two addresses through `getaddresses`.

Quote the non-ASCII name when it still contains specials, mirroring the ASCII branch — default-charset output is unchanged, since a real RFC 2047 encoded word never contains specials. Adds a regression test.

Thanks to @tonghuaroot for confirming and pinpointing this on the issue.

Fixes #100900


<!-- gh-issue-number: gh-100900 -->
* Issue: gh-100900
<!-- /gh-issue-number -->
