### PR TITLE
gh-155606: Increment the managed buffer export count atomically

### DIFF
--- a/Lib/test/test_free_threading/test_memoryview.py
+++ b/Lib/test/test_free_threading/test_memoryview.py
@@ -1,0 +1,36 @@
+import threading
+import unittest
+
+from test.support import threading_helper
+
+
+@threading_helper.requires_working_threading()
+class TestMemoryViewSliceRace(unittest.TestCase):
+    def test_concurrent_slicing_keeps_export_count(self):
+        # gh-155606: slicing registers a new view on the shared managed buffer,
+        # and mbuf_add_view() bumped that buffer's export count with a plain
+        # ++.  Concurrent slices of a single memoryview therefore lost
+        # increments, the count reached zero while views were still alive, and
+        # the underlying buffer was released early.
+        #
+        # The slices are created concurrently but only dropped afterwards, on
+        # one thread, so this covers the increment on its own.
+        mv = memoryview(bytes(2 ** 16))
+        slices = []
+        lock = threading.Lock()
+
+        def make_slices():
+            local = [mv[0:64] for _ in range(2000)]
+            with lock:
+                slices.extend(local)
+
+        threading_helper.run_concurrently(make_slices, nthreads=8)
+        del slices
+
+        # An early release makes this raise "operation forbidden on released
+        # memoryview object".
+        self.assertEqual(bytes(mv[0:4]), b"\x00" * 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-15-16-20-11.gh-issue-155606.Kv3Nqp.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-15-16-20-11.gh-issue-155606.Kv3Nqp.rst
@@ -1,0 +1,5 @@
+Fix a data race on free-threaded builds where slicing a shared
+:class:`memoryview` from several threads could release the underlying buffer
+while views were still alive, raising ``ValueError: operation forbidden on
+released memoryview object``. The managed buffer's export count is now
+incremented atomically.

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -699,7 +699,7 @@ mbuf_add_view(_PyManagedBufferObject *mbuf, const Py_buffer *src)
     init_flags(mv);
 
     mv->mbuf = (_PyManagedBufferObject*)Py_NewRef(mbuf);
-    mbuf->exports++;
+    FT_ATOMIC_ADD_SSIZE(mbuf->exports, 1);
 
     return (PyObject *)mv;
 }
@@ -729,7 +729,7 @@ mbuf_add_incomplete_view(_PyManagedBufferObject *mbuf, const Py_buffer *src,
     init_shared_values(dest, src);
 
     mv->mbuf = (_PyManagedBufferObject*)Py_NewRef(mbuf);
-    mbuf->exports++;
+    FT_ATOMIC_ADD_SSIZE(mbuf->exports, 1);
 
     return (PyObject *)mv;
 }


### PR DESCRIPTION
`memoryview` slicing registers a new view on the shared `_PyManagedBufferObject` and bumps its export count. Both registration sites do that with a plain `++`:

https://github.com/python/cpython/blob/main/Objects/memoryobject.c#L699-L703

`mbuf_add_view()` and `mbuf_add_incomplete_view()` are reached from `memory_subscript()`, so slicing one shared memoryview from several threads is concurrent unsynchronised read-modify-write on `mbuf->exports`. Increments get lost, the count ends up lower than the number of live views, and dropping those views walks it through zero early. `mbuf_release()` then frees the buffer while views are still using it, which is the `ValueError: operation forbidden on released memoryview object` from gh-155606. On a debug build it trips `assert(self->mbuf->exports > 0)` in `_memory_release()` first.

The sibling counter, `PyMemoryViewObject.exports`, is already atomic via `FT_ATOMIC_ADD_SSIZE` (added in gh-127085). This does the same for the managed buffer's counter. On default builds the macro expands to a plain `+=`, so nothing changes there.

### Verifying

Free-threaded debug build, `--disable-gil --with-pydebug`, 8 threads slicing one shared `memoryview`. I built each combination separately and ran each several times:

| `mbuf->exports++` fixed | #154770 applied | result |
| --- | --- | --- |
| no | no | 8/8 threads fail, then abort on the assert |
| **yes** | no | 8/8 threads fail, then abort on the assert |
| no | **yes** | 8/8 threads fail, then abort on the assert |
| **yes** | **yes** | clean, 0/8, over repeated runs |

So this is one of two independent races on the same counter and it is not enough on its own. The decrement side in `_memory_release()` is already covered by #154770 (open, for gh-127716), and I confirmed that PR does not fix gh-155606 by itself either. No overlapping hunks between the two, they touch different functions. Flagging it because reviewing this diff alone would suggest gh-155606 is closed, and it is not until both land.

The added test covers the increment on its own: slices are created concurrently but only dropped afterwards on a single thread, so the decrement race cannot contribute. It aborts on unpatched main and passes with just this change, 5 runs each. It is skipped on default builds.

Also ran `test_memoryview`, `test_buffer`, `test_free_threading`, `test_capi` on both a normal and a free-threaded build, plus `-R 3:3` on `test_memoryview` and `test_buffer`. All clean. `pre-commit` passes on the touched files.

One thing I did not do: I have no ThreadSanitizer build here, so the race is evidenced by the assert and the failure counts above rather than a TSan report.

apologies if I've missed something obvious in here, I worked through the logic myself and talked the design decisions over with Claude Code as a sanity check. still a freshman in college so I'm sure there's plenty I don't know yet, and I'd genuinely like the correction if I've got it wrong somewhere :)
