### PR TITLE
[3.13] gh-130094: Fix race conditions in `importlib` (gh-130101)

### DIFF
--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -1245,6 +1245,9 @@ def _find_spec(name, path, target=None):
         raise ImportError("sys.meta_path is None, Python is likely "
                           "shutting down")
 
+    # gh-130094: Copy sys.meta_path so that we have a consistent view of the
+    # list while iterating over it.
+    meta_path = list(meta_path)
     if not meta_path:
         _warnings.warn('sys.meta_path is empty', ImportWarning)
 
@@ -1299,7 +1302,6 @@ def _sanity_check(name, package, level):
 
 
 _ERR_MSG_PREFIX = 'No module named '
-_ERR_MSG = _ERR_MSG_PREFIX + '{!r}'
 
 def _find_and_load_unlocked(name, import_):
     path = None
@@ -1309,8 +1311,9 @@ def _find_and_load_unlocked(name, import_):
         if parent not in sys.modules:
             _call_with_frames_removed(import_, parent)
         # Crazy side-effects!
-        if name in sys.modules:
-            return sys.modules[name]
+        module = sys.modules.get(name)
+        if module is not None:
+            return module
         parent_module = sys.modules[parent]
         try:
             path = parent_module.__path__
@@ -1318,6 +1321,12 @@ def _find_and_load_unlocked(name, import_):
             msg = f'{_ERR_MSG_PREFIX}{name!r}; {parent!r} is not a package'
             raise ModuleNotFoundError(msg, name=name) from None
         parent_spec = parent_module.__spec__
+        if getattr(parent_spec, '_initializing', False):
+            _call_with_frames_removed(import_, parent)
+        # Crazy side-effects (again)!
+        module = sys.modules.get(name)
+        if module is not None:
+            return module
         child = name.rpartition('.')[2]
     spec = _find_spec(name, path)
     if spec is None:

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-14-00-32-52.gh-issue-130094.m3EF9E.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-14-00-32-52.gh-issue-130094.m3EF9E.rst
@@ -1,0 +1,2 @@
+Fix two race conditions involving concurrent imports that could lead to
+spurious failures with :exc:`ModuleNotFoundError`.


### PR DESCRIPTION
Entries may be added or removed from `sys.meta_path` concurrently. For example, setuptools temporarily adds and removes the `distutils` finder from the beginning of the list. The local copy ensures that we don't skip over any entries.

Some packages modify `sys.modules` during import. For example, `collections` inserts the entry for `collections.abc`  into `sys.modules` during import. We need to ensure that we re-check `sys.modules` *after* the parent module is fully initialized.
(cherry picked from commit 857bdba0ac66ed7963e9fca45ab1a5f7a32b4bfb)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130094 -->
* Issue: gh-130094
<!-- /gh-issue-number -->
