### PR TITLE
gh-155917: Narrow bare except in email._header_value_parser.get_parameter

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2537,7 +2537,7 @@ def get_parameter(value):
         else:
             try:
                 token, rest = get_extended_attrtext(inner_value)
-            except:
+            except errors.HeaderParseError:
                 pass
             else:
                 if not rest:


### PR DESCRIPTION
<!-- Please check the following list before submitting: -->
* [x] Issue title follows standard format (or no issue needed for simple fix)
* [x] Tests passed (`./python -m test test_email`)

### Summary of Changes
In `Lib/email/_header_value_parser.py`, all other 31 call sites catch specific exceptions like `errors.HeaderParseError`. 
This PR replaces the single remaining bare `except:` inside `get_parameter()` with `except errors.HeaderParseError:` to prevent masking unexpected exceptions.

<!-- gh-issue-number: gh-155917 -->
* Issue: gh-155917
<!-- /gh-issue-number -->
