### PR TITLE
[3.13] gh-155515: Use GC tracking for HAMT iterators (GH-155517)

### DIFF
--- a/Lib/test/test_context.py
+++ b/Lib/test/test_context.py
@@ -1096,6 +1096,31 @@ class HamtTest(unittest.TestCase):
 
         self.assertIsNone(ref())
 
+    def test_hamt_gc_3(self):
+        # gh-154535: the iterators must be tracked by the GC, otherwise a
+        # cycle running through one is never collected and the HAMT it
+        # holds -- and everything in it -- leaks.
+        A = HashKey(100, 'A')
+
+        container = []
+        h = hamt()
+        h = h.set(A, container)
+
+        hi = h.items()
+        self.assertTrue(gc.is_tracked(hi))
+
+        # Close the cycle: hi -> h -> container -> hi.
+        container.append(hi)
+        ref = weakref.ref(h)
+
+        del h, hi, container
+
+        gc.collect()
+        gc.collect()
+        gc.collect()
+
+        self.assertIsNone(ref())
+
     def test_hamt_in_1(self):
         A = HashKey(100, 'A')
         AA = HashKey(100, 'A')

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-10-11-20-00.gh-issue-155515.Lp3qWc.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-10-11-20-00.gh-issue-155515.Lp3qWc.rst
@@ -1,0 +1,4 @@
+Track the internal HAMT iterators, which back iteration over a
+:class:`contextvars.Context`, with the garbage collector.  A reference cycle
+running through such an iterator was never collected, leaking the whole
+context it iterated over.

--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -2487,6 +2487,10 @@ static int
 hamt_baseiter_tp_clear(PyHamtIterator *it)
 {
     Py_CLEAR(it->hi_obj);
+    /* i_nodes holds borrowed pointers into the tree that hi_obj was keeping
+       alive, so the cursor must not be used again.  A negative i_level makes
+       hamt_iterator_next() report I_END without touching i_nodes. */
+    it->hi_iter.i_level = -1;
     return 0;
 }
 
@@ -2530,6 +2534,10 @@ hamt_baseiter_tp_iternext(PyHamtIterator *it)
 static Py_ssize_t
 hamt_baseiter_tp_len(PyHamtIterator *it)
 {
+    if (it->hi_obj == NULL) {
+        /* tp_clear() ran on this iterator. */
+        return 0;
+    }
     return it->hi_obj->h_count;
 }
 
@@ -2550,6 +2558,7 @@ hamt_baseiter_new(PyTypeObject *type, binaryfunc yield, PyHamtObject *o)
 
     hamt_iterator_init(&it->hi_iter, o->h_root);
 
+    PyObject_GC_Track(it);
     return (PyObject*)it;
 }
 


### PR DESCRIPTION
(cherry picked from commit f0562124927ec0087a5d3460efe08567aab64b84)

Co-authored-by: Neil Schemenauer <nas-github@arctrix.com>

<!-- gh-issue-number: gh-155515 -->
* Issue: gh-155515
<!-- /gh-issue-number -->
