### PR TITLE
gh-149083: Document that dataclasses.MISSING and KW_ONLY are sentinels

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -531,8 +531,7 @@ Module contents
    A :class:`sentinel` object signifying a missing default or default_factory.
 
    .. versionchanged:: 3.15
-      :const:`!MISSING` is now a :class:`sentinel` object.  In earlier versions
-      it was an instance of a private class.
+      :const:`!MISSING` is now a :class:`sentinel` object.
 
 .. data:: KW_ONLY
 
@@ -562,8 +561,7 @@ Module contents
    .. versionadded:: 3.10
 
    .. versionchanged:: 3.15
-      :const:`!KW_ONLY` is now a :class:`sentinel` object.  In earlier versions
-      it was an instance of a private class.
+      :const:`!KW_ONLY` is now a :class:`sentinel` object.
 
 .. exception:: FrozenInstanceError
 

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -528,7 +528,7 @@ Module contents
 
 .. data:: MISSING
 
-   A :class:`sentinel` object signifying a missing default or default_factory.
+   A :class:`sentinel` object signifying a missing default or *default_factory*.
 
    .. versionchanged:: 3.15
       :const:`!MISSING` is now a :class:`sentinel` object.

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -532,7 +532,7 @@ Module contents
 
    .. versionchanged:: 3.15
       :const:`!MISSING` is now a :class:`sentinel` object.  In earlier versions
-      it was an instance of a private class and had a different :func:`repr`.
+      it was an instance of a private class.
 
 .. data:: KW_ONLY
 
@@ -563,7 +563,7 @@ Module contents
 
    .. versionchanged:: 3.15
       :const:`!KW_ONLY` is now a :class:`sentinel` object.  In earlier versions
-      it was an instance of a private class and had a different :func:`repr`.
+      it was an instance of a private class.
 
 .. exception:: FrozenInstanceError
 

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -262,8 +262,8 @@ Module contents
      c = C()
      c.mylist += [1, 2, 3]
 
-   As shown above, the :const:`MISSING` value is a sentinel object used to
-   detect if some parameters are provided by the user. This sentinel is
+   As shown above, the :const:`MISSING` value is a :class:`sentinel` object
+   used to detect if some parameters are provided by the user. This sentinel is
    used because ``None`` is a valid value for some parameters with
    a distinct meaning.  No code should directly use the :const:`MISSING` value.
 
@@ -528,11 +528,15 @@ Module contents
 
 .. data:: MISSING
 
-   A sentinel value signifying a missing default or default_factory.
+   A :class:`sentinel` object signifying a missing default or default_factory.
+
+   .. versionchanged:: 3.15
+      :const:`!MISSING` is now a :class:`sentinel` object.  In earlier versions
+      it was an instance of a private class and had a different :func:`repr`.
 
 .. data:: KW_ONLY
 
-   A sentinel value used as a type annotation.  Any fields after a
+   A :class:`sentinel` object used as a type annotation.  Any fields after a
    pseudo-field with the type of :const:`!KW_ONLY` are marked as
    keyword-only fields.  Note that a pseudo-field of type
    :const:`!KW_ONLY` is otherwise completely ignored.  This includes the
@@ -556,6 +560,10 @@ Module contents
    field whose type is :const:`!KW_ONLY`.
 
    .. versionadded:: 3.10
+
+   .. versionchanged:: 3.15
+      :const:`!KW_ONLY` is now a :class:`sentinel` object.  In earlier versions
+      it was an instance of a private class and had a different :func:`repr`.
 
 .. exception:: FrozenInstanceError
 


### PR DESCRIPTION
#149086 converted `dataclasses.MISSING` and `dataclasses.KW_ONLY` to instances of the builtin `sentinel`, but the `dataclasses` documentation was not updated to match.

This PR:
* links the prose and both `.. data::` entries to :class:`sentinel`;
* adds `.. versionchanged:: 3.15` notes to `MISSING` and `KW_ONLY`.

Documentation-only change, so no `Misc/NEWS.d` entry — please add the `skip news` label. Needs a backport to 3.15, where the change landed.

<!-- gh-issue-number: gh-149083 -->
* Issue: gh-149083
<!-- /gh-issue-number -->
