### PR TITLE
gh-105250: Fix NEWOBJ handling of custom metaclasses in C pickle

### DIFF
--- a/Include/internal/pycore_call.h
+++ b/Include/internal/pycore_call.h
@@ -32,7 +32,8 @@ PyAPI_FUNC(PyObject*) _Py_CheckFunctionResult(
     PyObject *result,
     const char *where);
 
-extern PyObject* _PyObject_Call_Prepend(
+// Export for '_pickle' shared extension.
+PyAPI_FUNC(PyObject*) _PyObject_Call_Prepend(
     PyThreadState *tstate,
     PyObject *callable,
     PyObject *obj,

--- a/Lib/test/picklecommon.py
+++ b/Lib/test/picklecommon.py
@@ -290,6 +290,40 @@ class MyIntWithNew2(MyIntWithNew):
     __new__ = int.__new__
 
 
+# For test_newobj_metaclass_lookup
+metaclass_new_lookups = []
+
+class LookupLoggingMeta(type):
+    def __getattribute__(cls, name):
+        if name == '__new__':
+            metaclass_new_lookups.append(name)
+        return super().__getattribute__(name)
+
+class NewInheriting(metaclass=LookupLoggingMeta):
+    # __new__ is inherited from object, so tp_new is a C slot function.
+    def __init__(self, value=None):
+        self.value = value
+
+class NewDefining(metaclass=LookupLoggingMeta):
+    # __new__ is defined in Python, so tp_new is slot_tp_new, which
+    # performs its own __new__ lookup through the metaclass.
+    def __new__(cls, *args):
+        return super().__new__(cls)
+
+    def __init__(self, value=None):
+        self.value = value
+
+class NewInheritingEx(dict, metaclass=LookupLoggingMeta):
+    # Like NewInheriting, but pickled with NEWOBJ_EX (protocol 4+):
+    # non-empty kwargs force the NEWOBJ_EX opcode, and dict's C tp_new
+    # accepts them while __new__ stays inherited.
+    def __init__(self, value=None):
+        self.value = value
+
+    def __getnewargs_ex__(self):
+        return (), {'ignored': True}
+
+
 # For test_newobj_list_slots
 class SlotList(MyList):
     __slots__ = ["foo"]

--- a/Lib/test/picklecommon.py
+++ b/Lib/test/picklecommon.py
@@ -291,12 +291,12 @@ class MyIntWithNew2(MyIntWithNew):
 
 
 # For test_newobj_metaclass_lookup
-metaclass_new_lookups = []
-
 class LookupLoggingMeta(type):
+    new_lookup_count = 0
+
     def __getattribute__(cls, name):
         if name == '__new__':
-            metaclass_new_lookups.append(name)
+            LookupLoggingMeta.new_lookup_count += 1
         return super().__getattribute__(name)
 
 class NewInheriting(metaclass=LookupLoggingMeta):

--- a/Lib/test/picklecommon.py
+++ b/Lib/test/picklecommon.py
@@ -292,11 +292,13 @@ class MyIntWithNew2(MyIntWithNew):
 
 # For test_newobj_metaclass_lookup
 class LookupLoggingMeta(type):
-    new_lookup_count = 0
+    # Name of the last class whose __new__ was looked up through the
+    # metaclass.
+    last_new_lookup = None
 
     def __getattribute__(cls, name):
         if name == '__new__':
-            LookupLoggingMeta.new_lookup_count += 1
+            LookupLoggingMeta.last_new_lookup = cls.__name__
         return super().__getattribute__(name)
 
 class NewInheriting(metaclass=LookupLoggingMeta):

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3608,11 +3608,11 @@ class AbstractPickleTests:
             for proto in protocols[min_proto:]:
                 with self.subTest(cls=cls, proto=proto):
                     s = self.dumps(cls(42), proto)
-                    metaclass_new_lookups.clear()
+                    before = LookupLoggingMeta.new_lookup_count
                     y = self.loads(s)
                     self.assertIs(type(y), cls)
                     self.assertEqual(y.value, 42)
-                    self.assertIn('__new__', metaclass_new_lookups)
+                    self.assertGreater(LookupLoggingMeta.new_lookup_count, before)
 
     def test_newobj_not_class(self):
         # Issue 24552

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3599,6 +3599,21 @@ class AbstractPickleTests:
                 self.assertEqual(int(y), 1)
                 self.assertEqual(y.foo, 42)
 
+    def test_newobj_metaclass_lookup(self):
+        # gh-105250: NEWOBJ and NEWOBJ_EX look __new__ up on the class,
+        # so a custom metaclass __getattribute__ hook observes the lookup.
+        for cls, min_proto in ((NewInheriting, 2),
+                               (NewDefining, 2),
+                               (NewInheritingEx, 4)):
+            for proto in protocols[min_proto:]:
+                with self.subTest(cls=cls, proto=proto):
+                    s = self.dumps(cls(42), proto)
+                    metaclass_new_lookups.clear()
+                    y = self.loads(s)
+                    self.assertIs(type(y), cls)
+                    self.assertEqual(y.value, 42)
+                    self.assertIn('__new__', metaclass_new_lookups)
+
     def test_newobj_not_class(self):
         # Issue 24552
         if self.py_version < (3, 4):

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3608,11 +3608,12 @@ class AbstractPickleTests:
             for proto in protocols[min_proto:]:
                 with self.subTest(cls=cls, proto=proto):
                     s = self.dumps(cls(42), proto)
-                    before = LookupLoggingMeta.new_lookup_count
+                    LookupLoggingMeta.last_new_lookup = None
                     y = self.loads(s)
                     self.assertIs(type(y), cls)
                     self.assertEqual(y.value, 42)
-                    self.assertGreater(LookupLoggingMeta.new_lookup_count, before)
+                    self.assertEqual(LookupLoggingMeta.last_new_lookup,
+                                     cls.__name__)
 
     def test_newobj_not_class(self):
         # Issue 24552

--- a/Misc/NEWS.d/next/Library/2026-08-17-11-35-48.gh-issue-105250.wNaXOE.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-17-11-35-48.gh-issue-105250.wNaXOE.rst
@@ -1,0 +1,5 @@
+Fix a difference in behavior between the C and pure Python implementations of
+:mod:`pickle` when unpickling with the ``NEWOBJ`` and ``NEWOBJ_EX`` opcodes:
+the C implementation now performs an attribute lookup of ``cls.__new__`` when
+the class has a custom metaclass, so that a metaclass ``__getattribute__``
+hook observes the lookup as documented.

--- a/Misc/NEWS.d/next/Library/2026-08-17-11-35-48.gh-issue-105250.wNaXOE.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-17-11-35-48.gh-issue-105250.wNaXOE.rst
@@ -2,4 +2,4 @@ Fix a difference in behavior between the C and pure Python implementations of
 :mod:`pickle` when unpickling with the ``NEWOBJ`` and ``NEWOBJ_EX`` opcodes:
 the C implementation now performs an attribute lookup of ``cls.__new__`` when
 the class has a custom metaclass, so that a metaclass ``__getattribute__``
-hook observes the lookup as documented.
+hook observes the lookup as documented. Patched by Chaewon Kim

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6328,7 +6328,36 @@ load_newobj(PickleState *state, UnpicklerObject *self, int use_kwargs)
         goto error;
     }
 
-    obj = ((PyTypeObject *)cls)->tp_new((PyTypeObject *)cls, args, kwargs);
+    if (Py_TYPE(cls) == &PyType_Type) {
+        /* Fast path: with the default metaclass, an attribute lookup of
+           cls.__new__ is not observable, so tp_new can be called
+           directly. */
+        obj = ((PyTypeObject *)cls)->tp_new((PyTypeObject *)cls, args,
+                                            kwargs);
+    }
+    else {
+        /* Look __new__ up on the class so that a custom metaclass
+           __getattribute__ observes the lookup, as in the Python
+           implementation. */
+        PyObject *func = PyObject_GetAttr(cls, &_Py_ID(__new__));
+        if (func == NULL) {
+            goto error;
+        }
+        Py_ssize_t nargs = PyTuple_GET_SIZE(args);
+        PyObject *newargs = PyTuple_New(nargs + 1);
+        if (newargs == NULL) {
+            Py_DECREF(func);
+            goto error;
+        }
+        PyTuple_SET_ITEM(newargs, 0, Py_NewRef(cls));
+        for (Py_ssize_t i = 0; i < nargs; i++) {
+            PyTuple_SET_ITEM(newargs, i + 1,
+                             Py_NewRef(PyTuple_GET_ITEM(args, i)));
+        }
+        obj = PyObject_Call(func, newargs, kwargs);
+        Py_DECREF(newargs);
+        Py_DECREF(func);
+    }
     if (obj == NULL) {
         goto error;
     }

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -10,6 +10,7 @@
 
 #include "Python.h"
 #include "pycore_bytesobject.h"   // _PyBytesWriter
+#include "pycore_call.h"          // _PyObject_Call_Prepend()
 #include "pycore_ceval.h"         // _Py_EnterRecursiveCall()
 #include "pycore_critical_section.h" // Py_BEGIN_CRITICAL_SECTION()
 #include "pycore_dict.h"          // _PyDict_SetItem_Take2()
@@ -6343,19 +6344,8 @@ load_newobj(PickleState *state, UnpicklerObject *self, int use_kwargs)
         if (func == NULL) {
             goto error;
         }
-        Py_ssize_t nargs = PyTuple_GET_SIZE(args);
-        PyObject *newargs = PyTuple_New(nargs + 1);
-        if (newargs == NULL) {
-            Py_DECREF(func);
-            goto error;
-        }
-        PyTuple_SET_ITEM(newargs, 0, Py_NewRef(cls));
-        for (Py_ssize_t i = 0; i < nargs; i++) {
-            PyTuple_SET_ITEM(newargs, i + 1,
-                             Py_NewRef(PyTuple_GET_ITEM(args, i)));
-        }
-        obj = PyObject_Call(func, newargs, kwargs);
-        Py_DECREF(newargs);
+        PyThreadState *tstate = _PyThreadState_GET();
+        obj = _PyObject_Call_Prepend(tstate, func, cls, args, kwargs);
         Py_DECREF(func);
     }
     if (obj == NULL) {


### PR DESCRIPTION
The [NEWOBJ](https://github.com/python/cpython/blob/7a845ce16548bf94e777984458ea534c5a65a2a8/Lib/pickletools.py#L2099-L2106) and [NEWOBJ_EX](https://github.com/python/cpython/blob/7a845ce16548bf94e777984458ea534c5a65a2a8/Lib/pickletools.py#L2114-L2121) opcodes are documented to call `cls.__new__(cls, *args)`, but the C implementation called `tp_new` directly, so a metaclass `__getattribute__` hook was skipped unless the class happened to define `__new__` in Python. Perform a real attribute lookup of `cls.__new__` when the class has a custom metaclass, matching the pure Python implementation.

When the metaclass is exactly `type`, no hook can exist and the lookup is not observable, so `tp_new` is still called directly - no performance change for ordinary classes.

The new test runs against both implementations and covers NEWOBJ (protocols 2-5) and NEWOBJ_EX (protocols 4-5); the cases inheriting `object.__new__` fail on the C unpickler without this change.

I benchmarked the three affected paths with pyperf 2.10.0 (script below). Both interpreters were built with the same plain `./configure` (release build, `Py_DEBUG=0`). Baseline is `main` at 70fdc966d04. Each benchmark unpickles a
list of 1000 instances.

| Benchmark | base | patched |
|---|---|---|
| `newobj_default` (NEWOBJ, default metaclass) | 295 µs | 296 µs: not significant |
| `newobj_ex_default` (NEWOBJ_EX, default metaclass) | 604 µs | 605 µs: not significant |
| `newobj_metaclass` (NEWOBJ, custom metaclass) | 293 µs | 338 µs: 1.15x slower |

The fast path shows no measurable regression for either opcode — the added `Py_TYPE(cls) == &PyType_Type` check is lost in the noise. The 1.15x slowdown is confined to the new slow path, which is only taken for classes with a custom metaclass: the cost of the `PyObject_GetAttr(cls, '__new__')` call plus building the argument tuple, on the path where the previous behaviour did not match the documented semantics.

Environment: macOS 26.5.1, Apple M3 Pro, no CPU isolation (`pyperf system tune` is Linux-only), 20 processes per benchmark.

Given the trade-off — documented `cls.__new__` semantics for custom-metaclass classes, at ~15% on that path and no change for ordinary classes — I'd like your feedback on whether this is acceptable, or whether you'd prefer to close
gh-105250 as a known limitation instead.

<details>
<summary>Benchmark script</summary>

```python
"""Micro-benchmark for load_newobj() in Modules/_pickle.c (gh-105250)."""
import pickle
import pyperf

assert pickle.Unpickler.__module__ == '_pickle', 'need the C implementation'


class Point:
    def __init__(self, x, y):
        self.x = x
        self.y = y


class PointEx:
    def __init__(self, x, y):
        self.x = x
        self.y = y

    def __getnewargs_ex__(self):
        return (self.x,), {'y': self.y}

    def __new__(cls, x=0, y=0):
        return super().__new__(cls)


class Meta(type):
    pass


class PointMeta(metaclass=Meta):
    def __init__(self, x, y):
        self.x = x
        self.y = y


N = 1000
DATA_DEFAULT = pickle.dumps([Point(i, i) for i in range(N)], protocol=2)
DATA_EX = pickle.dumps([PointEx(i, i) for i in range(N)], protocol=4)
DATA_META = pickle.dumps([PointMeta(i, i) for i in range(N)], protocol=2)

runner = pyperf.Runner()
runner.metadata['description'] = 'unpickle NEWOBJ/NEWOBJ_EX (gh-105250)'
runner.bench_func('newobj_default', pickle.loads, DATA_DEFAULT)
runner.bench_func('newobj_ex_default', pickle.loads, DATA_EX)
runner.bench_func('newobj_metaclass', pickle.loads, DATA_META)
```

</details>

<!-- gh-issue-number: gh-105250 -->
* Issue: gh-105250
<!-- /gh-issue-number -->