### PR TITLE
gh-150942: Optimize stringlib split/splitlines with _PyList_AppendTakeRef

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-17-14-00-00.gh-issue-150942.sTrSpL.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-17-14-00-00.gh-issue-150942.sTrSpL.rst
@@ -1,0 +1,4 @@
+Speed up :meth:`str.split`, :meth:`str.rsplit` and :meth:`str.splitlines`
+(and the corresponding :class:`bytes` and :class:`bytearray` methods) by
+appending result items to the output list without an extra reference-count
+round-trip.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-17-14-00-00.gh-issue-150942.sTrSpL.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-17-14-00-00.gh-issue-150942.sTrSpL.rst
@@ -1,4 +1,0 @@
-Speed up :meth:`str.split`, :meth:`str.rsplit` and :meth:`str.splitlines`
-(and the corresponding :class:`bytes` and :class:`bytearray` methods) by
-appending result items to the output list without an extra reference-count
-round-trip.

--- a/Objects/stringlib/split.h
+++ b/Objects/stringlib/split.h
@@ -4,6 +4,8 @@
 #error must include "stringlib/fastsearch.h" before including this module
 #endif
 
+#include "pycore_list.h"          // _PyList_AppendTakeRef()
+
 /* Overallocate the initial list to reduce the number of reallocs for small
    split sizes.  Eg, "A A A A A A A A A A".split() (10 elements) has three
    resizes, to sizes 4, 8, then 16.  Most observed string splits are for human
@@ -22,12 +24,8 @@
                         (right) - (left));      \
     if (sub == NULL)                            \
         goto onError;                           \
-    if (PyList_Append(list, sub)) {             \
-        Py_DECREF(sub);                         \
-        goto onError;                           \
-    }                                           \
-    else                                        \
-        Py_DECREF(sub);
+    if (_PyList_AppendTakeRef((PyListObject *)list, sub)) \
+        goto onError;
 
 #define SPLIT_ADD(data, left, right) {          \
     sub = STRINGLIB_NEW((data) + (left),        \
@@ -37,12 +35,8 @@
     if (count < MAX_PREALLOC) {                 \
         PyList_SET_ITEM(list, count, sub);      \
     } else {                                    \
-        if (PyList_Append(list, sub)) {         \
-            Py_DECREF(sub);                     \
+        if (_PyList_AppendTakeRef((PyListObject *)list, sub)) \
             goto onError;                       \
-        }                                       \
-        else                                    \
-            Py_DECREF(sub);                     \
     }                                           \
     count++; }
 


### PR DESCRIPTION
Append result items to the output list with `_PyList_AppendTakeRef` instead of `PyList_Append` followed by `Py_DECREF` in the stringlib `SPLIT_ADD` (past the 12-slot prealloc) and `SPLIT_APPEND` (used by `splitlines()` for every line) macros, removing a reference-count round-trip per appended item (and a per-append lock on the free-threaded build). This covers `split`/`rsplit`/`splitlines` for `str`, `bytes` and `bytearray`. The result list is freshly allocated and stays local to the split function until it is returned.

## Microbenchmarks

- Plain release build, macOS arm64
- Interleaved A/B runs (8 rounds alternating baseline/patched binaries), medians

| Benchmark | workload | main | this PR | speedup |
| --- | --- | ---: | ---: | :---: |
| `str_split_10k_pieces` | `("abc " * 10_000).split(" ")` | 165 us | 152 us | **1.09×** |
| `str_split_whitespace_10k` | `("word  " * 10_000).split()` | 184 us | 168 us | **1.10×** |
| `str_splitlines_10k` | `("line\n" * 10_000).splitlines()` | 182 us | 165 us | **1.10×** |
| `bytes_split_10k_pieces` | `(b"abc " * 10_000).split(b" ")` | 148 us | 139 us | 1.06× |
| **geomean** | | | | **1.09×** |

`test_str` and `test_bytes` pass, including `-R 3:3` refleak runs.

<details>
<summary>Benchmark script</summary>

```python
"""Microbenchmark str/bytes split / rsplit / splitlines (result-list building)."""
import pyperf

# Many small pieces (>12): exercises the append path after the 12-slot prealloc.
import pyperf

# Many small pieces (>12): exercises the append path after the 12-slot prealloc.
STR_MANY = "abc " * 10_000            # .split(" ") -> 10001 pieces
STR_WS = "word  " * 10_000            # .split() whitespace variant
BYTES_MANY = b"abc " * 10_000         # bytes.split
LINES = "line\n" * 10_000             # .splitlines(): SPLIT_APPEND for every line

# Controls
STR_FEW = "a b c d e f g h i j"       # 10 pieces: stays in the SET_ITEM prealloc path
STR_BIG = ("x" * 4096 + " ") * 250    # large pieces: copy-dominated


def bench_method(loops, obj, name, *args):
    method = getattr(obj, name)
    range_it = range(loops)
    t0 = pyperf.perf_counter()
    for _ in range_it:
        method(*args)
    return pyperf.perf_counter() - t0


runner = pyperf.Runner()
runner.bench_time_func("str_split_10k_pieces", bench_method, STR_MANY, "split", " ")
runner.bench_time_func("str_split_whitespace_10k", bench_method, STR_WS, "split")
runner.bench_time_func("str_splitlines_10k", bench_method, LINES, "splitlines")
runner.bench_time_func("bytes_split_10k_pieces", bench_method, BYTES_MANY, "split", b" ")
runner.bench_time_func("str_split_10_pieces_ctl", bench_method, STR_FEW, "split", " ")
runner.bench_time_func("str_split_large_pieces_ctl", bench_method, STR_BIG, "split", " ")
```

</details>

<!-- gh-issue-number: gh-150942 -->
* Issue: gh-150942
<!-- /gh-issue-number -->