### PR TITLE
gh-141510: Document frozendict support in json

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -486,7 +486,7 @@ Encoders and Decoders
    +----------------------------------------+---------------+
    | Python                                 | JSON          |
    +========================================+===============+
-   | dict                                   | object        |
+   | dict, frozendict                       | object        |
    +----------------------------------------+---------------+
    | list, tuple                            | array         |
    +----------------------------------------+---------------+
@@ -503,6 +503,9 @@ Encoders and Decoders
 
    .. versionchanged:: 3.4
       Added support for int- and float-derived Enum classes.
+
+   .. versionchanged:: 3.15
+      Added support for :class:`frozendict`.
 
    To extend this to recognize other objects, subclass and implement a
    :meth:`~JSONEncoder.default` method with another method that returns a serializable object


### PR DESCRIPTION
`json` gained `frozendict` support in 3.15 (GH-144903), but the docs were never updated: the Python-to-JSON conversion table in `Doc/library/json.rst`, while the equivalent table in the `JSONEncoder` docstring(`Lib/json/encoder.py`) already says `dict, frozendict`.

This updates the table and adds the corresponding `versionchanged` note.

<!-- gh-issue-number: gh-141510 -->
* Issue: gh-141510
<!-- /gh-issue-number -->
