### PR TITLE
[3.13] gh-153970: Fix str() of CalledProcessError when returncode is not an integer (GH-153971)

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -239,8 +239,8 @@ underlying :class:`Popen` interface can be used directly.
 
     .. attribute:: returncode
 
-        Exit status of the child process.  If the process exited due to a
-        signal, this will be the negative signal number.
+        Exit status of the child process, an integer.  If the process
+        exited due to a signal, this will be the negative signal number.
 
     .. attribute:: cmd
 

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -143,7 +143,7 @@ class CalledProcessError(SubprocessError):
         self.stderr = stderr
 
     def __str__(self):
-        if self.returncode and self.returncode < 0:
+        if isinstance(self.returncode, int) and self.returncode < 0:
             try:
                 return "Command '%s' died with %r." % (
                         self.cmd, signal.Signals(-self.returncode))
@@ -151,8 +151,8 @@ class CalledProcessError(SubprocessError):
                 return "Command '%s' died with unknown signal %d." % (
                         self.cmd, -self.returncode)
         else:
-            return "Command '%s' returned non-zero exit status %d." % (
-                    self.cmd, self.returncode)
+            return (f"Command '{self.cmd}' returned non-zero "
+                    f"exit status {self.returncode}.")
 
     @property
     def stdout(self):

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -2414,6 +2414,16 @@ class POSIXProcessTestCase(BaseTestCase):
         error_string = str(err)
         self.assertIn("non-zero exit status 2.", error_string)
 
+        # returncode which is not an integer, which happens for example when
+        # Popen is mocked: str() must not fail
+        for returncode in (None, "2", 2.5, [2]):
+            with self.subTest(returncode=returncode):
+                err = subprocess.CalledProcessError(returncode, "fake cmd")
+                self.assertEqual(
+                    str(err),
+                    f"Command 'fake cmd' returned non-zero "
+                    f"exit status {returncode}.")
+
     def test_preexec(self):
         # DISCLAIMER: Setting environment variables is *not* a good use
         # of a preexec_fn.  This is merely a test.

--- a/Misc/NEWS.d/next/Library/2026-07-22-12-00-00.gh-issue-153970.Kq7Wn3.rst
+++ b/Misc/NEWS.d/next/Library/2026-07-22-12-00-00.gh-issue-153970.Kq7Wn3.rst
@@ -1,0 +1,3 @@
+Calling :func:`str` on a :exc:`subprocess.CalledProcessError` no longer
+raises :exc:`TypeError` when its :attr:`!returncode` is not an integer, such
+as ``None``.


### PR DESCRIPTION
(cherry picked from commit 7c653e2540cbe4180efb3bd83b63865a1f675650)

Co-authored-by: Vyron Vasileiadis <hi@fedonman.com>

<!-- gh-issue-number: gh-153970 -->
* Issue: gh-153970
<!-- /gh-issue-number -->
