### PR TITLE
gh-155928: Close transport when a synchronous stream callback raises

### DIFF
--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -239,7 +239,13 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
         self._over_ssl = transport.get_extra_info('sslcontext') is not None
         if self._client_connected_cb is not None:
             writer = StreamWriter(transport, self, reader, self._loop)
-            res = self._client_connected_cb(reader, writer)
+            try:
+                res = self._client_connected_cb(reader, writer)
+            except BaseException:
+                transport.close()
+                raise
+            finally:
+                self._strong_reader = None
             if coroutines.iscoroutine(res):
                 def callback(task):
                     if task.cancelled():
@@ -256,8 +262,6 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
 
                 self._task = self._loop.create_task(res)
                 self._task.add_done_callback(callback)
-
-            self._strong_reader = None
 
     def connection_lost(self, exc):
         reader = self._stream_reader

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -889,6 +889,22 @@ class StreamTests(test_utils.TestCase):
         self.assertIs(reader._transport, new_transport)
         self.assertTrue(protocol._over_ssl)
 
+    def test_sync_client_cb_closes_transport_on_error(self):
+        reader = asyncio.StreamReader(loop=self.loop)
+
+        def client_connected_cb(reader, writer):
+            raise RuntimeError('test')
+
+        protocol = asyncio.StreamReaderProtocol(
+            reader, client_connected_cb, loop=self.loop)
+        transport = mock.Mock()
+        transport.get_extra_info.return_value = None
+
+        with self.assertRaisesRegex(RuntimeError, 'test'):
+            protocol.connection_made(transport)
+
+        transport.close.assert_called_once_with()
+
     def test_streamreader_constructor_without_loop(self):
         with self.assertRaisesRegex(RuntimeError, 'no current event loop'):
             asyncio.StreamReader()

--- a/Misc/NEWS.d/next/Library/2026-08-17-13-08-37.gh-issue-155928.nK7vQ2.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-17-13-08-37.gh-issue-155928.nK7vQ2.rst
@@ -1,0 +1,3 @@
+Close the transport when a synchronous callback passed to
+:func:`asyncio.start_server` or :func:`asyncio.start_unix_server` raises an
+exception.


### PR DESCRIPTION
Fixes #155928.

When a synchronous `client_connected_cb` raises in `StreamReaderProtocol.connection_made()`, the transport is left open.

This change closes the transport before re-raising the exception, preserving the existing exception-reporting behavior. It also ensures that the strong reference to the reader is released even on the exceptional path.

This affects both `asyncio.start_server()` and `asyncio.start_unix_server()`.

<!-- gh-issue-number: gh-155928 -->
* Issue: gh-155928
<!-- /gh-issue-number -->
