### PR TITLE
[3.13] gh-146004: propagate all -X options to multiprocessing child processes (GH-146005)

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -351,15 +351,16 @@ def _args_from_interpreter_flags():
     # -X options
     if dev_mode:
         args.extend(('-X', 'dev'))
-    for opt in ('faulthandler', 'tracemalloc', 'importtime',
-                'frozen_modules', 'showrefcount', 'utf8', 'gil'):
-        if opt in xoptions:
-            value = xoptions[opt]
-            if value is True:
-                arg = opt
-            else:
-                arg = '%s=%s' % (opt, value)
-            args.extend(('-X', arg))
+    for opt in sorted(xoptions):
+        if opt == 'dev':
+            # handled above via sys.flags.dev_mode
+            continue
+        value = xoptions[opt]
+        if value is True:
+            arg = opt
+        else:
+            arg = '%s=%s' % (opt, value)
+        args.extend(('-X', arg))
 
     return args
 

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -560,11 +560,19 @@ class TestSupport(unittest.TestCase, ExtraAssertions):
             # -X options
             ['-X', 'dev'],
             ['-Wignore', '-X', 'dev'],
+            ['-X', 'cpu_count=4'],
+            ['-X', 'disable-remote-debug'],
             ['-X', 'faulthandler'],
             ['-X', 'importtime'],
+            ['-X', 'importtime=2'],
+            ['-X', 'int_max_str_digits=1000'],
+            ['-X', 'lazy_imports=all'],
+            ['-X', 'no_debug_ranges'],
+            ['-X', 'pycache_prefix=/tmp/pycache'],
             ['-X', 'showrefcount'],
             ['-X', 'tracemalloc'],
             ['-X', 'tracemalloc=3'],
+            ['-X', 'warn_default_encoding'],
         ):
             with self.subTest(opts=opts):
                 self.check_options(opts, 'args_from_interpreter_flags')

--- a/Misc/NEWS.d/next/Library/2026-03-16-00-00-00.gh-issue-146004.xOptProp.rst
+++ b/Misc/NEWS.d/next/Library/2026-03-16-00-00-00.gh-issue-146004.xOptProp.rst
@@ -1,0 +1,9 @@
+All :option:`-X` options from the Python command line are now propagated to
+child processes spawned by :mod:`multiprocessing`, not just a hard-coded
+subset.  This makes the behavior consistent between default "spawn" and
+"forkserver" start methods and the old "fork" start method.  The options
+that were previously not propagated are: ``context_aware_warnings``,
+``cpu_count``, ``disable-remote-debug``, ``int_max_str_digits``,
+``lazy_imports``, ``no_debug_ranges``, ``pathconfig_warnings``, ``perf``,
+``perf_jit``, ``presite``, ``pycache_prefix``, ``thread_inherit_context``,
+and ``warn_default_encoding``.


### PR DESCRIPTION
Propagate all -X command line options to multiprocessing spawned child Python processes. (cherry picked from commit 1efe441de7c448852b9ba51fb0db4d355a7157a8)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-146004 -->
* Issue: gh-146004
<!-- /gh-issue-number -->
