### PR TITLE
gh-155935: Stop `FileFinder._find_children` retrying a failing directory scan

### DIFF
--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -1454,6 +1454,13 @@ class FileFinder:
             while True:
                 try:
                     entry = next(scan_iterator)
+                except StopIteration:
+                    break
+                except OSError:
+                    # A failing scan cannot make progress; end the listing
+                    # like _fill_cache() treats an unreadable directory.
+                    break
+                try:
                     if entry.name == _PYCACHE:
                         continue
                     # packages
@@ -1467,9 +1474,7 @@ class FileFinder:
                             if entry.name.endswith(suffix)
                         }
                 except OSError:
-                    pass  # ignore exceptions from next(scan_iterator) and os.DirEntry
-                except StopIteration:
-                    break
+                    pass  # skip entries whose os.DirEntry methods fail
 
     def discover(self, parent=None):
         if parent and parent.submodule_search_locations is None:

--- a/Lib/test/test_importlib/test_discover.py
+++ b/Lib/test/test_importlib/test_discover.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from test.test_importlib import util
 
@@ -113,6 +113,68 @@ class TestFileFinder:
             example = finder.find_spec('example')
             with self.assertRaises(ValueError):
                 list(finder.discover(example))
+
+    def _patch_scandir(self, scandir):
+        module_os = self.machinery.FileFinder._fill_cache.__globals__['_os']
+        return patch.object(module_os, 'scandir', scandir)
+
+    def test_discover_persistently_failing_scan(self):
+        # gh-155935: an iterator that raises OSError on every next() call
+        # must end the listing instead of looping forever.
+        class FailingScandirIterator:
+            calls = 0
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def __next__(self):
+                self.calls += 1
+                if self.calls > 100:
+                    # Safety net so regressed code fails fast on the call
+                    # count below instead of hanging the test forever.
+                    raise StopIteration
+                raise OSError('persistently failing directory scan')
+
+        scan_iterator = FailingScandirIterator()
+        with self._patch_scandir(lambda path: scan_iterator):
+            finder = self.get_finder('dummy')
+            discovered = list(finder.discover())
+        self.assertEqual(discovered, [])
+        # A failed scan must not be retried.
+        self.assertEqual(scan_iterator.calls, 1)
+
+    def test_find_children_failing_direntry(self):
+        # An entry whose DirEntry methods raise OSError is skipped; the
+        # remaining entries are still listed.
+        failing = Mock()
+        failing.name = 'failing'
+        failing.is_dir.side_effect = OSError('stat failed')
+        good = Mock()
+        good.name = 'example.py'
+        good.is_dir.return_value = False
+        good.is_file.return_value = True
+
+        class FakeScandirIterator:
+            def __init__(self, entries):
+                self._iterator = iter(entries)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def __next__(self):
+                return next(self._iterator)
+
+        with self._patch_scandir(
+                lambda path: FakeScandirIterator([failing, good])):
+            finder = self.get_finder('dummy')
+            children = list(finder._find_children())
+        self.assertEqual(children, ['example'])
 
 
 (

--- a/Misc/NEWS.d/next/Library/2026-08-17-06-07-49.gh-issue-155935.lbMPKW.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-17-06-07-49.gh-issue-155935.lbMPKW.rst
@@ -1,0 +1,1 @@
+Fix :meth:`!importlib.machinery.FileFinder.discover` looping forever when the underlying directory scan keeps failing with :exc:`OSError`. A failing scan now ends the listing instead of being retried.


### PR DESCRIPTION
Split the `OSError` handling: an `OSError` from `next()` ends the listing, while one from `is_dir()` or `is_file()` skips just that entry.

`FileFinder._find_children()` (added by gh-139900 implementing the new `PathEntryFinder.discover()` API proposed in gh-139899) scans a directory in a `while True:` loop and ignores any `OSError` without ending the loop.

The `except OSError: pass` covers two different failure sources: `next(scan_iterator)` and the `os.DirEntry` methods. For a `DirEntry` method (`is_dir()`/`is_file()` racing a deletion), skipping the entry is correct. But when `next(scan_iterator)` itself fails persistently (stale NFS handle, disconnected removable volume) every retry raises the same `OSError` again, `StopIteration` never arrives, and the loop never terminates.

Found via [@devdanzin's AI-assisted audit of `Lib/`](https://gist.github.com/devdanzin/3198710e3c0128fda5e0a7b4e0768e5f#30-filefinder_find_children-can-loop-forever-on-a-persistently-failing-directory-scan); working on it at the PyCon Korea 2026 sprint.

Claude Code helped to write the tests and the fix.

<!-- gh-issue-number: gh-155935 -->
* Issue: gh-155935
<!-- /gh-issue-number -->
