### PR TITLE
gh-150942: Speed up re.split result building

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-08-17-14-49-02.gh-issue-150942.y1jM9t.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-17-14-49-02.gh-issue-150942.y1jM9t.rst
@@ -1,3 +1,0 @@
-Speed up :func:`re.split` by appending result items to the output list
-without an extra reference-count round-trip (using the internal
-reference-stealing list append helper).

--- a/Misc/NEWS.d/next/Library/2026-08-17-14-49-02.gh-issue-150942.y1jM9t.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-17-14-49-02.gh-issue-150942.y1jM9t.rst
@@ -1,0 +1,3 @@
+Speed up :func:`re.split` by appending result items to the output list
+without an extra reference-count round-trip (using the internal
+reference-stealing list append helper).

--- a/Modules/_sre/sre.c
+++ b/Modules/_sre/sre.c
@@ -1273,8 +1273,7 @@ _sre_SRE_Pattern_split_impl(PatternObject *self, PyObject *string,
             );
         if (!item)
             goto error;
-        status = PyList_Append(list, item);
-        Py_DECREF(item);
+        status = _PyList_AppendTakeRef((PyListObject *)list, item);
         if (status < 0)
             goto error;
 
@@ -1283,8 +1282,7 @@ _sre_SRE_Pattern_split_impl(PatternObject *self, PyObject *string,
             item = state_getslice(&state, i+1, string, 0);
             if (!item)
                 goto error;
-            status = PyList_Append(list, item);
-            Py_DECREF(item);
+            status = _PyList_AppendTakeRef((PyListObject *)list, item);
             if (status < 0)
                 goto error;
         }
@@ -1301,8 +1299,7 @@ _sre_SRE_Pattern_split_impl(PatternObject *self, PyObject *string,
         );
     if (!item)
         goto error;
-    status = PyList_Append(list, item);
-    Py_DECREF(item);
+    status = _PyList_AppendTakeRef((PyListObject *)list, item);
     if (status < 0)
         goto error;
 


### PR DESCRIPTION
@hugovk @corona10 
Append result items to the output list with `_PyList_AppendTakeRef` instead of
`PyList_Append` followed by `Py_DECREF`, removing a reference-count round-trip
per appended item (and a per-append lock on the free-threaded build).  This is
the same change gh-150943 made to `re.findall` and `re.sub`/`subn`, applied to
the one result-building loop it left behind.  The `error:` label only drops
`list`, and `_PyList_AppendTakeRef` steals the reference on failure too, so the
error path is unchanged.

## Microbenchmarks

**Default build**

| Benchmark | main | this PR | speedup |
| --- | ---: | ---: | :---: |
| `re_split` | 4.54 ms | 4.31 ms | **1.05×** |
| `re_split_groups` | 5.52 ms | 5.23 ms | **1.06×** |
| `re_split_ws` | 4.18 ms | 4.03 ms | 1.04× |
| `re_split_bytes` | 4.08 ms | 3.95 ms | 1.03× |
| `str_split_control` | 1.37 ms | 1.37 ms | 1.00× |
| **geomean** | | | **1.03×** |

**Free-threading build**

| Benchmark | main | this PR | speedup |
| --- | ---: | ---: | :---: |
| `re_split` | 6.48 ms | 5.84 ms | **1.11×** |
| `re_split_groups` | 8.05 ms | 6.81 ms | **1.18×** |
| `re_split_ws` | 5.74 ms | 5.26 ms | 1.09× |
| `re_split_bytes` | 6.13 ms | 5.39 ms | 1.14× |
| `str_split_control` | | | not significant |
| **geomean** | | | **1.08×** |

<details>
<summary>Benchmark script</summary>

```python
"""Microbenchmark re.split (result-list building)."""
import re
import pyperf

WORDS = "the quick brown fox jumps over the lazy dog " * 2000
CSVISH = "field1,field2,field3,field4,field5,field6,field7,field8\n" * 3000
CSVISH_BYTES = CSVISH.encode()

split_re = re.compile(r"[,\n]")
group_re = re.compile(r"([,\n])")
ws_re = re.compile(r"\s+")
bytes_re = re.compile(rb"[,\n]")
nomatch_re = re.compile(r"[;|]")


def b_split():         return split_re.split(CSVISH)
def b_split_groups():  return group_re.split(CSVISH)
def b_split_ws():      return ws_re.split(WORDS)
def b_split_bytes():   return bytes_re.split(CSVISH_BYTES)
def b_split_nomatch(): return nomatch_re.split(CSVISH)
def b_str_split():     return CSVISH.split(",")


if __name__ == "__main__":
    runner = pyperf.Runner()
    runner.bench_func("re_split", b_split)
    runner.bench_func("re_split_groups", b_split_groups)
    runner.bench_func("re_split_ws", b_split_ws)
    runner.bench_func("re_split_bytes", b_split_bytes)
    runner.bench_func("re_split_nomatch", b_split_nomatch)
    runner.bench_func("str_split_control", b_str_split)
```

</details>


<!-- gh-issue-number: gh-150942 -->
* Issue: gh-150942
<!-- /gh-issue-number -->
