### PR TITLE
gh-155944: Catch only expected errors in getDOMImplementation fallback

### DIFF
--- a/Lib/test/test_xml_dom_domreg.py
+++ b/Lib/test/test_xml_dom_domreg.py
@@ -1,0 +1,54 @@
+import sys
+import unittest
+from unittest import mock
+
+from xml.dom import domreg
+
+
+class BrokenModule:
+    """Fake DOM implementation module whose factory is genuinely buggy."""
+
+    @staticmethod
+    def getDOMImplementation():
+        raise RuntimeError("bug in implementation factory")
+
+
+class MissingFactoryModule:
+    """Fake DOM implementation module without a factory (AttributeError)."""
+
+
+class GetDOMImplementationFallbackTests(unittest.TestCase):
+    """The nameless getDOMImplementation() call tries each well-known
+    implementation and skips the unavailable ones.
+    """
+
+    def _patch_implementations(self, module):
+        self.enterContext(
+            mock.patch.dict(sys.modules, {"test_fake_dom": module})
+        )
+        self.enterContext(
+            mock.patch.dict(
+                domreg.well_known_implementations,
+                {"test_fake_dom": "test_fake_dom"},
+                clear=True,
+            )
+        )
+        self.enterContext(mock.patch.dict(domreg.registered, clear=True))
+
+    def test_fallback_skips_unavailable_implementations(self):
+        # A missing factory (AttributeError) means "not available": skipped,
+        # and with no other implementation the lookup fails cleanly.
+        self._patch_implementations(MissingFactoryModule)
+        with self.assertRaises(ImportError):
+            domreg.getDOMImplementation()
+
+    def test_fallback_propagates_unexpected_errors(self):
+        # gh-155944: a genuine bug in a candidate's factory must propagate,
+        # not be silently treated as "implementation not available".
+        self._patch_implementations(BrokenModule)
+        with self.assertRaises(RuntimeError):
+            domreg.getDOMImplementation()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/xml/dom/domreg.py
+++ b/Lib/xml/dom/domreg.py
@@ -72,7 +72,8 @@ def getDOMImplementation(name=None, features=()):
     for creator in well_known_implementations.keys():
         try:
             dom = getDOMImplementation(name = creator)
-        except Exception: # typically ImportError, or AttributeError
+        except (ImportError, AttributeError):
+            # The implementation is not installed or lacks the factory.
             continue
         if _good_enough(dom, features):
             return dom

--- a/Misc/NEWS.d/next/Library/2026-08-17-07-30-02.gh-issue-155944.PaEX0U.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-17-07-30-02.gh-issue-155944.PaEX0U.rst
@@ -1,0 +1,1 @@
+:func:`xml.dom.getDOMImplementation` no longer masks genuine errors raised by a well-known implementation's factory during fallback discovery. Only :exc:`ImportError` and :exc:`AttributeError` are treated as "implementation not available".


### PR DESCRIPTION
Don't catch all exceptions from the `well_known_implementations` candidates, because only the expected `ImportError` and `AttributeError` mean the implementation is unavailable.

Found via [@devdanzin's AI-assisted audit of `Lib/`](https://gist.github.com/devdanzin/3198710e3c0128fda5e0a7b4e0768e5f#40-xmldomdomreggetdomimplementation-fallback-discovery-masks-genuine-bugs-not-just-not-installed); working on it at the PyCon Korea 2026 sprint.

In `well_known_implementations` the `xml.dom.DOMImplementation` seems to be a leftover from PyXML, so only `xml.dom.minidom` is used (comes from [`Lib/xml/dom/minidom.py`](https://github.com/python/cpython/blob/b6c11feb677f88f8367e80892b1c1979e16b68ee/Lib/xml/dom/minidom.py)):

https://github.com/python/cpython/blob/b6c11feb677f88f8367e80892b1c1979e16b68ee/Lib/xml/dom/domreg.py#L11-L14

Claude Code helped write the tests and the fix.


<!-- gh-issue-number: gh-155944 -->
* Issue: gh-155944
<!-- /gh-issue-number -->
