### PR TITLE
Correct 32-bit code alignment of  `perf_trampoline`'s `trampoline_api`

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-17-08-59-37.gh-issue-none.0FwOzm.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-17-08-59-37.gh-issue-none.0FwOzm.rst
@@ -1,1 +1,0 @@
-Fixed alginment bug with Perf trampolines using perf trampolines should now require slightly less memory

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-17-08-59-37.gh-issue-none.0FwOzm.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-17-08-59-37.gh-issue-none.0FwOzm.rst
@@ -1,0 +1,1 @@
+Fixed alginment bug with Perf trampolines using perf trampolines should now require slightly less memory

--- a/Python/perf_jit_trampoline.c
+++ b/Python/perf_jit_trampoline.c
@@ -517,7 +517,7 @@ static void* perf_map_jit_init(void) {
     size_t eh_frame_size = _PyJitUnwind_EhFrameSize(0);
     size_t unwind_data_size = sizeof(EhFrameHeader) + eh_frame_size;
     trampoline_api.code_padding = _Py_SIZE_ROUND_UP(unwind_data_size, 16);
-    trampoline_api.code_alignment = 32;
+    trampoline_api.code_alignment = 4;
 
     PyMutex_Unlock(&perf_jit_map_state.map_lock);
     return &perf_jit_map_state;

--- a/Python/perf_trampoline.c
+++ b/Python/perf_trampoline.c
@@ -274,7 +274,7 @@ perf_map_init_state(void)
 {
     PyUnstable_PerfMapState_Init();
     trampoline_api.code_padding = 0;
-    trampoline_api.code_alignment = 32;
+    trampoline_api.code_alignment = 4;
     perf_trampoline_type = PERF_TRAMPOLINE_TYPE_MAP;
     return NULL;
 }


### PR DESCRIPTION

bit byte confusion here, perf trampoline was previously aligned to 32 bytes, significantly overallocating space per trampoline

Code comment states we align to 32 bits, but units are in bytes, so we align 8* larger then we mean to. 
# Pull Request title
trivial fix does not need an issue number
