### PR TITLE
[3.14] gh-119452: Increase the timeout of test_large_content_length_truncated

### DIFF
--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -1134,7 +1134,7 @@ class CGIHTTPServerTestCase(BaseTestCase):
             self.assertEqual(res.read(), b'%d %d' % (size, size) + self.linesep)
 
     def test_large_content_length_truncated(self):
-        with support.swap_attr(self.request_handler, 'timeout', 0.001):
+        with support.swap_attr(self.request_handler, 'timeout', support.LOOPBACK_TIMEOUT):
             for w in range(18, 65):
                 size = 1 << w
                 headers = {'Content-Length' : str(size)}


### PR DESCRIPTION
In Fedora, the test fails randomly when run on s390x architecture. Increasing the timeout prevents the issue.

The test is not present on main/3.15 branch anymore, but the fix could make it to 3.14 and 3.13. 
