### PR TITLE
gh-155912: Handle PermissionError from os.sysconf under sandbox

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -700,8 +700,8 @@ def _check_system_limits():
         raise NotImplementedError(_system_limited)
     try:
         nsems_max = os.sysconf("SC_SEM_NSEMS_MAX")
-    except (AttributeError, ValueError):
-        # sysconf not available or setting not available
+    except (AttributeError, ValueError, OSError):
+        # sysconf not available, setting not available, or read denied
         return
     if nsems_max == -1:
         # indetermined limit, assume that limit is determined

--- a/Lib/test/test_concurrent_futures/test_process_pool.py
+++ b/Lib/test/test_concurrent_futures/test_process_pool.py
@@ -68,7 +68,7 @@ class ProcessPoolExecutorTest(ExecutorTest):
             # If it asks for something else, let the real one handle it
             # (though normally _check_system_limits only asks for SC_SEM_NSEMS_MAX)
             return os_sysconf_orig(name)
-            
+
         os_sysconf_orig = os.sysconf
         with unittest.mock.patch('os.sysconf', side_effect=mock_sysconf):
             # Should construct without raising PermissionError

--- a/Lib/test/test_concurrent_futures/test_process_pool.py
+++ b/Lib/test/test_concurrent_futures/test_process_pool.py
@@ -58,6 +58,24 @@ class ProcessPoolExecutorTest(ExecutorTest):
                                     "max_workers must be <= 61"):
             futures.ProcessPoolExecutor(max_workers=62)
 
+    @unittest.skipUnless(hasattr(os, 'sysconf'), 'requires os.sysconf')
+    def test_sysconf_permission_error(self):
+        # Issue 155912: ProcessPoolExecutor should handle PermissionError
+        # from os.sysconf("SC_SEM_NSEMS_MAX") when running under a strict sandbox.
+        def mock_sysconf(name):
+            if name == "SC_SEM_NSEMS_MAX":
+                raise PermissionError(1, "Operation not permitted")
+            # If it asks for something else, let the real one handle it
+            # (though normally _check_system_limits only asks for SC_SEM_NSEMS_MAX)
+            return os_sysconf_orig(name)
+            
+        os_sysconf_orig = os.sysconf
+        with unittest.mock.patch('os.sysconf', side_effect=mock_sysconf):
+            # Should construct without raising PermissionError
+            with futures.ProcessPoolExecutor(max_workers=1) as executor:
+                pass
+
+
     @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
     def test_killed_child(self):
         # When a child process is abruptly terminated, the whole pool gets

--- a/Misc/NEWS.d/next/Library/2026-08-17-17-18-00.gh-issue-155912.abcdef.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-17-17-18-00.gh-issue-155912.abcdef.rst
@@ -1,1 +1,1 @@
-Handle :exc:`PermissionError` from :func:`os.sysconf` in `concurrent.futures.ProcessPoolExecutor` when running under a strict sandbox.
+Handle :exc:`PermissionError` from :func:`os.sysconf` in ``concurrent.futures.ProcessPoolExecutor`` when running under a strict sandbox.

--- a/Misc/NEWS.d/next/Library/2026-08-17-17-18-00.gh-issue-155912.abcdef.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-17-17-18-00.gh-issue-155912.abcdef.rst
@@ -1,0 +1,1 @@
+Handle :exc:`PermissionError` from :func:`os.sysconf` in `concurrent.futures.ProcessPoolExecutor` when running under a strict sandbox.


### PR DESCRIPTION

## Description

This PR fixes a bug where `concurrent.futures.ProcessPoolExecutor` fails to construct on macOS (and other environments) when run under a strict sandbox profile that denies `sysctl` reads. 

When the sandbox denies access, `os.sysconf("SC_SEM_NSEMS_MAX")` raises a `PermissionError` (a subclass of `OSError`). Previously, `_check_system_limits()` only caught `AttributeError` and `ValueError`, meaning the `PermissionError` propagated up and fatally broke the executor initialization, even though the underlying semaphore primitives were fully functional.

**Changes:**
- Added `OSError` to the caught exceptions in `_check_system_limits()` in `Lib/concurrent/futures/process.py`, allowing the executor to gracefully fall back to assuming an undetermined limit when read access is denied.
- Added a regression test in `Lib/test/test_concurrent_futures/test_process_pool.py` that mocks `os.sysconf` to simulate a strict sandbox and asserts that the `ProcessPoolExecutor` initializes successfully.


<!-- gh-issue-number: gh-155912 -->
* Issue: gh-155912
<!-- /gh-issue-number -->
