### PR TITLE
gh-150942: Improve performance of csv reader by using _PyList_AppendT…

### DIFF
--- a/Misc/NEWS.d/next/C_API/2026-08-17-17-46-00.gh-issue-150942.abcdef.rst
+++ b/Misc/NEWS.d/next/C_API/2026-08-17-17-46-00.gh-issue-150942.abcdef.rst
@@ -1,0 +1,1 @@
+Improve performance of ``csv`` reader by using ``_PyList_AppendTakeRef`` internally.

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -15,6 +15,7 @@ module instead.
 
 #include "Python.h"
 #include "pycore_pyatomic_ft_wrappers.h"
+#include "pycore_list.h"
 
 #include <stddef.h>               // offsetof()
 #include <stdbool.h>
@@ -685,11 +686,9 @@ parse_save_field(ReaderObj *self)
         }
         self->field_len = 0;
     }
-    if (PyList_Append(self->fields, field) < 0) {
-        Py_DECREF(field);
+    if (_PyList_AppendTakeRef((PyListObject *)self->fields, field) < 0) {
         return -1;
     }
-    Py_DECREF(field);
     return 0;
 }
 


### PR DESCRIPTION
## Description

This PR improves the performance of the `csv` module's reader by replacing standard `PyList_Append` calls with the internal `_PyList_AppendTakeRef` stealing method.

When parsing CSV fields, the C extension previously appended the parsed field to a list and subsequently decremented the reference count of the field. By using the new stealing methods, we avoid the overhead of an unnecessary incref/decref pair and slightly simplify the C implementation. 

**Changes:**
- Included `"pycore_list.h"` in `Modules/_csv.c`.
- Replaced `PyList_Append` followed by `Py_DECREF` with `_PyList_AppendTakeRef` in the `parse_save_field` function.
- Added the corresponding `NEWS` blurb.


<!-- gh-issue-number: gh-150942 -->
* Issue: gh-150942
<!-- /gh-issue-number -->
