### PR TITLE
gh-151471: IDLE colorizes type as a soft keyword

### DIFF
--- a/Lib/idlelib/colorizer.py
+++ b/Lib/idlelib/colorizer.py
@@ -42,6 +42,11 @@ def make_pat():
         ]) +
         r"))"
     )
+    type_softkw = (
+        r"^[ \t]*" +  # at beginning of line + possible indentation
+        r"(?P<TYPE_SOFTKW>type)" +
+        r"(?=[ \t]+[A-Za-z_])"
+    )
     lazy_softkw = (  # lazy new in 3.15 (+ 2 lines below).
         r"^[ \t]*" +  # at beginning of line + possible indentation
         r"(?P<LAZY_SOFTKW>lazy)" +
@@ -59,7 +64,7 @@ def make_pat():
     dq3string = stringprefix + r'"""[^"\\]*((\\.|"(?!""))[^"\\]*)*(""")?'
     string = any("STRING", [sq3string, dq3string, sqstring, dqstring])
     prog = re.compile("|".join([
-                                builtin, comment, string, kw,
+                                type_softkw, builtin, comment, string, kw,
                                 match_softkw, case_default,
                                 case_softkw_and_pattern, lazy_softkw,
                                 any("SYNC", [r"\n"]),
@@ -75,6 +80,7 @@ prog_group_name_to_tag = {
     "CASE_SOFTKW": "KEYWORD",
     "CASE_DEFAULT_UNDERSCORE": "KEYWORD",
     "CASE_SOFTKW2": "KEYWORD",
+    "TYPE_SOFTKW": "KEYWORD",
     "LAZY_SOFTKW": "KEYWORD",
 }
 

--- a/Lib/idlelib/idle_test/test_colorizer.py
+++ b/Lib/idlelib/idle_test/test_colorizer.py
@@ -52,6 +52,8 @@ source = textwrap.dedent("""\
     '''
     case _:'''
     "match x:"
+    type Point = tuple[float, float]
+    type = type(1)
     """)
 
 
@@ -404,6 +406,8 @@ class ColorDelegatorTest(unittest.TestCase):
                     ('28.25', ('STRING',)), ('28.38', ('STRING',)),
                     ('30.0', ('STRING',)),
                     ('31.1', ('STRING',)),
+                    ('55.0', ('KEYWORD',)), ('55.4', ()), ('55.13', ('BUILTIN',)), ('55.19', ('BUILTIN',)),
+                    ('56.0', ('BUILTIN',)), ('56.7', ('BUILTIN',)),
                     # SYNC at the end of every line.
                     ('1.55', ('SYNC',)), ('2.50', ('SYNC',)), ('3.34', ('SYNC',)),
                    )

--- a/Misc/NEWS.d/next/IDLE/2026-08-17-17-51-00.gh-issue-151471.abcdef.rst
+++ b/Misc/NEWS.d/next/IDLE/2026-08-17-17-51-00.gh-issue-151471.abcdef.rst
@@ -1,0 +1,1 @@
+IDLE now colorizes ``type`` as a soft keyword when it begins a statement.


### PR DESCRIPTION
## Description

This PR fixes a syntax highlighting issue in IDLE where the `type` keyword (introduced in Python 3.12 for type parameter syntax) was incorrectly highlighted as a built-in variable instead of a soft keyword.

**Changes:**
- Added `type_softkw` to the regular expression patterns in `Lib/idlelib/colorizer.py`.
- Configured the colorizer to map `TYPE_SOFTKW` to `KEYWORD`.
- Ensured it only highlights as a keyword when it appears at the beginning of a statement and is followed by whitespace and a valid identifier.
- Added the corresponding `NEWS` blurb.


<!-- gh-issue-number: gh-151471 -->
* Issue: gh-151471
<!-- /gh-issue-number -->
