### PR TITLE
gh-155974: Restore the window attributes when a curses write fails

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -895,6 +895,21 @@ class TestCurses(unittest.TestCase):
                 self.assertRaises(ValueError, stdscr.insstr, arg)
                 self.assertRaises(ValueError, stdscr.insnstr, arg, 1)
 
+    def test_output_string_attr_restored(self):
+        # A write with an attr restores the window rendition afterwards,
+        # whether it succeeded or failed.
+        win = curses.newwin(2, 10, 0, 0)
+        for func, args in [(win.addstr, ('x',)), (win.addnstr, ('x', 1)),
+                           (win.insstr, ('x',)), (win.insnstr, ('x', 1))]:
+            with self.subTest(func.__qualname__):
+                win.attrset(curses.A_UNDERLINE)
+                # y=100 is outside the window, so the write fails.
+                self.assertRaises(curses.error, func, 100, 0, *args,
+                                  curses.A_BOLD)
+                self.assertEqual(win.getattrs(), curses.A_UNDERLINE)
+                func(0, 0, *args, curses.A_BOLD)
+                self.assertEqual(win.getattrs(), curses.A_UNDERLINE)
+
     def test_add_string_behavior(self):
         # addstr() advances the cursor past the written text; addnstr()
         # writes at most n characters.

--- a/Misc/NEWS.d/next/Library/2026-08-17-22-51-22.gh-issue-155974.Qz3Vb7.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-17-22-51-22.gh-issue-155974.Qz3Vb7.rst
@@ -1,0 +1,4 @@
+Fix a regression in Python 3.15: :meth:`~curses.window.addstr`,
+:meth:`~curses.window.addnstr`, :meth:`~curses.window.insstr` and
+:meth:`~curses.window.insnstr` again restore the window attributes when the
+write fails, instead of leaving the temporary *attr* applied.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -2262,15 +2262,14 @@ _curses_window_addstr_impl(PyCursesWindowObject *self, int group_left_1,
         }
         Py_DECREF(bytesobj);
     }
-    if (rtn == ERR) {
-        curses_window_set_error(self, funcname, "addstr");
-        return NULL;
-    }
     if (use_attr) {
-        rtn = wattrset(self->win, attr_old);
-        return curses_window_check_err(self, rtn, "wattrset", "addstr");
+        int attr_rtn = wattrset(self->win, attr_old);
+        if (rtn != ERR) {
+            rtn = attr_rtn;
+            funcname = "wattrset";
+        }
     }
-    Py_RETURN_NONE;
+    return curses_window_check_err(self, rtn, funcname, "addstr");
 }
 
 /*[clinic input]
@@ -2373,15 +2372,14 @@ _curses_window_addnstr_impl(PyCursesWindowObject *self, int group_left_1,
         }
         Py_DECREF(bytesobj);
     }
-    if (rtn == ERR) {
-        curses_window_set_error(self, funcname, "addnstr");
-        return NULL;
-    }
     if (use_attr) {
-        rtn = wattrset(self->win, attr_old);
-        return curses_window_check_err(self, rtn, "wattrset", "addnstr");
+        int attr_rtn = wattrset(self->win, attr_old);
+        if (rtn != ERR) {
+            rtn = attr_rtn;
+            funcname = "wattrset";
+        }
     }
-    Py_RETURN_NONE;
+    return curses_window_check_err(self, rtn, funcname, "addnstr");
 }
 
 /*[clinic input]
@@ -4094,15 +4092,14 @@ _curses_window_insstr_impl(PyCursesWindowObject *self, int group_left_1,
         }
         Py_DECREF(bytesobj);
     }
-    if (rtn == ERR) {
-        curses_window_set_error(self, funcname, "insstr");
-        return NULL;
-    }
     if (use_attr) {
-        rtn = wattrset(self->win, attr_old);
-        return curses_window_check_err(self, rtn, "wattrset", "insstr");
+        int attr_rtn = wattrset(self->win, attr_old);
+        if (rtn != ERR) {
+            rtn = attr_rtn;
+            funcname = "wattrset";
+        }
     }
-    Py_RETURN_NONE;
+    return curses_window_check_err(self, rtn, funcname, "insstr");
 }
 
 /*[clinic input]
@@ -4206,15 +4203,14 @@ _curses_window_insnstr_impl(PyCursesWindowObject *self, int group_left_1,
         }
         Py_DECREF(bytesobj);
     }
-    if (rtn == ERR) {
-        curses_window_set_error(self, funcname, "insnstr");
-        return NULL;
-    }
     if (use_attr) {
-        rtn = wattrset(self->win, attr_old);
-        return curses_window_check_err(self, rtn, "wattrset", "insnstr");
+        int attr_rtn = wattrset(self->win, attr_old);
+        if (rtn != ERR) {
+            rtn = attr_rtn;
+            funcname = "wattrset";
+        }
     }
-    Py_RETURN_NONE;
+    return curses_window_check_err(self, rtn, funcname, "insnstr");
 }
 
 /*[clinic input]


### PR DESCRIPTION
`addstr()`, `addnstr()`, `insstr()` and `insnstr()` now restore the window rendition before reporting a failed write, so a failure no longer leaves the caller's *attr* applied. A `wattrset()` failure is still reported when the write itself succeeded.

```
$ ./python -m test test_curses -u curses -v -m test_output_string_attr_restored
test_output_string_attr_restored (test.test_curses.TestCurses.test_output_string_attr_restored) ... ok
$ ./python -m test test_curses -u curses
Total tests: run=172 skipped=3
Result: SUCCESS
```


<!-- gh-issue-number: gh-155974 -->
* Issue: gh-155974
<!-- /gh-issue-number -->
