### PR TITLE
gh-155985: Do not fuse a set difference under IGNORECASE with LOCALE

### DIFF
--- a/Lib/re/_compiler.py
+++ b/Lib/re/_compiler.py
@@ -221,7 +221,7 @@ def _code(p, flags):
     flags = p.state.flags | flags
 
     # run the optimizer passes over the parsed pattern
-    optimize(p)
+    optimize(p, flags)
 
     code = []
 

--- a/Lib/re/_optimizer.py
+++ b/Lib/re/_optimizer.py
@@ -467,10 +467,12 @@ def _fuse_branch(av):
             items += cs
     return items if tail is None else items + tail
 
-def _fuse_difference(data):
+def _fuse_difference(data, flags):
     # Replace  <flat charset A> (?<![B1]) (?<![B2]) ...  with the single charset
     # [NEGATE] B1 B2 ... [NEGATE] A.  Each negative lookbehind over a flat
     # charset subtracts its set from the character A matches.
+    if flags & SRE_FLAG_IGNORECASE and flags & SRE_FLAG_LOCALE:
+        return
     out = []
     head = None        # _flat_items(A) for the fused difference now at out[-1]
     subtrahend = None  # its accumulated B items, or None when not fusing
@@ -493,17 +495,20 @@ def _fuse_difference(data):
         out.append((op, av))
     data[:] = out
 
-def _walk(seq):
+def _walk(seq, flags):
     for i, (op, av) in enumerate(seq):
+        subflags = flags
+        if op is SUBPATTERN:
+            subflags = _combine_flags(flags, av[1], av[2])
         for sub in _subpatterns(op, av):
-            _walk(sub.data)
+            _walk(sub.data, subflags)
         if op is BRANCH:
             items = _fuse_branch(av)
             if items is not None:
                 seq[i] = (IN, items)
-    _fuse_difference(seq)
+    _fuse_difference(seq, flags)
 
-def optimize(pattern):
+def optimize(pattern, flags):
     """Rewrite a parsed pattern in place and return it."""
-    _walk(pattern.data)
+    _walk(pattern.data, flags)
     return pattern

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1558,6 +1558,22 @@ class ReTests(unittest.TestCase):
         self.assertEqual(w.filename, __file__)
         self.assertEqual(re.findall(r'[~~1]', s), list('1~'))
 
+    def test_difference_not_fused_with_locale_ignorecase(self):
+        # IN_LOC_IGNORE tests the whole set once per locale case, so a fused
+        # difference, which relies on an embedded NEGATE, cannot be used.
+        IL = re.IGNORECASE | re.LOCALE
+        # [b] matches b'B' under these flags, so the lookbehind must reject it.
+        self.assertTrue(re.fullmatch(rb'[b]', b'B', IL))
+        self.assertIsNone(re.fullmatch(rb'\w(?<!b)', b'B', IL))
+        # IGNORECASE may also be scoped to the group.
+        self.assertIsNone(re.fullmatch(rb'(?i:\w(?<!b))', b'B', re.LOCALE))
+        # [0-m] matches b'N', so the difference operator must exclude it.
+        self.assertTrue(re.fullmatch(rb'[0-m]', b'N', IL))
+        self.assertIsNone(re.fullmatch(rb'[A-z--[0-m]]', b'N', IL))
+        # Without both flags the fusion is still applied.
+        self.assertTrue(re.fullmatch(rb'\w(?<!b)', b'B'))
+        self.assertTrue(re.fullmatch(rb'[a-c--[b]]', b'a'))
+
     def test_search_coverage(self):
         self.assertEqual(re.search(r"\s(b)", " b").group(1), "b")
         self.assertEqual(re.search(r"a\s", "a ").group(0), "a ")


### PR DESCRIPTION
`_fuse_difference()` now sees the compile flags and skips the fusion when `IGNORECASE` and `LOCALE` are both set, which is exactly when the fused set would compile to `IN_LOC_IGNORE`. The flags are threaded through `optimize()` and `_walk()` and recombined for a scoped group, so `(?i:...)` inside a `re.LOCALE` pattern is covered too.

```
$ ./python -m test test_re

Total duration: 1.3 sec
Total tests: run=170 skipped=3
Total test files: run=1/1
Result: SUCCESS
```

No NEWS fragment: the fusion landed earlier in this cycle (GH-152214) and has never been in a release, so there is nothing a user could have hit.


<!-- gh-issue-number: gh-155985 -->
* Issue: gh-155985
<!-- /gh-issue-number -->
