### PR TITLE
gh-155992: Fix missing LINE event for first line of a code object

### DIFF
--- a/Lib/test/test_monitoring.py
+++ b/Lib/test/test_monitoring.py
@@ -702,6 +702,25 @@ class LineMonitoringTest(MonitoringTestBase, unittest.TestCase):
 
         self.check_lines(f, [1,3,5,4,2,4])
 
+    def test_line_same_line_as_def(self):
+
+        def func(): line = 1; line = 2
+
+        self.check_lines(func, [0])
+
+    def test_line_multi_line_body_starting_on_def_line(self):
+
+        def func(): line = 1; \
+            line = 2
+
+        self.check_lines(func, [0, 1])
+
+    def test_line_lambda_body(self):
+
+        lam = lambda: 1
+
+        self.check_lines(lam, [0])
+
 class TestDisable(MonitoringTestBase, unittest.TestCase):
 
     def gen(self, cond):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-18-12-01-47.gh-issue-155992.Yl4gI2.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-18-12-01-47.gh-issue-155992.Yl4gI2.rst
@@ -1,0 +1,3 @@
+Fix a regression in ``sys.monitoring`` where the ``LINE`` event did not fire
+for the first line of a code object when the line also contains the ``def``
+or ``lambda`` statement. The event is emitted again as it was in Python 3.12.

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1349,7 +1349,9 @@ _Py_call_instrumentation_line(PyThreadState *tstate, _PyInterpreterFrame* frame,
         /* RESUME and INSTRUMENTED_RESUME are needed for the operation of
             * instrumentation, so must never be hidden by an INSTRUMENTED_LINE.
             */
-        if (prev_opcode != RESUME && prev_opcode != INSTRUMENTED_RESUME) {
+        if (_PyOpcode_Deopt[prev_opcode] != RESUME &&
+            prev_opcode != INSTRUMENTED_RESUME)
+        {
             goto done;
         }
     }


### PR DESCRIPTION
Fixes #155992.

The `sys.monitoring` `LINE` event did not fire for the first line of a
code object when the `def`/`lambda` body shared that line. Since 3.13,
`RESUME` is specialized to `RESUME_CHECK`, so the special case in
`_Py_call_instrumentation_line()` that forces the first `LINE` event
(when the previous instruction is `RESUME`/`INSTRUMENTED_RESUME`) no
longer matched. The check now uses `_PyOpcode_Deopt`, covering all
`RESUME` specializations.

Tests were added to `LineMonitoringTest` in `Lib/test/test_monitoring.py`
for single-line `def` bodies, multi-line bodies starting on the `def`
line, and `lambda`. All of `test_monitoring`, `test_trace`,
`test_profile`, and `test_sys_settrace` pass.

<!-- gh-issue-number: gh-155992 -->
* Issue: gh-155992
<!-- /gh-issue-number -->
