### PR TITLE
gh-149110: Fix race in _PyFrame_IsIncomplete for FRAME_OWNED_BY_FRAME…

### DIFF
--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -566,8 +566,11 @@ _PyCode_GetTLBCFast(PyThreadState *tstate, PyCodeObject *co)
 {
     _PyCodeArray *code = _PyCode_GetTLBCArray(co);
     int32_t idx = ((_PyThreadStateImpl*) tstate)->tlbc_index;
-    if (idx < code->size && code->entries[idx] != NULL) {
-        return (_Py_CODEUNIT *) code->entries[idx];
+    if (idx < code->size) {
+        void *entry = _Py_atomic_load_ptr_acquire(&code->entries[idx]);
+        if (entry != NULL) {
+            return (_Py_CODEUNIT *) entry;
+        }
     }
     return NULL;
 }

--- a/Include/internal/pycore_interpframe.h
+++ b/Include/internal/pycore_interpframe.h
@@ -61,7 +61,7 @@ _PyFrame_GetBytecode(_PyInterpreterFrame *f)
     PyCodeObject *co = _PyFrame_GetCode(f);
     _PyCodeArray *tlbc = _PyCode_GetTLBCArray(co);
     assert(f->tlbc_index >= 0 && f->tlbc_index < tlbc->size);
-    return (_Py_CODEUNIT *)tlbc->entries[f->tlbc_index];
+    return (_Py_CODEUNIT *)_Py_atomic_load_ptr_acquire(&tlbc->entries[f->tlbc_index]);
 #else
     return _PyCode_CODE(_PyFrame_GetCode(f));
 #endif
@@ -293,6 +293,12 @@ _PyFrame_IsIncomplete(_PyInterpreterFrame *frame)
 {
     if (frame->owner >= FRAME_OWNED_BY_INTERPRETER) {
         return true;
+    }
+    /* Frames owned by a frame object are guaranteed complete by take_ownership().
+     * Checking instr_ptr here would race with take_ownership() when called from
+     * another thread (e.g. pdb walking frame->f_back cross-thread). */
+    if (frame->owner == FRAME_OWNED_BY_FRAME_OBJECT) {
+        return false;
     }
     return frame->owner != FRAME_OWNED_BY_GENERATOR &&
            frame->instr_ptr < _PyFrame_GetBytecode(frame) +

--- a/Lib/test/test_free_threading/test_frame.py
+++ b/Lib/test/test_free_threading/test_frame.py
@@ -146,6 +146,40 @@ class TestFrameRaces(unittest.TestCase):
 
         threading_helper.run_concurrently([reader, reader, clearer])
 
+    def test_f_back_after_thread_return(self):
+        # gh-149110: Accessing frame.f_back cross-thread while the owning
+        # thread is returning caused a spurious assertion failure in
+        # PyFrame_GetBack on free-threaded builds.
+        frames = []
+        lock = threading.Lock()
+
+        def target():
+            frame = sys._getframe()
+            with lock:
+                frames.append(frame)
+
+        def inspector():
+            for _ in range(50):
+                frame = None
+                with lock:
+                    if frames:
+                        frame = frames[-1]
+                if frame is not None:
+                    try:
+                        _ = frame.f_back
+                    except Exception:
+                        pass
+                sys._clear_internal_caches()
+
+        threads = [threading.Thread(target=target) for _ in range(20)]
+        insp = threading.Thread(target=inspector)
+        insp.start()
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        insp.join()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-18-10-38-00.gh-issue-149110.rqYKjG.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-18-10-38-00.gh-issue-149110.rqYKjG.rst
@@ -1,0 +1,3 @@
+Fix a race condition in free-threaded builds where cross-thread frame
+inspection via :mod:`pdb` could cause a spurious assertion failure in
+:c:func:`PyFrame_GetBack`.

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -3406,7 +3406,7 @@ create_tlbc_lock_held(PyInterpreterState *interp, PyCodeObject *co, Py_ssize_t i
     }
     copy_code(interp, (_Py_CODEUNIT *) bc, co);
     assert(tlbc->entries[idx] == NULL);
-    tlbc->entries[idx] = bc;
+    _Py_atomic_store_ptr_release(&tlbc->entries[idx], bc);
     return (_Py_CODEUNIT *) bc;
 }
 

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -2399,10 +2399,15 @@ PyFrameObject*
 PyFrame_GetBack(PyFrameObject *frame)
 {
     assert(frame != NULL);
-    assert(!_PyFrame_IsIncomplete(frame->f_frame));
+    /* Use an acquire load so that if we observe the new f_frame pointer
+     * published by take_ownership()'s release store, we also observe
+     * new_frame->owner == FRAME_OWNED_BY_FRAME_OBJECT. */
+    _PyInterpreterFrame *f_frame =
+        (_PyInterpreterFrame *)_Py_atomic_load_ptr_acquire(&frame->f_frame);
+    assert(!_PyFrame_IsIncomplete(f_frame));
     PyFrameObject *back = frame->f_back;
     if (back == NULL) {
-        _PyInterpreterFrame *prev = frame->f_frame->previous;
+        _PyInterpreterFrame *prev = f_frame->previous;
         prev = _PyFrame_GetFirstComplete(prev);
         if (prev) {
             back = _PyFrame_GetFrameObject(prev);

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -55,8 +55,9 @@ take_ownership(PyFrameObject *f, _PyInterpreterFrame *frame)
     // _PyFrame_Copy takes the reference to the executable,
     // so we need to restore it.
     new_frame->f_executable = PyStackRef_DUP(new_frame->f_executable);
-    f->f_frame = new_frame;
-    new_frame->owner = FRAME_OWNED_BY_FRAME_OBJECT;
+    /* Fix instr_ptr BEFORE setting owner = FRAME_OWNED_BY_FRAME_OBJECT,
+     * since _PyFrame_IsIncomplete() short-circuits to false for that owner.
+     * The original owner (FRAME_OWNED_BY_THREAD) is used for the check. */
     if (_PyFrame_IsIncomplete(new_frame)) {
         // This may be a newly-created generator or coroutine frame. Since it's
         // dead anyways, just pretend that the first RESUME ran:
@@ -64,6 +65,11 @@ take_ownership(PyFrameObject *f, _PyInterpreterFrame *frame)
         new_frame->instr_ptr =
             _PyFrame_GetBytecode(new_frame) + code->_co_firsttraceable + 1;
     }
+    /* Set owner BEFORE updating f->f_frame so any concurrent reader that
+     * observes the new f_frame pointer also sees owner = FRAME_OWNED_BY_FRAME_OBJECT,
+     * causing _PyFrame_IsIncomplete() to short-circuit to false. */
+    new_frame->owner = FRAME_OWNED_BY_FRAME_OBJECT;
+    f->f_frame = new_frame;
     assert(!_PyFrame_IsIncomplete(new_frame));
     assert(f->f_back == NULL);
     _PyInterpreterFrame *prev = _PyFrame_GetFirstComplete(frame->previous);

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -69,7 +69,11 @@ take_ownership(PyFrameObject *f, _PyInterpreterFrame *frame)
      * observes the new f_frame pointer also sees owner = FRAME_OWNED_BY_FRAME_OBJECT,
      * causing _PyFrame_IsIncomplete() to short-circuit to false. */
     new_frame->owner = FRAME_OWNED_BY_FRAME_OBJECT;
-    f->f_frame = new_frame;
+    /* Publish f_frame with a release store so that any concurrent reader
+     * doing an acquire load of f_frame is guaranteed to also observe
+     * new_frame->owner == FRAME_OWNED_BY_FRAME_OBJECT (written above),
+     * satisfying the C11 happens-before relationship. */
+    _Py_atomic_store_ptr_release(&f->f_frame, new_frame);
     assert(!_PyFrame_IsIncomplete(new_frame));
     assert(f->f_back == NULL);
     _PyInterpreterFrame *prev = _PyFrame_GetFirstComplete(frame->previous);


### PR DESCRIPTION
`_PyFrame_IsIncomplete` was checking `instr_ptr` against a TLBC slot on
frames already owned by a frame object, which races with `take_ownership()`
when another thread walks `frame.f_back` (e.g. via pdb).

**Fix:**
- Short-circuit `_PyFrame_IsIncomplete` for `FRAME_OWNED_BY_FRAME_OBJECT`
  frames — `take_ownership()` already guarantees they're complete
- Fix publication order in `take_ownership()` so `owner` is set before
  `f->f_frame` is visible to concurrent readers
- Use atomic release/acquire for `co_tlbc->entries[idx]` writes/reads

Added a regression test in `test_free_threading/test_frame.py`.

Fixes issue #149110

<!-- gh-issue-number: gh-149110 -->
* Issue: gh-149110
<!-- /gh-issue-number -->
