### PR TITLE
gh-151138: Document Windows-specific temp dirs in gettempdir()

### DIFF
--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -348,8 +348,14 @@ The module defines the following user-callable items:
 
    #. A platform-specific location:
 
-      * On Windows, the directories :file:`C:\\TEMP`, :file:`C:\\TMP`,
-        :file:`\\TEMP`, and :file:`\\TMP`, in that order.
+      * On Windows, the following directories, in that order:
+
+        - :file:`%USERPROFILE%\\AppData\\Local\\Temp`
+        - :file:`%SYSTEMROOT%\\Temp`
+        - :file:`C:\\TEMP`
+        - :file:`C:\\TMP`
+        - :file:`\\TEMP`
+        - :file:`\\TMP`
 
       * On all other platforms, the directories :file:`/tmp`, :file:`/var/tmp`, and
         :file:`/usr/tmp`, in that order.
@@ -358,6 +364,11 @@ The module defines the following user-callable items:
 
    The result of this search is cached, see the description of
    :data:`tempdir` below.
+
+   .. versionchanged:: 3.6
+      On Windows, :file:`%USERPROFILE%\\AppData\\Local\\Temp` and
+      :file:`%SYSTEMROOT%\\Temp` are now checked before the hardcoded
+      directory paths.
 
    .. versionchanged:: 3.10
 


### PR DESCRIPTION
## Problem

The `tempfile.gettempdir()` documentation incorrectly states that on Windows,
only `C:\TEMP`, `C:\TMP`, `\TEMP`, and `\TMP` are checked.

## Fix

Since Python 3.6 (commit e5f41d2), the implementation also checks:
- `%USERPROFILE%\AppData\Local\Temp`
- `%SYSTEMROOT%\Temp`

These are checked **before** the hardcoded paths but were missing from the docs.

This PR:
- Adds the two missing directories to the documented search order
- Adds a `versionchanged:: 3.6` note to document when this was introduced

## Testing

Documentation-only change. Verified with `make html` — build succeeded with no errors.

Fixes gh-151138