### PR TITLE
gh-116946: remove unnecessary gc from _decimal types

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-08-19-07-11-40.gh-issue-144650.BYN9Xj.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-19-07-11-40.gh-issue-144650.BYN9Xj.rst
@@ -1,0 +1,2 @@
+Removed unnecessary gc support for :mod:`!_decimal` module.  That provide
+1.07x-1.14x speedup on standard pyperformance benchmarks.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -754,7 +754,6 @@ static void
 signaldict_dealloc(PyObject *self)
 {
     PyTypeObject *tp = Py_TYPE(self);
-    PyObject_GC_UnTrack(self);
     tp->tp_free(self);
     Py_DECREF(tp);
 }
@@ -842,7 +841,6 @@ static PyMethodDef signaldict_methods[] = {
 
 static PyType_Slot signaldict_slots[] = {
     {Py_tp_dealloc, signaldict_dealloc},
-    {Py_tp_traverse, _PyObject_VisitType},
     {Py_tp_repr, signaldict_repr},
     {Py_tp_hash, PyObject_HashNotImplemented},
     {Py_tp_getattro, PyObject_GenericGetAttr},
@@ -862,7 +860,7 @@ static PyType_Spec signaldict_spec = {
     .name = "decimal.SignalDictMixin",
     .basicsize = sizeof(PyDecSignalDictObject),
     .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
-              Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_IMMUTABLETYPE),
+              Py_TPFLAGS_IMMUTABLETYPE),
     .slots = signaldict_slots,
 };
 
@@ -1445,7 +1443,7 @@ context_new(PyTypeObject *type,
 
     decimal_state *state = get_module_state_by_def(type);
     if (type == state->PyDecContext_Type) {
-        self = PyObject_GC_New(PyDecContextObject, state->PyDecContext_Type);
+        self = PyObject_New(PyDecContextObject, state->PyDecContext_Type);
     }
     else {
         self = (PyDecContextObject *)type->tp_alloc(type, 0);
@@ -1483,21 +1481,7 @@ context_new(PyTypeObject *type,
     self->tstate = NULL;
     self->modstate = state;
 
-    if (type == state->PyDecContext_Type) {
-        PyObject_GC_Track(self);
-    }
-    assert(PyObject_GC_IsTracked((PyObject *)self));
     return (PyObject *)self;
-}
-
-static int
-context_traverse(PyObject *op, visitproc visit, void *arg)
-{
-    PyDecContextObject *self = _PyDecContextObject_CAST(op);
-    Py_VISIT(Py_TYPE(self));
-    Py_VISIT(self->traps);
-    Py_VISIT(self->flags);
-    return 0;
 }
 
 static int
@@ -1527,7 +1511,6 @@ static void
 context_dealloc(PyObject *self)
 {
     PyTypeObject *tp = Py_TYPE(self);
-    PyObject_GC_UnTrack(self);
     (void)context_clear(self);
     tp->tp_free(self);
     Py_DECREF(tp);
@@ -2152,7 +2135,7 @@ _decimal_localcontext_impl(PyObject *module, PyObject *local, PyObject *prec,
     }
 
     PyDecContextManagerObject *self;
-    self = PyObject_GC_New(PyDecContextManagerObject,
+    self = PyObject_New(PyDecContextManagerObject,
                            state->PyDecContextManager_Type);
     if (self == NULL) {
         Py_DECREF(local_copy);
@@ -2161,19 +2144,8 @@ _decimal_localcontext_impl(PyObject *module, PyObject *local, PyObject *prec,
 
     self->local = local_copy;
     self->global = Py_NewRef(global);
-    PyObject_GC_Track(self);
 
     return (PyObject *)self;
-}
-
-static int
-ctxmanager_traverse(PyObject *op, visitproc visit, void *arg)
-{
-    PyDecContextManagerObject *self = _PyDecContextManagerObject_CAST(op);
-    Py_VISIT(Py_TYPE(self));
-    Py_VISIT(self->local);
-    Py_VISIT(self->global);
-    return 0;
 }
 
 static int
@@ -2189,7 +2161,6 @@ static void
 ctxmanager_dealloc(PyObject *self)
 {
     PyTypeObject *tp = Py_TYPE(self);
-    PyObject_GC_UnTrack(self);
     (void)ctxmanager_clear(self);
     tp->tp_free(self);
     Py_DECREF(tp);
@@ -2233,7 +2204,6 @@ static PyMethodDef ctxmanager_methods[] = {
 static PyType_Slot ctxmanager_slots[] = {
     {Py_tp_dealloc, ctxmanager_dealloc},
     {Py_tp_getattro, PyObject_GenericGetAttr},
-    {Py_tp_traverse, ctxmanager_traverse},
     {Py_tp_clear, ctxmanager_clear},
     {Py_tp_methods, ctxmanager_methods},
     {0, NULL},
@@ -2242,7 +2212,7 @@ static PyType_Slot ctxmanager_slots[] = {
 static PyType_Spec ctxmanager_spec = {
     .name = "decimal.ContextManager",
     .basicsize = sizeof(PyDecContextManagerObject),
-    .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+    .flags = (Py_TPFLAGS_DEFAULT |
               Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION),
     .slots = ctxmanager_slots,
 };
@@ -2258,7 +2228,7 @@ PyDecType_New(decimal_state *state, PyTypeObject *type)
     PyDecObject *dec;
 
     if (type == state->PyDec_Type) {
-        dec = PyObject_GC_New(PyDecObject, state->PyDec_Type);
+        dec = PyObject_New(PyDecObject, state->PyDec_Type);
     }
     else {
         dec = (PyDecObject *)type->tp_alloc(type, 0);
@@ -2276,10 +2246,6 @@ PyDecType_New(decimal_state *state, PyTypeObject *type)
     MPD(dec)->alloc = _Py_DEC_MINALLOC;
     MPD(dec)->data = dec->data;
 
-    if (type == state->PyDec_Type) {
-        PyObject_GC_Track(dec);
-    }
-    assert(PyObject_GC_IsTracked((PyObject *)dec));
     return (PyObject *)dec;
 }
 #define dec_alloc(st) PyDecType_New(st, (st)->PyDec_Type)
@@ -2288,7 +2254,6 @@ static void
 dec_dealloc(PyObject *dec)
 {
     PyTypeObject *tp = Py_TYPE(dec);
-    PyObject_GC_UnTrack(dec);
     mpd_del(MPD(dec));
     tp->tp_free(dec);
     Py_DECREF(tp);
@@ -6177,7 +6142,6 @@ static PyType_Slot dec_slots[] = {
     {Py_tp_token, Py_TP_USE_SPEC},
     {Py_tp_dealloc, dec_dealloc},
     {Py_tp_getattro, PyObject_GenericGetAttr},
-    {Py_tp_traverse, _PyObject_VisitType},
     {Py_tp_repr, dec_repr},
     {Py_tp_hash, dec_hash},
     {Py_tp_str, dec_str},
@@ -6210,7 +6174,7 @@ static PyType_Spec dec_spec = {
     .name = "decimal.Decimal",
     .basicsize = sizeof(PyDecObject),
     .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
-              Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_IMMUTABLETYPE),
+              Py_TPFLAGS_IMMUTABLETYPE),
     .slots = dec_slots,
 };
 
@@ -7616,7 +7580,6 @@ static PyMethodDef context_methods [] =
 static PyType_Slot context_slots[] = {
     {Py_tp_token, Py_TP_USE_SPEC},
     {Py_tp_dealloc, context_dealloc},
-    {Py_tp_traverse, context_traverse},
     {Py_tp_clear, context_clear},
     {Py_tp_repr, context_repr},
     {Py_tp_getattro, context_getattr},
@@ -7633,7 +7596,7 @@ static PyType_Spec context_spec = {
     .name = "decimal.Context",
     .basicsize = sizeof(PyDecContextObject),
     .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
-              Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_IMMUTABLETYPE),
+              Py_TPFLAGS_IMMUTABLETYPE),
     .slots = context_slots,
 };
 


### PR DESCRIPTION
On my laptop (gcc 14.2, default configure flags) for pyperformance benchmarks (decimal_* should be enabled first, see https://github.com/python/pyperformance/issues/473):
```
decimal_factorial: Mean +- std dev: [ref] 1.05 sec +- 0.02 sec -> [patch] 918 ms +- 6 ms: 1.14x faster
decimal_pi: Mean +- std dev: [ref] 1.99 sec +- 0.02 sec -> [patch] 1.76 sec +- 0.02 sec: 1.13x faster
telco: Mean +- std dev: [ref] 78.7 ms +- 0.5 ms -> [patch] 73.5 ms +- 0.4 ms: 1.07x faster

Geometric mean: 1.11x faster
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116946 -->
* Issue: gh-116946
<!-- /gh-issue-number -->
