### PR TITLE
gh-156035: Validate pathlib rename and replace targets before filesystem changes

### DIFF
--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -1276,10 +1276,12 @@ class Path(PurePath):
 
         Returns the new Path instance pointing to the target path.
         """
-        if not hasattr(target, 'with_segments'):
-            target = self.with_segments(target)
+        if hasattr(target, 'with_segments'):
+            result = target
+        else:
+            result = self.with_segments(target)
         os.rename(self, target)
-        return target
+        return result
 
     def replace(self, target):
         """
@@ -1291,10 +1293,12 @@ class Path(PurePath):
 
         Returns the new Path instance pointing to the target path.
         """
-        if not hasattr(target, 'with_segments'):
-            target = self.with_segments(target)
+        if hasattr(target, 'with_segments'):
+            result = target
+        else:
+            result = self.with_segments(target)
         os.replace(self, target)
-        return target
+        return result
 
     def copy(self, target, **kwargs):
         """

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -1276,9 +1276,9 @@ class Path(PurePath):
 
         Returns the new Path instance pointing to the target path.
         """
-        os.rename(self, target)
         if not hasattr(target, 'with_segments'):
             target = self.with_segments(target)
+        os.rename(self, target)
         return target
 
     def replace(self, target):
@@ -1291,9 +1291,9 @@ class Path(PurePath):
 
         Returns the new Path instance pointing to the target path.
         """
-        os.replace(self, target)
         if not hasattr(target, 'with_segments'):
             target = self.with_segments(target)
+        os.replace(self, target)
         return target
 
     def copy(self, target, **kwargs):

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -2309,6 +2309,18 @@ class PathTest(PurePathTest):
         self.assertEqual(os.stat(r).st_size, size)
         self.assertFileNotFound(q.stat)
 
+    def test_rename_bytes_target(self):
+        P = self.cls(self.base)
+        source = P / 'fileA'
+        target = P / 'dirA' / 'fileAA'
+        target_bytes = os.fsencode(target)
+        for target_arg in (target_bytes, FakePath(target_bytes)):
+            with self.subTest(target=target_arg):
+                with self.assertRaises(TypeError):
+                    source.rename(target_arg)
+                self.assertTrue(source.exists())
+                self.assertFalse(target.exists())
+
     def test_replace(self):
         P = self.cls(self.base)
         p = P / 'fileA'
@@ -2325,6 +2337,18 @@ class PathTest(PurePathTest):
         self.assertEqual(replaced_q, self.cls(r))
         self.assertEqual(os.stat(r).st_size, size)
         self.assertFileNotFound(q.stat)
+
+    def test_replace_bytes_target(self):
+        P = self.cls(self.base)
+        source = P / 'fileA'
+        target = P / 'dirA' / 'fileAA'
+        target_bytes = os.fsencode(target)
+        for target_arg in (target_bytes, FakePath(target_bytes)):
+            with self.subTest(target=target_arg):
+                with self.assertRaises(TypeError):
+                    source.replace(target_arg)
+                self.assertTrue(source.exists())
+                self.assertFalse(target.exists())
 
     def test_touch_common(self):
         P = self.cls(self.base)

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -2321,6 +2321,15 @@ class PathTest(PurePathTest):
                 self.assertTrue(source.exists())
                 self.assertFalse(target.exists())
 
+    def test_rename_preserves_target(self):
+        P = self.cls(self.base)
+        source = P / 'fileA'
+        target = str(P / 'dirA' / 'fileAA') + self.parser.sep
+        with mock.patch.object(os, 'rename') as rename:
+            renamed = source.rename(target)
+        rename.assert_called_once_with(source, target)
+        self.assertEqual(renamed, self.cls(target))
+
     def test_replace(self):
         P = self.cls(self.base)
         p = P / 'fileA'
@@ -2349,6 +2358,15 @@ class PathTest(PurePathTest):
                     source.replace(target_arg)
                 self.assertTrue(source.exists())
                 self.assertFalse(target.exists())
+
+    def test_replace_preserves_target(self):
+        P = self.cls(self.base)
+        source = P / 'fileA'
+        target = str(P / 'dirA' / 'fileAA') + self.parser.sep
+        with mock.patch.object(os, 'replace') as replace:
+            replaced = source.replace(target)
+        replace.assert_called_once_with(source, target)
+        self.assertEqual(replaced, self.cls(target))
 
     def test_touch_common(self):
         P = self.cls(self.base)

--- a/Misc/NEWS.d/next/Library/2026-08-19-14-58-39.gh-issue-156035.7A9axQ.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-19-14-58-39.gh-issue-156035.7A9axQ.rst
@@ -1,0 +1,4 @@
+Fix :meth:`pathlib.Path.rename` and :meth:`pathlib.Path.replace` to validate
+the target before modifying the filesystem. Passing a bytes path, including
+a path-like object returning bytes, now raises :exc:`TypeError` without
+moving the source.


### PR DESCRIPTION


Validate targets before modifying the filesystem so invalid bytes paths raise TypeError without moving the source.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156035 -->
* Issue: gh-156035
<!-- /gh-issue-number -->
