### PR TITLE
gh-156049: Allow building with hardware address sanitizer

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -556,7 +556,7 @@ extern "C" {
 #      define _Py_MSAN_UNPOISON(PTR, SIZE)  (__msan_unpoison(PTR, SIZE))
 #    endif
 #  endif
-#  if __has_feature(address_sanitizer)
+#  if __has_feature(address_sanitizer) || __has_feature(hwaddress_sanitizer)
 #    if !defined(_Py_ADDRESS_SANITIZER)
 #      define _Py_ADDRESS_SANITIZER
 #      define _Py_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
@@ -569,7 +569,7 @@ extern "C" {
 #    endif
 #  endif
 #elif defined(__GNUC__)
-#  if defined(__SANITIZE_ADDRESS__)
+#  if defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_HWADDRESS__)
 #    define _Py_ADDRESS_SANITIZER
 #    define _Py_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
 #  endif

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -463,6 +463,7 @@ def check_sanitizer(*, address=False, memory=False, ub=False, thread=False,
     )
     address_sanitizer = (
         '-fsanitize=address' in cflags or
+        '-fsanitize=hwaddress' in cflags or
         '--with-address-sanitizer' in config_args
     )
     ub_sanitizer = (


### PR DESCRIPTION
There is a hardware address sanitizer

* The main documentation is on https://source.android.com/docs/security/test/hwasan
* The llvm doc is https://clang.llvm.org/docs/HardwareAssistedAddressSanitizerDesign.html

I'd like the CPython to be *buildable* with the hwasan config.

Feel free to object if you see that it's against the CPython direction.

<!-- gh-issue-number: gh-156049 -->
* Issue: gh-156049
<!-- /gh-issue-number -->
