### PR TITLE
gh-65961: Document __cached__ removal in What's New & clarify references to it

### DIFF
--- a/Doc/c-api/import.rst
+++ b/Doc/c-api/import.rst
@@ -146,7 +146,7 @@ Importing Modules
       alternatives.
 
    .. versionchanged:: 3.15
-      ``__cached__`` is no longer set.
+      The ``__cached__`` attribute is no longer set.
 
 
 .. c:function:: PyObject* PyImport_ExecCodeModuleEx(const char *name, PyObject *co, const char *pathname)
@@ -170,7 +170,7 @@ Importing Modules
       :class:`~importlib.machinery.ModuleSpec` for alternatives.
 
    .. versionchanged:: 3.15
-      ``__cached__`` no longer set.
+      The ``__cached__`` attribute no longer set.
 
 
 .. c:function:: PyObject* PyImport_ExecCodeModuleWithPathnames(const char *name, PyObject *co, const char *pathname, const char *cpathname)

--- a/Doc/deprecations/pending-removal-in-3.15.rst
+++ b/Doc/deprecations/pending-removal-in-3.15.rst
@@ -1,6 +1,13 @@
 Pending removal in Python 3.15
 ------------------------------
 
+* The import system:
+
+  * Setting ``__cached__`` on a module while
+    failing to set :attr:`__spec__.cached <importlib.machinery.ModuleSpec.cached>`
+    is deprecated. In Python 3.15, ``__cached__`` will cease to be set or
+    take into consideration by the import system or standard library. (:gh:`97879`)
+
 * :mod:`ctypes`:
 
   * The undocumented :func:`!ctypes.SetPointerType` function

--- a/Doc/deprecations/pending-removal-in-3.15.rst
+++ b/Doc/deprecations/pending-removal-in-3.15.rst
@@ -1,13 +1,6 @@
 Pending removal in Python 3.15
 ------------------------------
 
-* The import system:
-
-  * Setting ``__cached__`` on a module while
-    failing to set :attr:`__spec__.cached <importlib.machinery.ModuleSpec.cached>`
-    is deprecated. In Python 3.15, ``__cached__`` will cease to be set or
-    take into consideration by the import system or standard library. (:gh:`97879`)
-
 * :mod:`ctypes`:
 
   * The undocumented :func:`!ctypes.SetPointerType` function

--- a/Doc/library/runpy.rst
+++ b/Doc/library/runpy.rst
@@ -97,7 +97,7 @@ The :mod:`!runpy` module provides two functions:
       :class:`~importlib.machinery.ModuleSpec` for alternatives.
 
    .. versionchanged:: 3.15
-      ``__cached__`` is no longer set.
+      The global variable ``__cached__`` is no longer set.
 
 .. function:: run_path(path_name, init_globals=None, run_name=None)
 
@@ -175,7 +175,7 @@ The :mod:`!runpy` module provides two functions:
       ``__package__`` are deprecated.
 
    .. versionchanged:: 3.15
-      ``__cached__`` is no longer set.
+      The global variable ``__cached__`` is no longer set.
 
 .. seealso::
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1099,14 +1099,9 @@ this approach.
    :ref:`import system <importsystem>` may opt to leave it unset if it
    has no semantic meaning (for example, a module loaded from a database).
 
-   .. deprecated-removed:: 3.13 3.15
-      Setting ``__cached__`` on a module while failing to set
-      :attr:`!__spec__.cached` is deprecated. In Python 3.15,
-      ``__cached__`` will cease to be set or taken into consideration by
-      the import system or standard library.
-
-   .. versionchanged:: 3.15
-      ``__cached__`` is no longer set.
+.. versionchanged:: 3.15
+   The ``__cached__`` attribute is no longer set on modules or taken into
+   consideration by the import system or standard library.
 
 Other writable attributes on module objects
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -880,6 +880,14 @@ Other language changes
   other, as regular dynamic extensions do.
   (Contributed by Stefano Rivera in :gh:`122931`.)
 
+* The ``__cached__`` attribute on modules, which was deprecated since version
+  3.13, is no longer set or taken into consideration by the import system or
+  standard library.
+  Use :attr:`__spec__.cached <importlib.machinery.ModuleSpec.cached>` instead.
+  (Contributed by Brett Cannon in :gh:`97879`)
+
+  Note that the :attr:`~module.__loader__` and :attr:`~module.__package__`
+  attributes are also deprecated and scheduled for removal.
 
 
 Default interactive shell


### PR DESCRIPTION

- Move deprecation notice to Whatsnew change list.
  - Add a note that `__loader__` & `__package__` are next. (These also link to relevant docs.)
- Clarify references to ``__cached__`` now that the term doesn't link to its docs.
- Move the ``.. versionchanged`` from ``__file__`` docs to the top level, and remove the historical ``.. deprecated-removed::`` (fixes gh-145299).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-65961 -->
* Issue: gh-65961
<!-- /gh-issue-number -->
