### PR TITLE
gh-156058: Disallow lone starred expressions at the grammar level

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -732,7 +732,8 @@ star_expressions[expr_ty]:
     | a=star_expression b=(',' c=star_expression { c })+ [','] {
         _PyAST_Tuple(CHECK(asdl_expr_seq*, _PyPegen_seq_insert_in_front(p, a, b)), Load, EXTRA) }
     | a=star_expression ',' { _PyAST_Tuple(CHECK(asdl_expr_seq*, _PyPegen_singleton_seq(p, a)), Load, EXTRA) }
-    | star_expression
+    | expression
+    | invalid_lone_star_expression
 
 star_expression[expr_ty] (memo):
     | '*' a=bitwise_or { _PyAST_Starred(a, Load, EXTRA) }
@@ -1245,7 +1246,7 @@ expression_without_invalid[expr_ty]:
     | disjunction
     | lambdef
 invalid_legacy_expression:
-    | a=NAME !'(' b=star_expressions {
+    | a=NAME !'(' !'*' b=star_expressions {
         _PyPegen_check_legacy_stmt(p, a) ? RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b,
             "Missing parentheses in call to '%U'. Did you mean %U(...)?", a->v.Name.id, a->v.Name.id) : NULL}
 
@@ -1295,6 +1296,9 @@ invalid_named_expression(memo):
         RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "cannot assign to %s here. Maybe you meant '==' instead of '='?",
                                           _PyPegen_get_expr_name(a)) }
 
+invalid_lone_star_expression:
+    | a='*' b=bitwise_or { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "can't use starred expression here") }
+
 invalid_assignment:
     | a=invalid_ann_assign_target ':' expression {
         RAISE_SYNTAX_ERROR_KNOWN_LOCATION(
@@ -1325,6 +1329,8 @@ invalid_raise_stmt:
     | 'raise' expression a='from' {
         RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "did you forget an expression after 'from'?") }
 invalid_del_stmt:
+    | 'del' &'*' a=star_expression {
+        RAISE_SYNTAX_ERROR_INVALID_TARGET(DEL_TARGETS, a) }
     | 'del' a=star_expressions {
         RAISE_SYNTAX_ERROR_INVALID_TARGET(DEL_TARGETS, a) }
 invalid_assert_stmt:

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -22,28 +22,28 @@ static KeywordToken *reserved_keywords[] = {
     (KeywordToken[]) {{NULL, -1}},
     (KeywordToken[]) {{NULL, -1}},
     (KeywordToken[]) {
-        {"if", 700},
-        {"as", 698},
-        {"in", 713},
+        {"if", 701},
+        {"as", 699},
+        {"in", 714},
         {"or", 589},
         {"is", 597},
         {NULL, -1},
     },
     (KeywordToken[]) {
-        {"del", 634},
-        {"def", 717},
-        {"for", 712},
-        {"try", 674},
+        {"del", 635},
+        {"def", 718},
+        {"for", 713},
+        {"try", 675},
         {"and", 590},
-        {"not", 721},
+        {"not", 722},
         {NULL, -1},
     },
     (KeywordToken[]) {
-        {"from", 650},
+        {"from", 651},
         {"pass", 527},
-        {"with", 665},
-        {"elif", 705},
-        {"else", 704},
+        {"with", 666},
+        {"elif", 706},
+        {"else", 705},
         {"None", 628},
         {"True", 627},
         {NULL, -1},
@@ -52,24 +52,24 @@ static KeywordToken *reserved_keywords[] = {
         {"raise", 632},
         {"yield", 588},
         {"break", 528},
-        {"async", 716},
-        {"class", 719},
-        {"while", 707},
+        {"async", 717},
+        {"class", 720},
+        {"while", 708},
         {"False", 629},
         {"await", 598},
         {NULL, -1},
     },
     (KeywordToken[]) {
-        {"import", 651},
+        {"import", 652},
         {"return", 522},
-        {"assert", 638},
+        {"assert", 639},
         {"global", 530},
-        {"except", 695},
+        {"except", 696},
         {"lambda", 622},
         {NULL, -1},
     },
     (KeywordToken[]) {
-        {"finally", 691},
+        {"finally", 692},
         {NULL, -1},
     },
     (KeywordToken[]) {
@@ -302,249 +302,250 @@ static char *soft_keywords[] = {
 #define invalid_expression_type 1213
 #define invalid_if_expression_type 1214
 #define invalid_named_expression_type 1215
-#define invalid_assignment_type 1216
-#define invalid_ann_assign_target_type 1217
-#define invalid_raise_stmt_type 1218
-#define invalid_del_stmt_type 1219
-#define invalid_assert_stmt_type 1220
-#define invalid_block_type 1221
-#define invalid_comprehension_type 1222
-#define invalid_parameters_type 1223
-#define invalid_default_type 1224
-#define invalid_star_etc_type 1225
-#define invalid_kwds_type 1226
-#define invalid_parameters_helper_type 1227
-#define invalid_lambda_parameters_type 1228
-#define invalid_lambda_parameters_helper_type 1229
-#define invalid_lambda_star_etc_type 1230
-#define invalid_lambda_kwds_type 1231
-#define invalid_double_type_comments_type 1232
-#define invalid_with_item_type 1233
-#define invalid_for_if_clause_type 1234
-#define invalid_for_target_type 1235
-#define invalid_group_type 1236
-#define invalid_import_type 1237
-#define invalid_dotted_as_name_type 1238
-#define invalid_import_from_as_name_type 1239
-#define invalid_import_from_type 1240
-#define invalid_import_from_targets_type 1241
-#define invalid_with_stmt_type 1242
-#define invalid_with_stmt_indent_type 1243
-#define invalid_try_stmt_type 1244
-#define invalid_except_stmt_type 1245
-#define invalid_except_star_stmt_type 1246
-#define invalid_finally_stmt_type 1247
-#define invalid_except_stmt_indent_type 1248
-#define invalid_except_star_stmt_indent_type 1249
-#define invalid_match_stmt_type 1250
-#define invalid_case_block_type 1251
-#define invalid_as_pattern_type 1252
-#define invalid_class_pattern_type 1253
-#define invalid_mapping_pattern_type 1254
-#define invalid_class_argument_pattern_type 1255
-#define invalid_if_stmt_type 1256
-#define invalid_elif_stmt_type 1257
-#define invalid_else_stmt_type 1258
-#define invalid_while_stmt_type 1259
-#define invalid_for_stmt_type 1260
-#define invalid_def_raw_type 1261
-#define invalid_class_def_raw_type 1262
-#define invalid_double_starred_kvpairs_type 1263
-#define invalid_kvpair_unpacking_type 1264
-#define invalid_kvpair_type 1265
-#define invalid_starred_expression_unpacking_type 1266
-#define invalid_starred_expression_unpacking_sequence_type 1267
-#define invalid_starred_expression_type 1268
-#define invalid_fstring_replacement_field_type 1269
-#define invalid_fstring_conversion_character_type 1270
-#define invalid_tstring_replacement_field_type 1271
-#define invalid_tstring_conversion_character_type 1272
-#define invalid_string_tstring_concat_type 1273
-#define invalid_arithmetic_type 1274  // Left-recursive
-#define invalid_factor_type 1275
-#define invalid_type_params_type 1276
-#define invalid_bitwise_and_type 1277  // Left-recursive
-#define invalid_bitwise_or_type 1278  // Left-recursive
-#define _loop0_1_type 1279
-#define _loop1_2_type 1280
-#define _loop0_3_type 1281
-#define _gather_4_type 1282
-#define _tmp_5_type 1283
-#define _tmp_6_type 1284
-#define _tmp_7_type 1285
-#define _tmp_8_type 1286
-#define _tmp_9_type 1287
-#define _tmp_10_type 1288
-#define _tmp_11_type 1289
-#define _loop1_12_type 1290
-#define _loop0_13_type 1291
-#define _gather_14_type 1292
-#define _tmp_15_type 1293
-#define _tmp_16_type 1294
-#define _loop0_17_type 1295
-#define _loop1_18_type 1296
-#define _loop0_19_type 1297
-#define _gather_20_type 1298
-#define _tmp_21_type 1299
-#define _loop0_22_type 1300
-#define _gather_23_type 1301
-#define _loop1_24_type 1302
-#define _tmp_25_type 1303
-#define _tmp_26_type 1304
-#define _loop0_27_type 1305
-#define _loop0_28_type 1306
-#define _loop1_29_type 1307
-#define _loop1_30_type 1308
-#define _loop0_31_type 1309
-#define _loop1_32_type 1310
-#define _loop0_33_type 1311
-#define _gather_34_type 1312
-#define _tmp_35_type 1313
-#define _loop1_36_type 1314
-#define _loop1_37_type 1315
-#define _loop1_38_type 1316
-#define _loop0_39_type 1317
-#define _gather_40_type 1318
-#define _tmp_41_type 1319
-#define _tmp_42_type 1320
-#define _tmp_43_type 1321
-#define _loop0_44_type 1322
-#define _gather_45_type 1323
-#define _loop0_46_type 1324
-#define _gather_47_type 1325
-#define _tmp_48_type 1326
-#define _loop0_49_type 1327
-#define _gather_50_type 1328
-#define _loop0_51_type 1329
-#define _gather_52_type 1330
-#define _loop0_53_type 1331
-#define _gather_54_type 1332
-#define _loop1_55_type 1333
-#define _loop1_56_type 1334
-#define _loop0_57_type 1335
-#define _gather_58_type 1336
-#define _loop0_59_type 1337
-#define _gather_60_type 1338
-#define _loop1_61_type 1339
-#define _loop1_62_type 1340
-#define _loop1_63_type 1341
-#define _tmp_64_type 1342
-#define _loop0_65_type 1343
-#define _gather_66_type 1344
-#define _tmp_67_type 1345
-#define _tmp_68_type 1346
-#define _tmp_69_type 1347
-#define _tmp_70_type 1348
-#define _tmp_71_type 1349
-#define _loop0_72_type 1350
-#define _loop0_73_type 1351
-#define _loop1_74_type 1352
-#define _loop1_75_type 1353
-#define _loop0_76_type 1354
-#define _loop1_77_type 1355
-#define _loop0_78_type 1356
-#define _loop0_79_type 1357
-#define _loop0_80_type 1358
-#define _loop0_81_type 1359
-#define _loop1_82_type 1360
-#define _loop1_83_type 1361
-#define _tmp_84_type 1362
-#define _loop0_85_type 1363
-#define _gather_86_type 1364
-#define _loop1_87_type 1365
-#define _loop0_88_type 1366
-#define _tmp_89_type 1367
-#define _loop0_90_type 1368
-#define _gather_91_type 1369
-#define _tmp_92_type 1370
-#define _loop0_93_type 1371
-#define _gather_94_type 1372
-#define _loop0_95_type 1373
-#define _gather_96_type 1374
-#define _loop0_97_type 1375
-#define _loop0_98_type 1376
-#define _gather_99_type 1377
-#define _loop1_100_type 1378
-#define _tmp_101_type 1379
-#define _loop0_102_type 1380
-#define _gather_103_type 1381
-#define _loop0_104_type 1382
-#define _gather_105_type 1383
-#define _tmp_106_type 1384
-#define _tmp_107_type 1385
-#define _loop0_108_type 1386
-#define _gather_109_type 1387
-#define _tmp_110_type 1388
-#define _tmp_111_type 1389
-#define _tmp_112_type 1390
-#define _tmp_113_type 1391
-#define _tmp_114_type 1392
-#define _loop1_115_type 1393
-#define _tmp_116_type 1394
-#define _tmp_117_type 1395
-#define _tmp_118_type 1396
-#define _tmp_119_type 1397
-#define _tmp_120_type 1398
-#define _loop0_121_type 1399
-#define _loop0_122_type 1400
-#define _tmp_123_type 1401
-#define _tmp_124_type 1402
-#define _tmp_125_type 1403
-#define _tmp_126_type 1404
-#define _tmp_127_type 1405
-#define _tmp_128_type 1406
-#define _tmp_129_type 1407
-#define _tmp_130_type 1408
-#define _loop0_131_type 1409
-#define _gather_132_type 1410
-#define _tmp_133_type 1411
-#define _tmp_134_type 1412
-#define _tmp_135_type 1413
-#define _tmp_136_type 1414
-#define _loop0_137_type 1415
-#define _gather_138_type 1416
-#define _tmp_139_type 1417
-#define _loop0_140_type 1418
-#define _gather_141_type 1419
-#define _loop0_142_type 1420
-#define _gather_143_type 1421
-#define _tmp_144_type 1422
-#define _loop0_145_type 1423
-#define _tmp_146_type 1424
-#define _tmp_147_type 1425
-#define _tmp_148_type 1426
-#define _tmp_149_type 1427
-#define _tmp_150_type 1428
-#define _tmp_151_type 1429
-#define _tmp_152_type 1430
-#define _tmp_153_type 1431
-#define _tmp_154_type 1432
-#define _tmp_155_type 1433
-#define _tmp_156_type 1434
-#define _tmp_157_type 1435
-#define _tmp_158_type 1436
-#define _tmp_159_type 1437
-#define _tmp_160_type 1438
-#define _tmp_161_type 1439
-#define _tmp_162_type 1440
-#define _tmp_163_type 1441
-#define _tmp_164_type 1442
-#define _tmp_165_type 1443
-#define _tmp_166_type 1444
-#define _tmp_167_type 1445
-#define _tmp_168_type 1446
-#define _tmp_169_type 1447
-#define _tmp_170_type 1448
-#define _tmp_171_type 1449
-#define _tmp_172_type 1450
-#define _tmp_173_type 1451
-#define _loop0_174_type 1452
-#define _tmp_175_type 1453
-#define _tmp_176_type 1454
-#define _tmp_177_type 1455
-#define _tmp_178_type 1456
-#define _tmp_179_type 1457
-#define _tmp_180_type 1458
+#define invalid_lone_star_expression_type 1216
+#define invalid_assignment_type 1217
+#define invalid_ann_assign_target_type 1218
+#define invalid_raise_stmt_type 1219
+#define invalid_del_stmt_type 1220
+#define invalid_assert_stmt_type 1221
+#define invalid_block_type 1222
+#define invalid_comprehension_type 1223
+#define invalid_parameters_type 1224
+#define invalid_default_type 1225
+#define invalid_star_etc_type 1226
+#define invalid_kwds_type 1227
+#define invalid_parameters_helper_type 1228
+#define invalid_lambda_parameters_type 1229
+#define invalid_lambda_parameters_helper_type 1230
+#define invalid_lambda_star_etc_type 1231
+#define invalid_lambda_kwds_type 1232
+#define invalid_double_type_comments_type 1233
+#define invalid_with_item_type 1234
+#define invalid_for_if_clause_type 1235
+#define invalid_for_target_type 1236
+#define invalid_group_type 1237
+#define invalid_import_type 1238
+#define invalid_dotted_as_name_type 1239
+#define invalid_import_from_as_name_type 1240
+#define invalid_import_from_type 1241
+#define invalid_import_from_targets_type 1242
+#define invalid_with_stmt_type 1243
+#define invalid_with_stmt_indent_type 1244
+#define invalid_try_stmt_type 1245
+#define invalid_except_stmt_type 1246
+#define invalid_except_star_stmt_type 1247
+#define invalid_finally_stmt_type 1248
+#define invalid_except_stmt_indent_type 1249
+#define invalid_except_star_stmt_indent_type 1250
+#define invalid_match_stmt_type 1251
+#define invalid_case_block_type 1252
+#define invalid_as_pattern_type 1253
+#define invalid_class_pattern_type 1254
+#define invalid_mapping_pattern_type 1255
+#define invalid_class_argument_pattern_type 1256
+#define invalid_if_stmt_type 1257
+#define invalid_elif_stmt_type 1258
+#define invalid_else_stmt_type 1259
+#define invalid_while_stmt_type 1260
+#define invalid_for_stmt_type 1261
+#define invalid_def_raw_type 1262
+#define invalid_class_def_raw_type 1263
+#define invalid_double_starred_kvpairs_type 1264
+#define invalid_kvpair_unpacking_type 1265
+#define invalid_kvpair_type 1266
+#define invalid_starred_expression_unpacking_type 1267
+#define invalid_starred_expression_unpacking_sequence_type 1268
+#define invalid_starred_expression_type 1269
+#define invalid_fstring_replacement_field_type 1270
+#define invalid_fstring_conversion_character_type 1271
+#define invalid_tstring_replacement_field_type 1272
+#define invalid_tstring_conversion_character_type 1273
+#define invalid_string_tstring_concat_type 1274
+#define invalid_arithmetic_type 1275  // Left-recursive
+#define invalid_factor_type 1276
+#define invalid_type_params_type 1277
+#define invalid_bitwise_and_type 1278  // Left-recursive
+#define invalid_bitwise_or_type 1279  // Left-recursive
+#define _loop0_1_type 1280
+#define _loop1_2_type 1281
+#define _loop0_3_type 1282
+#define _gather_4_type 1283
+#define _tmp_5_type 1284
+#define _tmp_6_type 1285
+#define _tmp_7_type 1286
+#define _tmp_8_type 1287
+#define _tmp_9_type 1288
+#define _tmp_10_type 1289
+#define _tmp_11_type 1290
+#define _loop1_12_type 1291
+#define _loop0_13_type 1292
+#define _gather_14_type 1293
+#define _tmp_15_type 1294
+#define _tmp_16_type 1295
+#define _loop0_17_type 1296
+#define _loop1_18_type 1297
+#define _loop0_19_type 1298
+#define _gather_20_type 1299
+#define _tmp_21_type 1300
+#define _loop0_22_type 1301
+#define _gather_23_type 1302
+#define _loop1_24_type 1303
+#define _tmp_25_type 1304
+#define _tmp_26_type 1305
+#define _loop0_27_type 1306
+#define _loop0_28_type 1307
+#define _loop1_29_type 1308
+#define _loop1_30_type 1309
+#define _loop0_31_type 1310
+#define _loop1_32_type 1311
+#define _loop0_33_type 1312
+#define _gather_34_type 1313
+#define _tmp_35_type 1314
+#define _loop1_36_type 1315
+#define _loop1_37_type 1316
+#define _loop1_38_type 1317
+#define _loop0_39_type 1318
+#define _gather_40_type 1319
+#define _tmp_41_type 1320
+#define _tmp_42_type 1321
+#define _tmp_43_type 1322
+#define _loop0_44_type 1323
+#define _gather_45_type 1324
+#define _loop0_46_type 1325
+#define _gather_47_type 1326
+#define _tmp_48_type 1327
+#define _loop0_49_type 1328
+#define _gather_50_type 1329
+#define _loop0_51_type 1330
+#define _gather_52_type 1331
+#define _loop0_53_type 1332
+#define _gather_54_type 1333
+#define _loop1_55_type 1334
+#define _loop1_56_type 1335
+#define _loop0_57_type 1336
+#define _gather_58_type 1337
+#define _loop0_59_type 1338
+#define _gather_60_type 1339
+#define _loop1_61_type 1340
+#define _loop1_62_type 1341
+#define _loop1_63_type 1342
+#define _tmp_64_type 1343
+#define _loop0_65_type 1344
+#define _gather_66_type 1345
+#define _tmp_67_type 1346
+#define _tmp_68_type 1347
+#define _tmp_69_type 1348
+#define _tmp_70_type 1349
+#define _tmp_71_type 1350
+#define _loop0_72_type 1351
+#define _loop0_73_type 1352
+#define _loop1_74_type 1353
+#define _loop1_75_type 1354
+#define _loop0_76_type 1355
+#define _loop1_77_type 1356
+#define _loop0_78_type 1357
+#define _loop0_79_type 1358
+#define _loop0_80_type 1359
+#define _loop0_81_type 1360
+#define _loop1_82_type 1361
+#define _loop1_83_type 1362
+#define _tmp_84_type 1363
+#define _loop0_85_type 1364
+#define _gather_86_type 1365
+#define _loop1_87_type 1366
+#define _loop0_88_type 1367
+#define _tmp_89_type 1368
+#define _loop0_90_type 1369
+#define _gather_91_type 1370
+#define _tmp_92_type 1371
+#define _loop0_93_type 1372
+#define _gather_94_type 1373
+#define _loop0_95_type 1374
+#define _gather_96_type 1375
+#define _loop0_97_type 1376
+#define _loop0_98_type 1377
+#define _gather_99_type 1378
+#define _loop1_100_type 1379
+#define _tmp_101_type 1380
+#define _loop0_102_type 1381
+#define _gather_103_type 1382
+#define _loop0_104_type 1383
+#define _gather_105_type 1384
+#define _tmp_106_type 1385
+#define _tmp_107_type 1386
+#define _loop0_108_type 1387
+#define _gather_109_type 1388
+#define _tmp_110_type 1389
+#define _tmp_111_type 1390
+#define _tmp_112_type 1391
+#define _tmp_113_type 1392
+#define _tmp_114_type 1393
+#define _loop1_115_type 1394
+#define _tmp_116_type 1395
+#define _tmp_117_type 1396
+#define _tmp_118_type 1397
+#define _tmp_119_type 1398
+#define _tmp_120_type 1399
+#define _loop0_121_type 1400
+#define _loop0_122_type 1401
+#define _tmp_123_type 1402
+#define _tmp_124_type 1403
+#define _tmp_125_type 1404
+#define _tmp_126_type 1405
+#define _tmp_127_type 1406
+#define _tmp_128_type 1407
+#define _tmp_129_type 1408
+#define _tmp_130_type 1409
+#define _loop0_131_type 1410
+#define _gather_132_type 1411
+#define _tmp_133_type 1412
+#define _tmp_134_type 1413
+#define _tmp_135_type 1414
+#define _tmp_136_type 1415
+#define _loop0_137_type 1416
+#define _gather_138_type 1417
+#define _tmp_139_type 1418
+#define _loop0_140_type 1419
+#define _gather_141_type 1420
+#define _loop0_142_type 1421
+#define _gather_143_type 1422
+#define _tmp_144_type 1423
+#define _loop0_145_type 1424
+#define _tmp_146_type 1425
+#define _tmp_147_type 1426
+#define _tmp_148_type 1427
+#define _tmp_149_type 1428
+#define _tmp_150_type 1429
+#define _tmp_151_type 1430
+#define _tmp_152_type 1431
+#define _tmp_153_type 1432
+#define _tmp_154_type 1433
+#define _tmp_155_type 1434
+#define _tmp_156_type 1435
+#define _tmp_157_type 1436
+#define _tmp_158_type 1437
+#define _tmp_159_type 1438
+#define _tmp_160_type 1439
+#define _tmp_161_type 1440
+#define _tmp_162_type 1441
+#define _tmp_163_type 1442
+#define _tmp_164_type 1443
+#define _tmp_165_type 1444
+#define _tmp_166_type 1445
+#define _tmp_167_type 1446
+#define _tmp_168_type 1447
+#define _tmp_169_type 1448
+#define _tmp_170_type 1449
+#define _tmp_171_type 1450
+#define _tmp_172_type 1451
+#define _tmp_173_type 1452
+#define _loop0_174_type 1453
+#define _tmp_175_type 1454
+#define _tmp_176_type 1455
+#define _tmp_177_type 1456
+#define _tmp_178_type 1457
+#define _tmp_179_type 1458
+#define _tmp_180_type 1459
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
@@ -762,6 +763,7 @@ static void *invalid_type_param_rule(Parser *p);
 static void *invalid_expression_rule(Parser *p);
 static void *invalid_if_expression_rule(Parser *p);
 static void *invalid_named_expression_rule(Parser *p);
+static void *invalid_lone_star_expression_rule(Parser *p);
 static void *invalid_assignment_rule(Parser *p);
 static expr_ty invalid_ann_assign_target_rule(Parser *p);
 static void *invalid_raise_stmt_rule(Parser *p);
@@ -1774,7 +1776,7 @@ simple_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'del' del_stmt"));
         stmt_ty del_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 634)  // token='del'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 635)  // token='del'
             &&
             (del_stmt_var = del_stmt_rule(p))  // del_stmt
         )
@@ -1816,7 +1818,7 @@ simple_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'assert' assert_stmt"));
         stmt_ty assert_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 638)  // token='assert'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 639)  // token='assert'
             &&
             (assert_stmt_var = assert_stmt_rule(p))  // assert_stmt
         )
@@ -1970,7 +1972,7 @@ compound_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'if' if_stmt"));
         stmt_ty if_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 700)  // token='if'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 701)  // token='if'
             &&
             (if_stmt_var = if_stmt_rule(p))  // if_stmt
         )
@@ -2054,7 +2056,7 @@ compound_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'try' try_stmt"));
         stmt_ty try_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 674)  // token='try'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 675)  // token='try'
             &&
             (try_stmt_var = try_stmt_rule(p))  // try_stmt
         )
@@ -2075,7 +2077,7 @@ compound_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'while' while_stmt"));
         stmt_ty while_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 707)  // token='while'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 708)  // token='while'
             &&
             (while_stmt_var = while_stmt_rule(p))  // while_stmt
         )
@@ -2842,7 +2844,7 @@ raise_stmt_rule(Parser *p)
             &&
             (a = expression_rule(p))  // expression
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 650))  // token='from'
+            (_keyword_1 = _PyPegen_expect_token(p, 651))  // token='from'
             &&
             (b = expression_rule(p))  // expression
         )
@@ -3305,7 +3307,7 @@ del_stmt_rule(Parser *p)
         Token * _keyword;
         asdl_expr_seq* a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 634))  // token='del'
+            (_keyword = _PyPegen_expect_token(p, 635))  // token='del'
             &&
             (a = del_targets_rule(p))  // del_targets
             &&
@@ -3471,7 +3473,7 @@ assert_stmt_rule(Parser *p)
         expr_ty a;
         void *b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 638))  // token='assert'
+            (_keyword = _PyPegen_expect_token(p, 639))  // token='assert'
             &&
             (a = expression_rule(p))  // expression
             &&
@@ -3621,7 +3623,7 @@ import_name_rule(Parser *p)
         if (
             (lazy = _PyPegen_expect_soft_keyword(p, "lazy"), !p->error_indicator)  // "lazy"?
             &&
-            (_keyword = _PyPegen_expect_token(p, 651))  // token='import'
+            (_keyword = _PyPegen_expect_token(p, 652))  // token='import'
             &&
             (a = dotted_as_names_rule(p))  // dotted_as_names
         )
@@ -3713,13 +3715,13 @@ import_from_rule(Parser *p)
         if (
             (lazy = _PyPegen_expect_soft_keyword(p, "lazy"), !p->error_indicator)  // "lazy"?
             &&
-            (_keyword = _PyPegen_expect_token(p, 650))  // token='from'
+            (_keyword = _PyPegen_expect_token(p, 651))  // token='from'
             &&
             (a = _loop0_17_rule(p))  // (('.' | '...'))*
             &&
             (b = dotted_name_rule(p))  // dotted_name
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 651))  // token='import'
+            (_keyword_1 = _PyPegen_expect_token(p, 652))  // token='import'
             &&
             (c = import_from_targets_rule(p))  // import_from_targets
         )
@@ -3760,11 +3762,11 @@ import_from_rule(Parser *p)
         if (
             (lazy = _PyPegen_expect_soft_keyword(p, "lazy"), !p->error_indicator)  // "lazy"?
             &&
-            (_keyword = _PyPegen_expect_token(p, 650))  // token='from'
+            (_keyword = _PyPegen_expect_token(p, 651))  // token='from'
             &&
             (a = _loop1_18_rule(p))  // (('.' | '...'))+
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 651))  // token='import'
+            (_keyword_1 = _PyPegen_expect_token(p, 652))  // token='import'
             &&
             (b = import_from_targets_rule(p))  // import_from_targets
         )
@@ -4551,7 +4553,7 @@ class_def_raw_rule(Parser *p)
         asdl_stmt_seq* c;
         void *t;
         if (
-            (_keyword = _PyPegen_expect_token(p, 719))  // token='class'
+            (_keyword = _PyPegen_expect_token(p, 720))  // token='class'
             &&
             (a = _PyPegen_name_token(p))  // NAME
             &&
@@ -4718,7 +4720,7 @@ function_def_raw_rule(Parser *p)
         void *t;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 717))  // token='def'
+            (_keyword = _PyPegen_expect_token(p, 718))  // token='def'
             &&
             (n = _PyPegen_name_token(p))  // NAME
             &&
@@ -4779,9 +4781,9 @@ function_def_raw_rule(Parser *p)
         void *t;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 716))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 717))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 717))  // token='def'
+            (_keyword_1 = _PyPegen_expect_token(p, 718))  // token='def'
             &&
             (n = _PyPegen_name_token(p))  // NAME
             &&
@@ -6119,7 +6121,7 @@ if_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         stmt_ty c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 700))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 701))  // token='if'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6164,7 +6166,7 @@ if_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 700))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 701))  // token='if'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6259,7 +6261,7 @@ elif_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         stmt_ty c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 705))  // token='elif'
+            (_keyword = _PyPegen_expect_token(p, 706))  // token='elif'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6304,7 +6306,7 @@ elif_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 705))  // token='elif'
+            (_keyword = _PyPegen_expect_token(p, 706))  // token='elif'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6385,7 +6387,7 @@ else_block_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 704))  // token='else'
+            (_keyword = _PyPegen_expect_token(p, 705))  // token='else'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -6464,7 +6466,7 @@ while_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 707))  // token='while'
+            (_keyword = _PyPegen_expect_token(p, 708))  // token='while'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6564,11 +6566,11 @@ for_stmt_rule(Parser *p)
         expr_ty t;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 712))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 713))  // token='for'
             &&
             (t = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 713))  // token='in'
+            (_keyword_1 = _PyPegen_expect_token(p, 714))  // token='in'
             &&
             (_cut_var = 1)
             &&
@@ -6626,13 +6628,13 @@ for_stmt_rule(Parser *p)
         expr_ty t;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 716))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 717))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 712))  // token='for'
+            (_keyword_1 = _PyPegen_expect_token(p, 713))  // token='for'
             &&
             (t = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_2 = _PyPegen_expect_token(p, 713))  // token='in'
+            (_keyword_2 = _PyPegen_expect_token(p, 714))  // token='in'
             &&
             (_cut_var = 1)
             &&
@@ -6761,7 +6763,7 @@ with_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 665))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 666))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -6812,7 +6814,7 @@ with_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 665))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 666))  // token='with'
             &&
             (a = (asdl_withitem_seq*)_gather_34_rule(p))  // ','.with_item+
             &&
@@ -6861,9 +6863,9 @@ with_stmt_rule(Parser *p)
         asdl_withitem_seq* a;
         asdl_stmt_seq* b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 716))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 717))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 665))  // token='with'
+            (_keyword_1 = _PyPegen_expect_token(p, 666))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -6913,9 +6915,9 @@ with_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 716))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 717))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 665))  // token='with'
+            (_keyword_1 = _PyPegen_expect_token(p, 666))  // token='with'
             &&
             (a = (asdl_withitem_seq*)_gather_34_rule(p))  // ','.with_item+
             &&
@@ -7001,7 +7003,7 @@ with_item_rule(Parser *p)
         if (
             (e = expression_rule(p))  // expression
             &&
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 699))  // token='as'
             &&
             (t = star_target_rule(p))  // star_target
             &&
@@ -7126,7 +7128,7 @@ try_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         asdl_stmt_seq* f;
         if (
-            (_keyword = _PyPegen_expect_token(p, 674))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 675))  // token='try'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -7170,7 +7172,7 @@ try_stmt_rule(Parser *p)
         asdl_excepthandler_seq* ex;
         void *f;
         if (
-            (_keyword = _PyPegen_expect_token(p, 674))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 675))  // token='try'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -7218,7 +7220,7 @@ try_stmt_rule(Parser *p)
         asdl_excepthandler_seq* ex;
         void *f;
         if (
-            (_keyword = _PyPegen_expect_token(p, 674))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 675))  // token='try'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -7317,7 +7319,7 @@ except_block_rule(Parser *p)
         asdl_stmt_seq* b;
         expr_ty e;
         if (
-            (_keyword = _PyPegen_expect_token(p, 695))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (e = expression_rule(p))  // expression
             &&
@@ -7361,11 +7363,11 @@ except_block_rule(Parser *p)
         expr_ty e;
         expr_ty t;
         if (
-            (_keyword = _PyPegen_expect_token(p, 695))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (e = expression_rule(p))  // expression
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 698))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 699))  // token='as'
             &&
             (t = _PyPegen_name_token(p))  // NAME
             &&
@@ -7407,7 +7409,7 @@ except_block_rule(Parser *p)
         asdl_stmt_seq* b;
         expr_ty e;
         if (
-            (_keyword = _PyPegen_expect_token(p, 695))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (e = expressions_rule(p))  // expressions
             &&
@@ -7448,7 +7450,7 @@ except_block_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 695))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -7560,7 +7562,7 @@ except_star_block_rule(Parser *p)
         asdl_stmt_seq* b;
         expr_ty e;
         if (
-            (_keyword = _PyPegen_expect_token(p, 695))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -7607,13 +7609,13 @@ except_star_block_rule(Parser *p)
         expr_ty e;
         expr_ty t;
         if (
-            (_keyword = _PyPegen_expect_token(p, 695))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
             (e = expression_rule(p))  // expression
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 698))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 699))  // token='as'
             &&
             (t = _PyPegen_name_token(p))  // NAME
             &&
@@ -7656,7 +7658,7 @@ except_star_block_rule(Parser *p)
         asdl_stmt_seq* b;
         expr_ty e;
         if (
-            (_keyword = _PyPegen_expect_token(p, 695))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -7756,7 +7758,7 @@ finally_block_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 691))  // token='finally'
+            (_keyword = _PyPegen_expect_token(p, 692))  // token='finally'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -8064,7 +8066,7 @@ guard_rule(Parser *p)
         Token * _keyword;
         expr_ty guard;
         if (
-            (_keyword = _PyPegen_expect_token(p, 700))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 701))  // token='if'
             &&
             (guard = named_expression_rule(p))  // named_expression
         )
@@ -8259,7 +8261,7 @@ as_pattern_rule(Parser *p)
         if (
             (pattern = or_pattern_rule(p))  // or_pattern
             &&
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 699))  // token='as'
             &&
             (target = pattern_capture_target_rule(p))  // pattern_capture_target
         )
@@ -11727,11 +11729,11 @@ if_expression_rule(Parser *p)
         if (
             (a = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 700))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 701))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 704))  // token='else'
+            (_keyword_1 = _PyPegen_expect_token(p, 705))  // token='else'
             &&
             (c = expression_rule(p))  // expression
         )
@@ -11798,7 +11800,7 @@ yield_expr_rule(Parser *p)
         if (
             (_keyword = _PyPegen_expect_token(p, 588))  // token='yield'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 650))  // token='from'
+            (_keyword_1 = _PyPegen_expect_token(p, 651))  // token='from'
             &&
             (a = expression_rule(p))  // expression
         )
@@ -11870,7 +11872,8 @@ yield_expr_rule(Parser *p)
 // star_expressions:
 //     | star_expression ((',' star_expression))+ ','?
 //     | star_expression ','
-//     | star_expression
+//     | expression
+//     | invalid_lone_star_expression
 static expr_ty
 star_expressions_rule(Parser *p)
 {
@@ -11968,24 +11971,43 @@ star_expressions_rule(Parser *p)
         D(fprintf(stderr, "%*c%s star_expressions[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "star_expression ','"));
     }
-    { // star_expression
+    { // expression
         if (p->error_indicator) {
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> star_expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "star_expression"));
-        expr_ty star_expression_var;
+        D(fprintf(stderr, "%*c> star_expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "expression"));
+        expr_ty expression_var;
         if (
-            (star_expression_var = star_expression_rule(p))  // star_expression
+            (expression_var = expression_rule(p))  // expression
         )
         {
-            D(fprintf(stderr, "%*c+ star_expressions[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "star_expression"));
-            _res = star_expression_var;
+            D(fprintf(stderr, "%*c+ star_expressions[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "expression"));
+            _res = expression_var;
             goto done;
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s star_expressions[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "star_expression"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "expression"));
+    }
+    if (p->call_invalid_rules) { // invalid_lone_star_expression
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> star_expressions[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_lone_star_expression"));
+        void *invalid_lone_star_expression_var;
+        if (
+            (invalid_lone_star_expression_var = invalid_lone_star_expression_rule(p))  // invalid_lone_star_expression
+        )
+        {
+            D(fprintf(stderr, "%*c+ star_expressions[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "invalid_lone_star_expression"));
+            _res = invalid_lone_star_expression_var;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s star_expressions[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "invalid_lone_star_expression"));
     }
     _res = NULL;
   done:
@@ -12680,7 +12702,7 @@ inversion_rule(Parser *p)
         Token * _keyword;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 721))  // token='not'
+            (_keyword = _PyPegen_expect_token(p, 722))  // token='not'
             &&
             (a = inversion_rule(p))  // inversion
         )
@@ -13334,9 +13356,9 @@ notin_bitwise_or_rule(Parser *p)
         Token * _keyword_1;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 721))  // token='not'
+            (_keyword = _PyPegen_expect_token(p, 722))  // token='not'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 713))  // token='in'
+            (_keyword_1 = _PyPegen_expect_token(p, 714))  // token='in'
             &&
             (a = bitwise_or_rule(p))  // bitwise_or
         )
@@ -13382,7 +13404,7 @@ in_bitwise_or_rule(Parser *p)
         Token * _keyword;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 713))  // token='in'
+            (_keyword = _PyPegen_expect_token(p, 714))  // token='in'
             &&
             (a = bitwise_or_rule(p))  // bitwise_or
         )
@@ -13431,7 +13453,7 @@ isnot_bitwise_or_rule(Parser *p)
         if (
             (_keyword = _PyPegen_expect_token(p, 597))  // token='is'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 721))  // token='not'
+            (_keyword_1 = _PyPegen_expect_token(p, 722))  // token='not'
             &&
             (a = bitwise_or_rule(p))  // bitwise_or
         )
@@ -18127,13 +18149,13 @@ for_if_clause_rule(Parser *p)
         expr_ty b;
         asdl_expr_seq* c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 716))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 717))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 712))  // token='for'
+            (_keyword_1 = _PyPegen_expect_token(p, 713))  // token='for'
             &&
             (a = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_2 = _PyPegen_expect_token(p, 713))  // token='in'
+            (_keyword_2 = _PyPegen_expect_token(p, 714))  // token='in'
             &&
             (_cut_var = 1)
             &&
@@ -18172,11 +18194,11 @@ for_if_clause_rule(Parser *p)
         expr_ty b;
         asdl_expr_seq* c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 712))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 713))  // token='for'
             &&
             (a = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 713))  // token='in'
+            (_keyword_1 = _PyPegen_expect_token(p, 714))  // token='in'
             &&
             (_cut_var = 1)
             &&
@@ -21503,11 +21525,11 @@ expression_without_invalid_rule(Parser *p)
         if (
             (a = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 700))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 701))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 704))  // token='else'
+            (_keyword_1 = _PyPegen_expect_token(p, 705))  // token='else'
             &&
             (c = expression_rule(p))  // expression
         )
@@ -21583,7 +21605,7 @@ expression_without_invalid_rule(Parser *p)
     return _res;
 }
 
-// invalid_legacy_expression: NAME !'(' star_expressions
+// invalid_legacy_expression: NAME !'(' !'*' star_expressions
 static void *
 invalid_legacy_expression_rule(Parser *p)
 {
@@ -21596,12 +21618,12 @@ invalid_legacy_expression_rule(Parser *p)
     }
     void * _res = NULL;
     int _mark = p->mark;
-    { // NAME !'(' star_expressions
+    { // NAME !'(' !'*' star_expressions
         if (p->error_indicator) {
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> invalid_legacy_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME !'(' star_expressions"));
+        D(fprintf(stderr, "%*c> invalid_legacy_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "NAME !'(' !'*' star_expressions"));
         expr_ty a;
         expr_ty b;
         if (
@@ -21609,10 +21631,12 @@ invalid_legacy_expression_rule(Parser *p)
             &&
             _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 7)  // token='('
             &&
+            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 16)  // token='*'
+            &&
             (b = star_expressions_rule(p))  // star_expressions
         )
         {
-            D(fprintf(stderr, "%*c+ invalid_legacy_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NAME !'(' star_expressions"));
+            D(fprintf(stderr, "%*c+ invalid_legacy_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "NAME !'(' !'*' star_expressions"));
             _res = _PyPegen_check_legacy_stmt ( p , a ) ? RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "Missing parentheses in call to '%U'. Did you mean %U(...)?" , a -> v . Name . id , a -> v . Name . id ) : NULL;
             if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
                 p->error_indicator = 1;
@@ -21623,7 +21647,7 @@ invalid_legacy_expression_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s invalid_legacy_expression[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "NAME !'(' star_expressions"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "NAME !'(' !'*' star_expressions"));
     }
     _res = NULL;
   done:
@@ -21807,7 +21831,7 @@ invalid_expression_rule(Parser *p)
         if (
             (a = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 700))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 701))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
@@ -21840,11 +21864,11 @@ invalid_expression_rule(Parser *p)
         if (
             (a = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 700))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 701))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 704))  // token='else'
+            (_keyword_1 = _PyPegen_expect_token(p, 705))  // token='else'
             &&
             _PyPegen_lookahead_for_expr(0, expression_rule, p)
         )
@@ -21876,11 +21900,11 @@ invalid_expression_rule(Parser *p)
         if (
             (a = (stmt_ty)_tmp_118_rule(p))  // pass_stmt | break_stmt | continue_stmt
             &&
-            (_keyword = _PyPegen_expect_token(p, 700))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 701))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 704))  // token='else'
+            (_keyword_1 = _PyPegen_expect_token(p, 705))  // token='else'
             &&
             (c = simple_stmt_rule(p))  // simple_stmt
         )
@@ -21999,11 +22023,11 @@ invalid_if_expression_rule(Parser *p)
         if (
             (disjunction_var = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 700))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 701))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 704))  // token='else'
+            (_keyword_1 = _PyPegen_expect_token(p, 705))  // token='else'
             &&
             (a = _PyPegen_expect_token(p, 16))  // token='*'
         )
@@ -22035,11 +22059,11 @@ invalid_if_expression_rule(Parser *p)
         if (
             (disjunction_var = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 700))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 701))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 704))  // token='else'
+            (_keyword_1 = _PyPegen_expect_token(p, 705))  // token='else'
             &&
             (a = _PyPegen_expect_token(p, 35))  // token='**'
         )
@@ -22182,6 +22206,52 @@ invalid_named_expression_rule(Parser *p)
     _res = NULL;
   done:
     _PyPegen_insert_memo(p, _mark, invalid_named_expression_type, _res);
+    p->level--;
+    return _res;
+}
+
+// invalid_lone_star_expression: '*' bitwise_or
+static void *
+invalid_lone_star_expression_rule(Parser *p)
+{
+    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+        _Pypegen_stack_overflow(p);
+    }
+    if (p->error_indicator) {
+        p->level--;
+        return NULL;
+    }
+    void * _res = NULL;
+    int _mark = p->mark;
+    { // '*' bitwise_or
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> invalid_lone_star_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*' bitwise_or"));
+        Token * a;
+        expr_ty b;
+        if (
+            (a = _PyPegen_expect_token(p, 16))  // token='*'
+            &&
+            (b = bitwise_or_rule(p))  // bitwise_or
+        )
+        {
+            D(fprintf(stderr, "%*c+ invalid_lone_star_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'*' bitwise_or"));
+            _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "can't use starred expression here" );
+            if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s invalid_lone_star_expression[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'*' bitwise_or"));
+    }
+    _res = NULL;
+  done:
     p->level--;
     return _res;
 }
@@ -22508,7 +22578,7 @@ invalid_raise_stmt_rule(Parser *p)
         if (
             (a = _PyPegen_expect_token(p, 632))  // token='raise'
             &&
-            (b = _PyPegen_expect_token(p, 650))  // token='from'
+            (b = _PyPegen_expect_token(p, 651))  // token='from'
         )
         {
             D(fprintf(stderr, "%*c+ invalid_raise_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'raise' 'from'"));
@@ -22538,7 +22608,7 @@ invalid_raise_stmt_rule(Parser *p)
             &&
             (expression_var = expression_rule(p))  // expression
             &&
-            (a = _PyPegen_expect_token(p, 650))  // token='from'
+            (a = _PyPegen_expect_token(p, 651))  // token='from'
         )
         {
             D(fprintf(stderr, "%*c+ invalid_raise_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'raise' expression 'from'"));
@@ -22560,7 +22630,7 @@ invalid_raise_stmt_rule(Parser *p)
     return _res;
 }
 
-// invalid_del_stmt: 'del' star_expressions
+// invalid_del_stmt: 'del' &'*' star_expression | 'del' star_expressions
 static void *
 invalid_del_stmt_rule(Parser *p)
 {
@@ -22573,6 +22643,35 @@ invalid_del_stmt_rule(Parser *p)
     }
     void * _res = NULL;
     int _mark = p->mark;
+    { // 'del' &'*' star_expression
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> invalid_del_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'del' &'*' star_expression"));
+        Token * _keyword;
+        expr_ty a;
+        if (
+            (_keyword = _PyPegen_expect_token(p, 635))  // token='del'
+            &&
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 16)  // token='*'
+            &&
+            (a = star_expression_rule(p))  // star_expression
+        )
+        {
+            D(fprintf(stderr, "%*c+ invalid_del_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'del' &'*' star_expression"));
+            _res = RAISE_SYNTAX_ERROR_INVALID_TARGET ( DEL_TARGETS , a );
+            if ((_res == NULL || p->error_indicator) && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s invalid_del_stmt[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'del' &'*' star_expression"));
+    }
     { // 'del' star_expressions
         if (p->error_indicator) {
             p->level--;
@@ -22582,7 +22681,7 @@ invalid_del_stmt_rule(Parser *p)
         Token * _keyword;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 634))  // token='del'
+            (_keyword = _PyPegen_expect_token(p, 635))  // token='del'
             &&
             (a = star_expressions_rule(p))  // star_expressions
         )
@@ -22634,7 +22733,7 @@ invalid_assert_stmt_rule(Parser *p)
         expr_ty a;
         expr_ty b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 638))  // token='assert'
+            (_keyword = _PyPegen_expect_token(p, 639))  // token='assert'
             &&
             (a = expression_rule(p))  // expression
             &&
@@ -22669,7 +22768,7 @@ invalid_assert_stmt_rule(Parser *p)
         expr_ty b;
         expr_ty expression_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 638))  // token='assert'
+            (_keyword = _PyPegen_expect_token(p, 639))  // token='assert'
             &&
             (expression_var = expression_rule(p))  // expression
             &&
@@ -22706,7 +22805,7 @@ invalid_assert_stmt_rule(Parser *p)
         expr_ty a;
         expr_ty b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 638))  // token='assert'
+            (_keyword = _PyPegen_expect_token(p, 639))  // token='assert'
             &&
             (a = expression_rule(p))  // expression
             &&
@@ -22741,7 +22840,7 @@ invalid_assert_stmt_rule(Parser *p)
         expr_ty b;
         expr_ty expression_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 638))  // token='assert'
+            (_keyword = _PyPegen_expect_token(p, 639))  // token='assert'
             &&
             (expression_var = expression_rule(p))  // expression
             &&
@@ -24167,7 +24266,7 @@ invalid_with_item_rule(Parser *p)
         if (
             (expression_var = expression_rule(p))  // expression
             &&
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 699))  // token='as'
             &&
             (a = expression_rule(p))  // expression
             &&
@@ -24217,13 +24316,13 @@ invalid_for_if_clause_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         void *_tmp_136_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 716), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 717), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 712))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 713))  // token='for'
             &&
             (_tmp_136_var = _tmp_136_rule(p))  // bitwise_or ((',' bitwise_or))* ','?
             &&
-            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 713)  // token='in'
+            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 714)  // token='in'
         )
         {
             D(fprintf(stderr, "%*c+ invalid_for_if_clause[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'async'? 'for' (bitwise_or ((',' bitwise_or))* ','?) !'in'"));
@@ -24269,9 +24368,9 @@ invalid_for_target_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         expr_ty a;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 716), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 717), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 712))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 713))  // token='for'
             &&
             (a = star_expressions_rule(p))  // star_expressions
         )
@@ -24401,11 +24500,11 @@ invalid_import_rule(Parser *p)
         Token * a;
         expr_ty dotted_name_var;
         if (
-            (a = _PyPegen_expect_token(p, 651))  // token='import'
+            (a = _PyPegen_expect_token(p, 652))  // token='import'
             &&
             (_gather_138_var = _gather_138_rule(p))  // ','.dotted_name+
             &&
-            (_keyword = _PyPegen_expect_token(p, 650))  // token='from'
+            (_keyword = _PyPegen_expect_token(p, 651))  // token='from'
             &&
             (dotted_name_var = dotted_name_rule(p))  // dotted_name
         )
@@ -24432,7 +24531,7 @@ invalid_import_rule(Parser *p)
         Token * _keyword;
         Token * token;
         if (
-            (_keyword = _PyPegen_expect_token(p, 651))  // token='import'
+            (_keyword = _PyPegen_expect_token(p, 652))  // token='import'
             &&
             (token = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
@@ -24481,7 +24580,7 @@ invalid_dotted_as_name_rule(Parser *p)
         if (
             (dotted_name_var = dotted_name_rule(p))  // dotted_name
             &&
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 699))  // token='as'
             &&
             _PyPegen_lookahead(0, _tmp_139_rule, p)
             &&
@@ -24532,7 +24631,7 @@ invalid_import_from_as_name_rule(Parser *p)
         if (
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 699))  // token='as'
             &&
             _PyPegen_lookahead(0, _tmp_139_rule, p)
             &&
@@ -24585,7 +24684,7 @@ invalid_import_from_rule(Parser *p)
         expr_ty dotted_name_var;
         asdl_alias_seq* import_from_targets_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 650))  // token='from'
+            (_keyword = _PyPegen_expect_token(p, 651))  // token='from'
             &&
             (_loop0_17_var = _loop0_17_rule(p))  // (('.' | '...'))*
             &&
@@ -24593,7 +24692,7 @@ invalid_import_from_rule(Parser *p)
             &&
             (a = _PyPegen_expect_soft_keyword(p, "lazy"))  // soft_keyword='"lazy"'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 651))  // token='import'
+            (_keyword_1 = _PyPegen_expect_token(p, 652))  // token='import'
             &&
             (import_from_targets_var = import_from_targets_rule(p))  // import_from_targets
         )
@@ -24719,9 +24818,9 @@ invalid_with_stmt_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         Token * trailing;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 716), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 717), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 665))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 666))  // token='with'
             &&
             (_gather_141_var = _gather_141_rule(p))  // ','.(expression ['as' star_target])+
             &&
@@ -24755,9 +24854,9 @@ invalid_with_stmt_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 716), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 717), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 665))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 666))  // token='with'
             &&
             (_gather_141_var = _gather_141_rule(p))  // ','.(expression ['as' star_target])+
             &&
@@ -24793,9 +24892,9 @@ invalid_with_stmt_rule(Parser *p)
         UNUSED(_opt_var_1); // Silence compiler warnings
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 716), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 717), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 665))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 666))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -24855,9 +24954,9 @@ invalid_with_stmt_indent_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 716), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 717), !p->error_indicator)  // 'async'?
             &&
-            (a = _PyPegen_expect_token(p, 665))  // token='with'
+            (a = _PyPegen_expect_token(p, 666))  // token='with'
             &&
             (_gather_141_var = _gather_141_rule(p))  // ','.(expression ['as' star_target])+
             &&
@@ -24898,9 +24997,9 @@ invalid_with_stmt_indent_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 716), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 717), !p->error_indicator)  // 'async'?
             &&
-            (a = _PyPegen_expect_token(p, 665))  // token='with'
+            (a = _PyPegen_expect_token(p, 666))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -24963,7 +25062,7 @@ invalid_try_stmt_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 674))  // token='try'
+            (a = _PyPegen_expect_token(p, 675))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -24995,7 +25094,7 @@ invalid_try_stmt_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* block_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 674))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 675))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -25034,7 +25133,7 @@ invalid_try_stmt_rule(Parser *p)
         Token * b;
         expr_ty expression_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 674))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 675))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -25042,7 +25141,7 @@ invalid_try_stmt_rule(Parser *p)
             &&
             (_loop1_36_var = _loop1_36_rule(p))  // except_block+
             &&
-            (a = _PyPegen_expect_token(p, 695))  // token='except'
+            (a = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (b = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -25081,7 +25180,7 @@ invalid_try_stmt_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         Token * a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 674))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 675))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -25089,7 +25188,7 @@ invalid_try_stmt_rule(Parser *p)
             &&
             (_loop1_37_var = _loop1_37_rule(p))  // except_star_block+
             &&
-            (a = _PyPegen_expect_token(p, 695))  // token='except'
+            (a = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (_opt_var = _tmp_146_rule(p), !p->error_indicator)  // [expression ['as' NAME]]
             &&
@@ -25146,7 +25245,7 @@ invalid_except_stmt_rule(Parser *p)
         expr_ty expressions_var;
         expr_ty name_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 695))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (a = expression_rule(p))  // expression
             &&
@@ -25154,7 +25253,7 @@ invalid_except_stmt_rule(Parser *p)
             &&
             (expressions_var = expressions_rule(p))  // expressions
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 698))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 699))  // token='as'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -25186,7 +25285,7 @@ invalid_except_stmt_rule(Parser *p)
         expr_ty expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 695))  // token='except'
+            (a = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (expression_var = expression_rule(p))  // expression
             &&
@@ -25217,7 +25316,7 @@ invalid_except_stmt_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 695))  // token='except'
+            (a = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
@@ -25248,11 +25347,11 @@ invalid_except_stmt_rule(Parser *p)
         asdl_stmt_seq* block_var;
         expr_ty expression_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 695))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (expression_var = expression_rule(p))  // expression
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 698))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 699))  // token='as'
             &&
             (a = expression_rule(p))  // expression
             &&
@@ -25312,7 +25411,7 @@ invalid_except_star_stmt_rule(Parser *p)
         expr_ty expressions_var;
         expr_ty name_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 695))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -25322,7 +25421,7 @@ invalid_except_star_stmt_rule(Parser *p)
             &&
             (expressions_var = expressions_rule(p))  // expressions
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 698))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 699))  // token='as'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -25355,7 +25454,7 @@ invalid_except_star_stmt_rule(Parser *p)
         expr_ty expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 695))  // token='except'
+            (a = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -25389,7 +25488,7 @@ invalid_except_star_stmt_rule(Parser *p)
         void *_tmp_147_var;
         Token * a;
         if (
-            (a = _PyPegen_expect_token(p, 695))  // token='except'
+            (a = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -25423,13 +25522,13 @@ invalid_except_star_stmt_rule(Parser *p)
         asdl_stmt_seq* block_var;
         expr_ty expression_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 695))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
             (expression_var = expression_rule(p))  // expression
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 698))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 699))  // token='as'
             &&
             (a = expression_rule(p))  // expression
             &&
@@ -25480,7 +25579,7 @@ invalid_finally_stmt_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 691))  // token='finally'
+            (a = _PyPegen_expect_token(p, 692))  // token='finally'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -25536,7 +25635,7 @@ invalid_except_stmt_indent_rule(Parser *p)
         expr_ty expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 695))  // token='except'
+            (a = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (expression_var = expression_rule(p))  // expression
             &&
@@ -25572,7 +25671,7 @@ invalid_except_stmt_indent_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 695))  // token='except'
+            (a = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -25628,7 +25727,7 @@ invalid_except_star_stmt_indent_rule(Parser *p)
         expr_ty expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 695))  // token='except'
+            (a = _PyPegen_expect_token(p, 696))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -25905,7 +26004,7 @@ invalid_as_pattern_rule(Parser *p)
         if (
             (or_pattern_var = or_pattern_rule(p))  // or_pattern
             &&
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 699))  // token='as'
             &&
             (a = _PyPegen_expect_soft_keyword(p, "_"))  // soft_keyword='"_"'
         )
@@ -25935,7 +26034,7 @@ invalid_as_pattern_rule(Parser *p)
         if (
             (or_pattern_var = or_pattern_rule(p))  // or_pattern
             &&
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 699))  // token='as'
             &&
             (a = expression_rule(p))  // expression
         )
@@ -26151,7 +26250,7 @@ invalid_if_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 700))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 701))  // token='if'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -26182,7 +26281,7 @@ invalid_if_stmt_rule(Parser *p)
         expr_ty a_1;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 700))  // token='if'
+            (a = _PyPegen_expect_token(p, 701))  // token='if'
             &&
             (a_1 = named_expression_rule(p))  // named_expression
             &&
@@ -26237,7 +26336,7 @@ invalid_elif_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 705))  // token='elif'
+            (_keyword = _PyPegen_expect_token(p, 706))  // token='elif'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -26268,7 +26367,7 @@ invalid_elif_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 705))  // token='elif'
+            (a = _PyPegen_expect_token(p, 706))  // token='elif'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -26321,7 +26420,7 @@ invalid_else_stmt_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 704))  // token='else'
+            (a = _PyPegen_expect_token(p, 705))  // token='else'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -26354,13 +26453,13 @@ invalid_else_stmt_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* block_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 704))  // token='else'
+            (_keyword = _PyPegen_expect_token(p, 705))  // token='else'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
             (block_var = block_rule(p))  // block
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 705))  // token='elif'
+            (_keyword_1 = _PyPegen_expect_token(p, 706))  // token='elif'
         )
         {
             D(fprintf(stderr, "%*c+ invalid_else_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'else' ':' block 'elif'"));
@@ -26407,7 +26506,7 @@ invalid_while_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 707))  // token='while'
+            (_keyword = _PyPegen_expect_token(p, 708))  // token='while'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -26438,7 +26537,7 @@ invalid_while_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 707))  // token='while'
+            (a = _PyPegen_expect_token(p, 708))  // token='while'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -26497,13 +26596,13 @@ invalid_for_stmt_rule(Parser *p)
         expr_ty star_expressions_var;
         expr_ty star_targets_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 716), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 717), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 712))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 713))  // token='for'
             &&
             (star_targets_var = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 713))  // token='in'
+            (_keyword_1 = _PyPegen_expect_token(p, 714))  // token='in'
             &&
             (star_expressions_var = star_expressions_rule(p))  // star_expressions
             &&
@@ -26538,13 +26637,13 @@ invalid_for_stmt_rule(Parser *p)
         expr_ty star_expressions_var;
         expr_ty star_targets_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 716), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 717), !p->error_indicator)  // 'async'?
             &&
-            (a = _PyPegen_expect_token(p, 712))  // token='for'
+            (a = _PyPegen_expect_token(p, 713))  // token='for'
             &&
             (star_targets_var = star_targets_rule(p))  // star_targets
             &&
-            (_keyword = _PyPegen_expect_token(p, 713))  // token='in'
+            (_keyword = _PyPegen_expect_token(p, 714))  // token='in'
             &&
             (star_expressions_var = star_expressions_rule(p))  // star_expressions
             &&
@@ -26610,9 +26709,9 @@ invalid_def_raw_rule(Parser *p)
         expr_ty name_var;
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 716), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 717), !p->error_indicator)  // 'async'?
             &&
-            (a = _PyPegen_expect_token(p, 717))  // token='def'
+            (a = _PyPegen_expect_token(p, 718))  // token='def'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -26669,9 +26768,9 @@ invalid_def_raw_rule(Parser *p)
         asdl_stmt_seq* block_var;
         expr_ty name_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 716), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 717), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 717))  // token='def'
+            (_keyword = _PyPegen_expect_token(p, 718))  // token='def'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -26735,7 +26834,7 @@ invalid_class_def_raw_rule(Parser *p)
         expr_ty name_var;
         Token * newline_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 719))  // token='class'
+            (_keyword = _PyPegen_expect_token(p, 720))  // token='class'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -26774,7 +26873,7 @@ invalid_class_def_raw_rule(Parser *p)
         expr_ty name_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 719))  // token='class'
+            (a = _PyPegen_expect_token(p, 720))  // token='class'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -28411,7 +28510,7 @@ invalid_arithmetic_rule(Parser *p)
             &&
             (_tmp_157_var = _tmp_157_rule(p))  // '+' | '-' | '*' | '/' | '%' | '//' | '@'
             &&
-            (a = _PyPegen_expect_token(p, 721))  // token='not'
+            (a = _PyPegen_expect_token(p, 722))  // token='not'
             &&
             (b = inversion_rule(p))  // inversion
         )
@@ -28460,7 +28559,7 @@ invalid_factor_rule(Parser *p)
         if (
             (_tmp_158_var = _tmp_158_rule(p))  // '+' | '-' | '~'
             &&
-            (a = _PyPegen_expect_token(p, 721))  // token='not'
+            (a = _PyPegen_expect_token(p, 722))  // token='not'
             &&
             (b = factor_rule(p))  // factor
         )
@@ -28907,7 +29006,7 @@ _tmp_5_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_5[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'import'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 651))  // token='import'
+            (_keyword = _PyPegen_expect_token(p, 652))  // token='import'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_5[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'import'"));
@@ -28926,7 +29025,7 @@ _tmp_5_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_5[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'from'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 650))  // token='from'
+            (_keyword = _PyPegen_expect_token(p, 651))  // token='from'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_5[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'from'"));
@@ -28983,7 +29082,7 @@ _tmp_6_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_6[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'def'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 717))  // token='def'
+            (_keyword = _PyPegen_expect_token(p, 718))  // token='def'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_6[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'def'"));
@@ -29021,7 +29120,7 @@ _tmp_6_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_6[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'async'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 716))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 717))  // token='async'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_6[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'async'"));
@@ -29059,7 +29158,7 @@ _tmp_7_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_7[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'class'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 719))  // token='class'
+            (_keyword = _PyPegen_expect_token(p, 720))  // token='class'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_7[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'class'"));
@@ -29116,7 +29215,7 @@ _tmp_8_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_8[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'with'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 665))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 666))  // token='with'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_8[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'with'"));
@@ -29135,7 +29234,7 @@ _tmp_8_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_8[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'async'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 716))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 717))  // token='async'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_8[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'async'"));
@@ -29173,7 +29272,7 @@ _tmp_9_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_9[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'for'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 712))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 713))  // token='for'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_9[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'for'"));
@@ -29192,7 +29291,7 @@ _tmp_9_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_9[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'async'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 716))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 717))  // token='async'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_9[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'async'"));
@@ -29893,7 +29992,7 @@ _tmp_21_rule(Parser *p)
         Token * _keyword;
         expr_ty z;
         if (
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 699))  // token='as'
             &&
             (z = _PyPegen_name_token(p))  // NAME
         )
@@ -35865,7 +35964,7 @@ _tmp_117_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_117[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'else'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 704))  // token='else'
+            (_keyword = _PyPegen_expect_token(p, 705))  // token='else'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_117[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'else'"));
@@ -37528,7 +37627,7 @@ _tmp_144_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_144[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 695))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 696))  // token='except'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_144[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'except'"));
@@ -37547,7 +37646,7 @@ _tmp_144_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_144[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'finally'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 691))  // token='finally'
+            (_keyword = _PyPegen_expect_token(p, 692))  // token='finally'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_144[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'finally'"));
@@ -38849,7 +38948,7 @@ _tmp_166_rule(Parser *p)
         Token * _keyword;
         expr_ty z;
         if (
-            (_keyword = _PyPegen_expect_token(p, 700))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 701))  // token='if'
             &&
             (z = disjunction_rule(p))  // disjunction
         )
@@ -39585,7 +39684,7 @@ _tmp_180_rule(Parser *p)
         Token * _keyword;
         expr_ty star_target_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 699))  // token='as'
             &&
             (star_target_var = star_target_rule(p))  // star_target
         )

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -5604,6 +5604,9 @@ codegen_visit_expr_impl(compiler *c, expr_ty e, bool result_is_unused)
             return _PyCompile_Error(c, loc,
                 "starred assignment target must be in a list or tuple");
         default:
+            /* In non-Store contexts, "lone" star expressions (that is,
+             * ones without a comma after them) should not be allowed by
+             * the grammar. */
             return _PyCompile_Error(c, loc,
                 "can't use starred expression here");
         }


### PR DESCRIPTION
Statements like the following (where `()` can be any iterable -- or at the syntax level, any value):

*  `*()`
* `x = *()`
* `yield *()`
* `return *()`
* `for _ in *(): ...`

are not valid without a comma after the iterable.
These are allowed by `python.gram` and only rejected in the code generation step. This means that the documented [Full Grammar specification](https://docs.python.org/3/reference/grammar.html) is incomplete.

Change the grammar itself to disallow "lone" starred expressions.

This interfered with the `invalid_legacy_expression` rule, where in ``return i*i for _ in _`` the ``i *i`` was parsed similarly to ``print *i``, generating "can't use starred expression here" from `*i` (before getting to the "Missing parentheses in call" message instead of a generic "invalid syntax".
Exclude the star in `invalid_legacy_expression` to prevent this.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156058 -->
* Issue: gh-156058
<!-- /gh-issue-number -->
