### PR TITLE
gh-156060: Do not scan every process four times in `remote_debugging.get_child_pids()` on macOS

### DIFF
--- a/Modules/_remote_debugging/subprocess.c
+++ b/Modules/_remote_debugging/subprocess.c
@@ -307,6 +307,7 @@ get_child_pids_platform(pid_t target_pid, int recursive, pid_array_t *result)
         PyErr_SetString(PyExc_OSError, "Failed to get process count");
         goto done;
     }
+    n_pids /= sizeof(pid_t);
 
     /* Allocate buffer for PIDs (add some slack for new processes) */
     int buffer_size = n_pids + 64;
@@ -322,6 +323,7 @@ get_child_pids_platform(pid_t target_pid, int recursive, pid_array_t *result)
         PyErr_SetString(PyExc_OSError, "Failed to list PIDs");
         goto done;
     }
+    actual /= sizeof(pid_t);
 
     /* Build pid -> ppid mapping */
     ppids = (pid_t *)PyMem_Malloc(actual * sizeof(pid_t));


### PR DESCRIPTION
Closes #156060 

Please see #156060 for more details.

Basically, `proc_listpids()` returns the number of bytes, not the number of PIDs.

This reduces the number of reads:

```
2026-08-19T19:00:30.252314000+0200 maurycy@gimel /Users/maurycy/src/github.com/maurycy/cpython (listpids fb54f37?) % cat repro.py
import _remote_debugging, os
_remote_debugging.get_child_pids(os.getpid(), recursive=True)
2026-08-19T19:00:30.557830000+0200 maurycy@gimel /Users/maurycy/src/github.com/maurycy/cpython (listpids fb54f37?) % ps axlww | wc -l
     996
2026-08-19T19:00:31.930414000+0200 maurycy@gimel /Users/maurycy/src/github.com/maurycy/cpython (listpids fb54f37?) % sudo dtrace -q -n 'pid$target::proc_pidinfo:entry { @ = count(); }' -c "./python.exe repro.py"

              998
```

I don't think it's newsworthy, and I'm not sure how to provide a test for this.

Perhaps a better approach would be just `sysctl(KERN_PROC, KERN_PROC_ALL)`. I believe it's also available since forever.

<!-- gh-issue-number: gh-156060 -->
* Issue: gh-156060
<!-- /gh-issue-number -->
