### PR TITLE
gh-156062: Fix SynchronizedBase instantiation without a lock or a ctx

### DIFF
--- a/Lib/multiprocessing/sharedctypes.py
+++ b/Lib/multiprocessing/sharedctypes.py
@@ -189,7 +189,7 @@ class SynchronizedBase(object):
         if lock:
             self._lock = lock
         else:
-            ctx = ctx or get_context(force=True)
+            ctx = ctx or get_context()
             self._lock = ctx.RLock()
         self.acquire = self._lock.acquire
         self.release = self._lock.release

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4628,6 +4628,25 @@ class _TestSharedCTypes(BaseTestCase):
     def test_synchronize(self):
         self.test_sharedctypes(lock=True)
 
+    def test_synchronized_wrapper_default_context(self):
+        # gh-156062: SynchronizedBase used to call get_context() with an
+        # unexpected argument when neither a lock nor a context was given,
+        # so the wrapper classes could not be instantiated directly.
+        from multiprocessing.sharedctypes import (
+            RawValue, RawArray,
+            Synchronized, SynchronizedArray, SynchronizedString,
+        )
+        for wrapper, obj in [
+            (Synchronized, RawValue('i', 7)),
+            (SynchronizedArray, RawArray('d', [1.0, 2.0])),
+            (SynchronizedString, RawArray('c', 8)),
+        ]:
+            with self.subTest(wrapper=wrapper.__name__):
+                wrapped = wrapper(obj)
+                self.assertIs(wrapped.get_obj(), obj)
+                with wrapped:
+                    pass
+
     def test_copy(self):
         foo = _Foo(2, 5.0, 2 ** 33)
         bar = copy(foo)

--- a/Misc/NEWS.d/next/Library/2026-08-19-17-31-12.gh-issue-156062.-nTriK.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-19-17-31-12.gh-issue-156062.-nTriK.rst
@@ -1,0 +1,4 @@
+Fix :class:`!multiprocessing.sharedctypes.SynchronizedBase` and its subclasses
+raising :exc:`TypeError` when instantiated without a *lock* or a *ctx*
+argument: they called :func:`multiprocessing.get_context` with an
+unsupported ``force`` argument.


### PR DESCRIPTION
`SynchronizedBase.__init__` calls `get_context(force=True)` when it is given neither a `lock` nor a `ctx`, but `get_context()` has never accepted a `force` argument (`set_start_method()` does). So instantiating `Synchronized`, `SynchronizedArray` or `SynchronizedString` directly, without a lock or a context, raised:

```
TypeError: DefaultContext.get_context() got an unexpected keyword argument 'force'
```

`Value()`, `Array()` and `synchronized()` always resolve a context and pass it down, which is why this went unnoticed since the line was written in b1694cf588 (bpo-18999). The fix mirrors what `synchronized()` does a few lines above: call `get_context()`.

The new test instantiates each of the three wrapper classes without a lock or a context and exercises the resulting lock. Without the fix all three subtests fail with the `TypeError` above; with it they pass under the `spawn` and `forkserver` start methods (the `fork` variants are skipped on macOS, where I ran this).

Found by running pylint over the standard library (`unexpected-keyword-arg`).

* Issue: gh-156062
