### PR TITLE
gh-156064: Make patchcheck find the upstream remote in a partial clone

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2026-08-19-17-36-21.gh-issue-156064.xbNrA0.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2026-08-19-17-36-21.gh-issue-156064.xbNrA0.rst
@@ -1,0 +1,3 @@
+Fix ``make patchcheck`` not finding the upstream remote in a partial clone,
+where ``git remote -v`` appends the object filter (for example
+``[blob:none]``) after ``(fetch)``.

--- a/Tools/patchcheck/patchcheck.py
+++ b/Tools/patchcheck/patchcheck.py
@@ -68,10 +68,16 @@ def get_git_upstream_remote():
         cwd=SRCDIR,
         encoding="UTF-8"
     )
+    # Keep the "(fetch)" lines only. A partial clone lists its filter after
+    # the URL type, e.g. "upstream\thttps://github.com/python/cpython (fetch)
+    # [blob:none]", so "(fetch)" is not necessarily at the end of the line.
+    fetch_remotes = [
+        remote for remote in output.split('\n') if "(fetch)" in remote
+    ]
     # Filter to desired remotes, accounting for potential uppercasing
     filtered_remotes = {
-        remote.split("\t")[0].lower() for remote in output.split('\n')
-        if "python/cpython" in remote.lower() and remote.endswith("(fetch)")
+        remote.split("\t")[0].lower() for remote in fetch_remotes
+        if "python/cpython" in remote.lower()
     }
     if len(filtered_remotes) == 1:
         [remote] = filtered_remotes
@@ -79,9 +85,7 @@ def get_git_upstream_remote():
     for remote_name in ["upstream", "origin", "python"]:
         if remote_name in filtered_remotes:
             return remote_name
-    remotes_found = "\n".join(
-        {remote for remote in output.split('\n') if remote.endswith("(fetch)")}
-    )
+    remotes_found = "\n".join(fetch_remotes)
     raise ValueError(
         f"Patchcheck was unable to find an unambiguous upstream remote, "
         f"with URL matching 'https://github.com/python/cpython'. "


### PR DESCRIPTION
Since Git 2.37 (git/git@ef6d15ca53), `git remote -v` appends the object filter of a promisor remote to its fetch line:

```
upstream	https://github.com/python/cpython.git (fetch) [blob:none]
```

`get_git_upstream_remote()` kept fetch lines with `remote.endswith("(fetch)")`, so in a partial clone the `upstream` remote was neither considered nor listed in the "Remotes found" part of the error, and `make patchcheck` failed with a misleading message. This matches `"(fetch)"` anywhere on the line instead and reuses the same filtered list for the error message.

Verified in a `--filter=blob:none` clone with `origin` (fork) and `upstream` (python/cpython) remotes: `make patchcheck` now reports `Getting base branch for PR ... upstream/main` instead of raising.

No NEWS entry, as for #135806 (developer tooling).

* Issue: gh-156064
