### PR TITLE
gh-156070: Fix operator precedence in multiprocessing's batched Windows wait

### DIFF
--- a/Lib/multiprocessing/connection.py
+++ b/Lib/multiprocessing/connection.py
@@ -1062,7 +1062,7 @@ if sys.platform == 'win32':
                 return []
             ready.extend(L[i] for i in res)
             if res:
-                L = [h for i, h in enumerate(L) if i > res[0] & i not in res]
+                L = [h for i, h in enumerate(L) if i > res[0] and i not in res]
             timeout = 0
         while L:
             short_L = L[:60] if len(L) > 60 else L

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5923,18 +5923,23 @@ class TestWait(unittest.TestCase):
         import _winapi
         from multiprocessing.connection import _exhaustive_wait
 
-        # More than 60 handles takes the batched path.
+        # More than 60 handles takes the batched path. Manual reset events
+        # stay signalled, so the handles the batched wait already reported
+        # must be dropped from the list that is scanned afterwards.
         events = [_winapi.CreateEventW(0, True, False, None)
                   for _ in range(70)]
         self.addCleanup(lambda: [_winapi.CloseHandle(e) for e in events])
 
-        # Spread the signalled events out so they do not all land in the
-        # first batch, and leave index 0 unsignalled.
-        chosen = [3, 17, 42, 68]
+        # BatchedWaitForMultipleObjects reports the lowest signalled handle
+        # of each 63 handle batch, so signalling the first event pins the
+        # first reported index at 0 and spreads the rest over both batches.
+        chosen = [0, 17, 42, 68]
         for i in chosen:
             _winapi.SetEvent(events[i])
 
-        ready = _exhaustive_wait(events, 0)
+        # A zero timeout is not usable here: the batched wait would report a
+        # timeout before its worker threads have run.
+        ready = _exhaustive_wait(events, 10_000)
         self.assertEqual(sorted(ready), sorted(events[i] for i in chosen))
 
 #

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5918,6 +5918,25 @@ class TestWait(unittest.TestCase):
         a.close()
         b.close()
 
+    @unittest.skipUnless(WIN32, "skipped on non-Windows platforms")
+    def test_exhaustive_wait_more_than_60_handles(self):
+        import _winapi
+        from multiprocessing.connection import _exhaustive_wait
+
+        # More than 60 handles takes the batched path.
+        events = [_winapi.CreateEventW(0, True, False, None)
+                  for _ in range(70)]
+        self.addCleanup(lambda: [_winapi.CloseHandle(e) for e in events])
+
+        # Spread the signalled events out so they do not all land in the
+        # first batch, and leave index 0 unsignalled.
+        chosen = [3, 17, 42, 68]
+        for i in chosen:
+            _winapi.SetEvent(events[i])
+
+        ready = _exhaustive_wait(events, 0)
+        self.assertEqual(sorted(ready), sorted(events[i] for i in chosen))
+
 #
 # Issue 14151: Test invalid family on invalid environment
 #

--- a/Misc/NEWS.d/next/Library/2026-08-19-21-00-25.gh-issue-156070.fwmRPu.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-19-21-00-25.gh-issue-156070.fwmRPu.rst
@@ -1,0 +1,3 @@
+Fix :func:`multiprocessing.connection.wait` on Windows with more than 60
+handles: the batched wait used ``&`` where ``and`` was meant when removing
+already signalled handles from the remaining list.

--- a/Misc/NEWS.d/next/Library/2026-08-19-21-00-25.gh-issue-156070.fwmRPu.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-19-21-00-25.gh-issue-156070.fwmRPu.rst
@@ -1,3 +1,3 @@
-Fix :func:`multiprocessing.connection.wait` on Windows with more than 60
-handles: the batched wait used ``&`` where ``and`` was meant when removing
-already signalled handles from the remaining list.
+Fix :func:`multiprocessing.connection.wait` on Windows when waiting on more
+than 60 objects: an object that was already ready could be reported more than
+once, and other ready objects could be left out of the result.


### PR DESCRIPTION
In the Windows branch of `multiprocessing.connection._exhaustive_wait()` that handles more than 60 handles, the filter

```python
L = [h for i, h in enumerate(L) if i > res[0] & i not in res]
```

parses as `i > (res[0] & i) not in res` because `&` binds tighter than the comparison operators, so signalled handles could stay in the list and unsignalled ones be dropped. Use `and`, as intended.

* Issue: gh-156070