### PR TITLE
gh-156078: Prevent ZipFile.mkdir() during an active write

### DIFF
--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -4599,6 +4599,8 @@ class OtherTests(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     zipf.write(__file__, 'file')
                 with self.assertRaises(ValueError):
+                    zipf.mkdir('directory')
+                with self.assertRaises(ValueError):
                     zipf.close()
                 w1.write(msg2)
             with zipf.open('baz', mode='w') as w2:

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -5520,6 +5520,9 @@ class TestWithDirectory(unittest.TestCase):
             zf.extractall(target)
             self.assertEqual(set(os.listdir(target)), {"directory", "directory2", "directory3", "directory4"})
 
+        with self.assertRaises(ValueError):
+            zf.mkdir("closed")
+
     def test_create_directory_with_write(self):
         with zipfile.ZipFile(TESTFN, "w") as zf:
             zf.writestr(zipfile.ZipInfo('directory/'), '')

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -2596,6 +2596,11 @@ class ZipFile:
         else:
             raise TypeError("Expected type str or ZipInfo")
 
+        if self._writing:
+            raise ValueError(
+                "Can't write to ZIP archive while an open writing handle exists."
+            )
+
         with self._lock:
             if self._seekable:
                 self.fp.seek(self.start_dir)

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -2598,7 +2598,8 @@ class ZipFile:
 
         if not self.fp:
             raise ValueError(
-                "Attempt to write to ZIP archive that was already closed")
+                "Attempt to write to ZIP archive that was already closed"
+            )
         if self._writing:
             raise ValueError(
                 "Can't write to ZIP archive while an open writing handle exists."

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -2596,6 +2596,9 @@ class ZipFile:
         else:
             raise TypeError("Expected type str or ZipInfo")
 
+        if not self.fp:
+            raise ValueError(
+                "Attempt to write to ZIP archive that was already closed")
         if self._writing:
             raise ValueError(
                 "Can't write to ZIP archive while an open writing handle exists."

--- a/Misc/NEWS.d/next/Library/2026-08-20-09-56-45.gh-issue-156078.-E7gZc.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-20-09-56-45.gh-issue-156078.-E7gZc.rst
@@ -1,3 +1,2 @@
-Fix :meth:`zipfile.ZipFile.mkdir` to raise :exc:`ValueError` when called
-while a writable member handle is open, preventing corruption of the ZIP
-archive.
+:meth:`zipfile.ZipFile.mkdir` now raises :exc:`ValueError` when the archive
+is closed or when a writable member handle is open.

--- a/Misc/NEWS.d/next/Library/2026-08-20-09-56-45.gh-issue-156078.-E7gZc.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-20-09-56-45.gh-issue-156078.-E7gZc.rst
@@ -1,0 +1,3 @@
+Fix :meth:`zipfile.ZipFile.mkdir` to raise :exc:`ValueError` when called
+while a writable member handle is open, preventing corruption of the ZIP
+archive.


### PR DESCRIPTION
Fix `ZipFile.mkdir()` so that it raises `ValueError` when another writable member handle returned by `ZipFile.open(..., mode="w")` is still open.

This issue also affects Python 3.13, 3.14, and 3.15
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156078 -->
* Issue: gh-156078
<!-- /gh-issue-number -->
