### PR TITLE
[3.12] Add a timeout to the 'Check if the ABI has changed' job (GH-156051)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
   check-abi:
     name: 'Check if the ABI has changed'
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     needs: build-context
     if: needs.build-context.outputs.run-tests == 'true'
     steps:


### PR DESCRIPTION
(cherry picked from commit 93404cebd972cd85a6adfa1af3acf61b74de56eb)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
