### PR TITLE
Use more reasonable timeouts for some jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-26.04
     container:
       image: ghcr.io/python/autoconf:2025.01.02.12581854023
-    timeout-minutes: 60
+    timeout-minutes: 5
     needs: build-context
     if: needs.build-context.outputs.run-tests == 'true'
     steps:
@@ -97,7 +97,7 @@ jobs:
     # Don't use ubuntu-latest but a specific version to make the job
     # reproducible: to get the same tools versions (autoconf, aclocal, ...)
     runs-on: ubuntu-26.04
-    timeout-minutes: 60
+    timeout-minutes: 30
     needs: build-context
     if: needs.build-context.outputs.run-tests == 'true'
     steps:
@@ -254,7 +254,7 @@ jobs:
   build-ubuntu-ssltests:
     name: 'Ubuntu SSL tests'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 10
     needs: build-context
     if: needs.build-context.outputs.run-ubuntu == 'true'
     strategy:
@@ -328,7 +328,7 @@ jobs:
     name: Android (${{ matrix.arch }})
     needs: build-context
     if: needs.build-context.outputs.run-android == 'true'
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -350,7 +350,7 @@ jobs:
     name: iOS
     needs: build-context
     if: needs.build-context.outputs.run-ios == 'true'
-    timeout-minutes: 60
+    timeout-minutes: 40
     runs-on: macos-26
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -375,7 +375,7 @@ jobs:
   test-hypothesis:
     name: "Hypothesis tests on Ubuntu"
     runs-on: ubuntu-26.04
-    timeout-minutes: 60
+    timeout-minutes: 30
     needs: build-context
     if: needs.build-context.outputs.run-ubuntu == 'true'
     env:
@@ -479,7 +479,7 @@ jobs:
   build-asan:
     name: 'Address sanitizer'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     needs: build-context
     if: needs.build-context.outputs.run-ubuntu == 'true'
     strategy:
@@ -550,7 +550,7 @@ jobs:
   cross-build-linux:
     name: Cross build Linux
     runs-on: ubuntu-26.04
-    timeout-minutes: 60
+    timeout-minutes: 30
     needs: build-context
     if: needs.build-context.outputs.run-ubuntu == 'true'
     steps:
@@ -632,7 +632,7 @@ jobs:
   all-required-green:  # This job does nothing and is only used for the branch protection
     name: All required checks pass
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 2
     needs:
     - build-context  # Transitive dependency, needed to access `run-tests` value
     - check-docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -50,7 +50,7 @@ jobs:
   mypy:
     name: Run mypy on ${{ matrix.target }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/new-bugs-announce-notifier.yml
+++ b/.github/workflows/new-bugs-announce-notifier.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       issues: read
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       pull-requests: read
-    timeout-minutes: 10
+    timeout-minutes: 2
 
     steps:
       - name: Check there's no DO-NOT-MERGE
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       pull-requests: read
-    timeout-minutes: 10
+    timeout-minutes: 2
 
     steps:
       # Check that the PR is not awaiting changes from the author due to previous review.

--- a/.github/workflows/reusable-check-html-ids.yml
+++ b/.github/workflows/reusable-check-html-ids.yml
@@ -13,7 +13,7 @@ jobs:
   check-html-ids:
     name: 'Check for removed HTML IDs'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - name: 'Check out PR head'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/reusable-cifuzz.yml
+++ b/.github/workflows/reusable-cifuzz.yml
@@ -20,7 +20,7 @@ jobs:
   cifuzz:
     name: ${{ inputs.oss-fuzz-project-name }} (${{ inputs.sanitizer }})
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 40
     steps:
       - name: Build fuzzers (${{ inputs.sanitizer }})
         id: build

--- a/.github/workflows/reusable-context.yml
+++ b/.github/workflows/reusable-context.yml
@@ -58,7 +58,7 @@ jobs:
   compute-changes:
     name: Create context from changed files
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     outputs:
       run-android: ${{ steps.changes.outputs.run-android }}
       run-ci-fuzz: ${{ steps.changes.outputs.run-ci-fuzz }}

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -29,7 +29,7 @@ jobs:
   build-doc:
     name: 'Docs'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 10
     env:
       branch_base: 'origin/${{ github.event.pull_request.base.ref }}'
       branch_pr: 'origin/${{ github.event.pull_request.head.ref }}'
@@ -115,7 +115,7 @@ jobs:
   doctest:
     name: 'Doctest'
     runs-on: ubuntu-26.04
-    timeout-minutes: 60
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
@@ -141,7 +141,7 @@ jobs:
   check-epub:
     name: 'Check EPUB'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:

--- a/.github/workflows/reusable-install.yml
+++ b/.github/workflows/reusable-install.yml
@@ -13,7 +13,7 @@ jobs:
   build-install-test:
     name: build, install and test
     runs-on: ubuntu-26.04-arm
-    timeout-minutes: 60
+    timeout-minutes: 30
     env:
       PYTHONSTRICTEXTENSIONBUILD: 1
     steps:

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -22,7 +22,7 @@ jobs:
   build-macos:
     name: build and test (${{ inputs.os }})
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     env:
       HOMEBREW_NO_ANALYTICS: 1
       HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/reusable-san.yml
+++ b/.github/workflows/reusable-san.yml
@@ -28,7 +28,7 @@ jobs:
         || ''
       }}
     runs-on: ubuntu-26.04
-    timeout-minutes: 60
+    timeout-minutes: 40
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -33,7 +33,7 @@ jobs:
   build-ubuntu-reusable:
     name: build and test (${{ inputs.os }})
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     env:
       OPENSSL_VER: 3.5.7
       PYTHONSTRICTEXTENSIONBUILD: 1

--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -13,7 +13,7 @@ jobs:
   build-wasi-reusable:
     name: 'build and test'
     runs-on: ubuntu-26.04-arm
-    timeout-minutes: 60
+    timeout-minutes: 30
     env:
       WASMTIME_VERSION: 38.0.3
       CROSS_BUILD_WASI: cross-build/wasm32-wasip1

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     name: Build and test (${{ inputs.arch }}, ${{ inputs.interpreter }})
     runs-on: ${{ inputs.arch == 'arm64' && 'windows-11-arm' || 'windows-2025' }}
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.free-threading && 60 || 40 }}
     env:
       ARCH: ${{ inputs.arch }}
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       actions: write
       pull-requests: write
-    timeout-minutes: 10
+    timeout-minutes: 5
 
     steps:
     - name: "Check PRs"

--- a/.github/workflows/tail-call.yml
+++ b/.github/workflows/tail-call.yml
@@ -26,7 +26,7 @@ jobs:
   macos:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -39,9 +39,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.11'
       - name: Install dependencies
         run: |
           brew update
@@ -60,7 +57,7 @@ jobs:
   linux:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -78,9 +75,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.11'
       - name: Build
         run: |
           # On ubuntu-26.04 image, clang is clang-21 by default

--- a/.github/workflows/verify-ensurepip-wheels.yml
+++ b/.github/workflows/verify-ensurepip-wheels.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   verify:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
A job that on average, takes under half a minute, does not need a 60 minute time out. As such, when something goes wrong and the job hangs we are needlessly wasting CI resources. So I propose some slightly stricter `timeout-minutes`. They are all still quite generous, however, giving around 2-4x the average time.

Also, drop `actions/setup-python` in `tail-call.yml`, it's not needed for anything.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
