### PR TITLE
gh-156099: Fix a crash when deleting SSLContext.keylog_filename

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -5518,6 +5518,10 @@ class TestSSLDebug(unittest.TestCase):
         with self.assertRaises(TypeError):
             ctx.keylog_filename = 1
 
+        with self.assertRaisesRegex(AttributeError, 'cannot be deleted'):
+            del ctx.keylog_filename
+        self.assertEqual(ctx.keylog_filename, None)
+
     def test_keylog_filename(self):
         self.addCleanup(os_helper.unlink, os_helper.TESTFN)
         client_context, server_context, hostname = testing_context()

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -5518,9 +5518,11 @@ class TestSSLDebug(unittest.TestCase):
         with self.assertRaises(TypeError):
             ctx.keylog_filename = 1
 
+        ctx.keylog_filename = os_helper.TESTFN
         with self.assertRaisesRegex(AttributeError, 'cannot be deleted'):
             del ctx.keylog_filename
-        self.assertEqual(ctx.keylog_filename, None)
+        # a failed deletion does not change the value
+        self.assertEqual(ctx.keylog_filename, os_helper.TESTFN)
 
     def test_keylog_filename(self):
         self.addCleanup(os_helper.unlink, os_helper.TESTFN)

--- a/Misc/NEWS.d/next/Library/2026-08-20-12-00-00.gh-issue-156099.Kp4vRt.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-20-12-00-00.gh-issue-156099.Kp4vRt.rst
@@ -1,0 +1,3 @@
+Fix a crash when deleting the ``keylog_filename`` attribute of
+:class:`ssl.SSLContext`.
+It now raises :exc:`AttributeError`.

--- a/Modules/_ssl/debughelpers.c
+++ b/Modules/_ssl/debughelpers.c
@@ -182,6 +182,12 @@ static int
 _PySSLContext_set_keylog_filename(PyObject *op, PyObject *arg,
                                   void *Py_UNUSED(closure))
 {
+    if (arg == NULL) {
+        PyErr_Format(PyExc_AttributeError,
+                     "attribute 'keylog_filename' of '%.100s' objects "
+                     "cannot be deleted", Py_TYPE(op)->tp_name);
+        return -1;
+    }
 #if defined(MS_WINDOWS_APP) && !defined(MS_WINDOWS_DESKTOP)
     PyErr_SetString(PyExc_NotImplementedError,
                     "set_keylog_filename: unavailable on UWP build");


### PR DESCRIPTION
The setter did not check the value for `NULL` and passed it to `Py_fopen()`.
Deleting the attribute now raises `AttributeError`, like other attributes of `_ssl._SSLContext`.

<!-- gh-issue-number: gh-156099 -->
* Issue: gh-156099
<!-- /gh-issue-number -->
