### PR TITLE
gh-156100: Fix crashes in the sqlite3 Connection.autocommit setter

### DIFF
--- a/Lib/test/test_sqlite3/test_transactions.py
+++ b/Lib/test/test_sqlite3/test_transactions.py
@@ -396,10 +396,12 @@ class AutocommitAttribute(unittest.TestCase):
 
     def test_autocommit_delete(self):
         with memory_database() as cx:
+            cx.autocommit = False
             with self.assertRaisesRegex(AttributeError,
                                         "cannot delete autocommit attribute"):
                 del cx.autocommit
-            self.assertEqual(cx.autocommit, sqlite.LEGACY_TRANSACTION_CONTROL)
+            # a failed deletion does not change the value
+            self.assertIs(cx.autocommit, False)
 
     def test_autocommit_disabled(self):
         expected = [

--- a/Lib/test/test_sqlite3/test_transactions.py
+++ b/Lib/test/test_sqlite3/test_transactions.py
@@ -394,6 +394,13 @@ class AutocommitAttribute(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, msg):
                     sqlite.connect(":memory:", autocommit=mode)
 
+    def test_autocommit_delete(self):
+        with memory_database() as cx:
+            with self.assertRaisesRegex(AttributeError,
+                                        "cannot delete autocommit attribute"):
+                del cx.autocommit
+            self.assertEqual(cx.autocommit, sqlite.LEGACY_TRANSACTION_CONTROL)
+
     def test_autocommit_disabled(self):
         expected = [
             "SELECT 1",

--- a/Lib/test/test_sqlite3/test_transactions.py
+++ b/Lib/test/test_sqlite3/test_transactions.py
@@ -389,10 +389,16 @@ class AutocommitAttribute(unittest.TestCase):
 
     def test_autocommit_setget_invalid(self):
         msg = "autocommit must be True, False, or.*LEGACY"
-        for mode in "a", 12, (), None:
+        for mode in "a", 12, (), None, 2**1000, -2**1000:
             with self.subTest(mode=mode):
                 with self.assertRaisesRegex(ValueError, msg):
                     sqlite.connect(":memory:", autocommit=mode)
+                with memory_database() as cx:
+                    with self.assertRaisesRegex(ValueError, msg):
+                        cx.autocommit = mode
+                    # a failed assignment does not change the value
+                    self.assertEqual(cx.autocommit,
+                                     sqlite.LEGACY_TRANSACTION_CONTROL)
 
     def test_autocommit_delete(self):
         with memory_database() as cx:

--- a/Misc/NEWS.d/next/Library/2026-08-20-12-05-00.gh-issue-156100.Lm7qWz.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-20-12-05-00.gh-issue-156100.Lm7qWz.rst
@@ -1,3 +1,4 @@
-Fix a crash when deleting the :attr:`~sqlite3.Connection.autocommit`
-attribute of :class:`sqlite3.Connection`.
-It now raises :exc:`AttributeError`.
+Fix crashes in :class:`sqlite3.Connection` when deleting the
+:attr:`~sqlite3.Connection.autocommit` attribute or setting it to an integer
+which does not fit in C :c:expr:`long`.
+Both now raise an exception.

--- a/Misc/NEWS.d/next/Library/2026-08-20-12-05-00.gh-issue-156100.Lm7qWz.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-20-12-05-00.gh-issue-156100.Lm7qWz.rst
@@ -1,0 +1,3 @@
+Fix a crash when deleting the :attr:`~sqlite3.Connection.autocommit`
+attribute of :class:`sqlite3.Connection`.
+It now raises :exc:`AttributeError`.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -104,11 +104,16 @@ autocommit_converter(PyObject *val, enum autocommit_mode *result)
         *result = AUTOCOMMIT_DISABLED;
         return 1;
     }
-    if (PyLong_Check(val) &&
-        PyLong_AsLong(val) == LEGACY_TRANSACTION_CONTROL)
-    {
-        *result = AUTOCOMMIT_LEGACY;
-        return 1;
+    if (PyLong_Check(val)) {
+        int overflow;
+        long value = PyLong_AsLongAndOverflow(val, &overflow);
+        if (value == -1 && PyErr_Occurred()) {
+            return 0;
+        }
+        if (!overflow && value == LEGACY_TRANSACTION_CONTROL) {
+            *result = AUTOCOMMIT_LEGACY;
+            return 1;
+        }
     }
 
     PyErr_SetString(PyExc_ValueError,

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -2621,6 +2621,11 @@ static int
 set_autocommit(PyObject *op, PyObject *val, void *Py_UNUSED(closure))
 {
     pysqlite_Connection *self = _pysqlite_Connection_CAST(op);
+    if (val == NULL) {
+        PyErr_SetString(PyExc_AttributeError,
+                        "cannot delete autocommit attribute");
+        return -1;
+    }
     if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
         return -1;
     }


### PR DESCRIPTION
The setter passed the deleted value to `autocommit_converter()`, which dereferences it in `Py_IsTrue()`.
Deleting the attribute now raises `AttributeError`, like `row_factory` and `text_factory` (gh-149738).

`autocommit_converter()` also reported success with `OverflowError` set when the value was an integer which does not fit in C `long`, because `PyLong_AsLong()` returns -1 on error, and `LEGACY_TRANSACTION_CONTROL` is -1.
Such value is now rejected with `ValueError`, like any other invalid value.

<!-- gh-issue-number: gh-156100 -->
* Issue: gh-156100
<!-- /gh-issue-number -->
