### PR TITLE
gh-156101: Fix sqlite3 Cursor.arraysize on a failed assignment

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1078,6 +1078,8 @@ class CursorTests(unittest.TestCase):
         self.assertRaises(TypeError, setter, 1.0)
         self.assertRaises(ValueError, setter, -3)
         self.assertRaises(OverflowError, setter, UINT32_MAX + 1)
+        # a failed assignment does not change the value
+        self.assertEqual(self.cu.arraysize, 1)
 
     def test_fetchmany(self):
         # no active SQL statement

--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1075,11 +1075,13 @@ class CursorTests(unittest.TestCase):
         UINT32_MAX = (1 << 32) - 1
         setter = functools.partial(setattr, self.cu, 'arraysize')
 
+        self.cu.arraysize = 2
         self.assertRaises(TypeError, setter, 1.0)
         self.assertRaises(ValueError, setter, -3)
         self.assertRaises(OverflowError, setter, UINT32_MAX + 1)
+        self.assertRaises(ValueError, setter, -(UINT32_MAX + 1))
         # a failed assignment does not change the value
-        self.assertEqual(self.cu.arraysize, 1)
+        self.assertEqual(self.cu.arraysize, 2)
 
     def test_fetchmany(self):
         # no active SQL statement

--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1079,7 +1079,8 @@ class CursorTests(unittest.TestCase):
         self.assertRaises(TypeError, setter, 1.0)
         self.assertRaises(ValueError, setter, -3)
         self.assertRaises(OverflowError, setter, UINT32_MAX + 1)
-        self.assertRaises(ValueError, setter, -(UINT32_MAX + 1))
+        self.assertRaises(OverflowError, setter, 2**1000)
+        self.assertRaises(ValueError, setter, -2**1000)
         # a failed assignment does not change the value
         self.assertEqual(self.cu.arraysize, 2)
 

--- a/Misc/NEWS.d/next/Library/2026-08-20-12-10-00.gh-issue-156101.Qb2xNv.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-20-12-10-00.gh-issue-156101.Qb2xNv.rst
@@ -1,0 +1,3 @@
+Fix :attr:`sqlite3.Cursor.arraysize` being set to 0 if the assigned value is
+too large.
+The attribute is now left unchanged if the assignment fails.

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -1378,7 +1378,12 @@ static int
 _sqlite3_Cursor_arraysize_set_impl(pysqlite_Cursor *self, PyObject *value)
 /*[clinic end generated code: output=af59a6b09f8cce6e input=ace48cb114e26060]*/
 {
-    return PyLong_AsUInt32(value, &self->arraysize);
+    uint32_t arraysize;
+    if (PyLong_AsUInt32(value, &arraysize) < 0) {
+        return -1;
+    }
+    self->arraysize = arraysize;
+    return 0;
 }
 
 static PyMethodDef cursor_methods[] = {


### PR DESCRIPTION
`PyLong_AsUInt32()` stores 0 in the target on error, so assigning a too large value left `arraysize` set to 0.
The value is now converted into a local variable first, as in 3.13.

<!-- gh-issue-number: gh-156101 -->
* Issue: gh-156101
<!-- /gh-issue-number -->
