### PR TITLE
gh-156112: Load the ObjC runtime by name when find_library() cannot resolve it

### DIFF
--- a/Lib/_ios_support.py
+++ b/Lib/_ios_support.py
@@ -10,12 +10,15 @@ except ImportError:
 else:
     # ctypes is available. Load the ObjC library, and wrap the objc_getClass,
     # sel_registerName methods
-    lib = util.find_library("objc")
-    if lib is None:
-        # Failed to load the objc library
-        raise ImportError("ObjC runtime library couldn't be loaded")
+    # find_library() resolves a system library through the dyld shared cache,
+    # which needs _dyld_shared_cache_contains_path(); that is unavailable before
+    # iOS 14, so fall back to the bare name, which dyld resolves by itself.
+    lib = util.find_library("objc") or "libobjc.dylib"
 
-    objc = cdll.LoadLibrary(lib)
+    try:
+        objc = cdll.LoadLibrary(lib)
+    except OSError:
+        raise ImportError("ObjC runtime library couldn't be loaded")
     objc.objc_getClass.restype = c_void_p
     objc.objc_getClass.argtypes = [c_char_p]
     objc.sel_registerName.restype = c_void_p

--- a/Misc/NEWS.d/next/Library/2026-08-20-13-50-49.gh-issue-156112.yEcma8.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-20-13-50-49.gh-issue-156112.yEcma8.rst
@@ -1,0 +1,4 @@
+:mod:`!_ios_support` no longer fails to import when
+:func:`ctypes.util.find_library` cannot resolve the ObjC runtime through the
+dyld shared cache, as is the case on iOS 13. The runtime is now loaded by name,
+which dyld resolves against the cache directly.


### PR DESCRIPTION
`_ios_support` raises `ImportError` at import when `ctypes.util.find_library("objc")` returns `None`. That happens whenever the dyld shared cache cannot be queried: `dyld_find()` falls back to `_dyld_shared_cache_contains_path()`, which `Modules/_ctypes/callproc.c` guards with `__builtin_available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)`, so on iOS 13 it raises `NotImplementedError` and no path can be resolved for a library that exists only in the cache.

`IPHONEOS_DEPLOYMENT_TARGET` defaults to `13.0`, so this sits inside the supported range, and it takes `platform.platform()` and `platform.ios_ver()` down with it.

dyld resolves a bare library name against the cache by itself, so this falls back to the name when `find_library()` comes up empty, and keeps reporting a real load failure as `ImportError` rather than letting `OSError` escape.

Verified on macOS, where the same cache mechanism applies — `find_library("objc")` names a path that is not a file, and a bare-name load works:

```
>>> util.find_library("objc"), os.path.isfile("/usr/lib/libobjc.dylib")
('/usr/lib/libobjc.dylib', False)
>>> cdll.LoadLibrary("libobjc.dylib")
<CDLL 'libobjc.dylib', handle ... at ...>
```

and with `find_library` patched to return `None`, the module loads the runtime and `objc_getClass(b"NSProcessInfo")` succeeds.

I do not have an iOS 13 device or simulator runtime available, so the import failure itself is derived from the source rather than reproduced on-device; the fallback is verified as above.

<!-- gh-issue-number: gh-156112 -->
* Issue: gh-156112
<!-- /gh-issue-number -->
