### PR TITLE
gh-156115: Use the simulator deployment-target flag for iOS simulator builds

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-08-20-14-02-33.gh-issue-156115.KXr8wU.rst
+++ b/Misc/NEWS.d/next/Build/2026-08-20-14-02-33.gh-issue-156115.KXr8wU.rst
@@ -1,0 +1,4 @@
+iOS simulator builds are now configured with
+``-mios-simulator-version-min`` instead of the device's
+``-mios-version-min``. The device flag made the linker reject libraries
+resolved from the simulator SDK, so library detection silently failed.

--- a/configure
+++ b/configure
@@ -4895,18 +4895,16 @@ case $host in #(
      ;;
 esac
 
-case $ac_sys_system in #(
-  iOS) :
+case $host in #(
+  *-apple-ios*-simulator) :
 
-            if test "x$_host_device" = "xsimulator"
-then :
-  _ios_version_min_flag=-mios-simulator-version-min
-else case e in #(
-  e) _ios_version_min_flag=-mios-version-min ;;
-esac
-fi
-    as_fn_append CFLAGS " ${_ios_version_min_flag}=${IPHONEOS_DEPLOYMENT_TARGET}"
-    as_fn_append LDFLAGS " ${_ios_version_min_flag}=${IPHONEOS_DEPLOYMENT_TARGET}"
+    as_fn_append CFLAGS " -mios-simulator-version-min=${IPHONEOS_DEPLOYMENT_TARGET}"
+    as_fn_append LDFLAGS " -mios-simulator-version-min=${IPHONEOS_DEPLOYMENT_TARGET}"
+   ;; #(
+  *-apple-ios*) :
+
+    as_fn_append CFLAGS " -mios-version-min=${IPHONEOS_DEPLOYMENT_TARGET}"
+    as_fn_append LDFLAGS " -mios-version-min=${IPHONEOS_DEPLOYMENT_TARGET}"
    ;; #(
   *) :
      ;;

--- a/configure
+++ b/configure
@@ -4898,8 +4898,15 @@ esac
 case $ac_sys_system in #(
   iOS) :
 
-    as_fn_append CFLAGS " -mios-version-min=${IPHONEOS_DEPLOYMENT_TARGET}"
-    as_fn_append LDFLAGS " -mios-version-min=${IPHONEOS_DEPLOYMENT_TARGET}"
+            if test "x$_host_device" = "xsimulator"
+then :
+  _ios_version_min_flag=-mios-simulator-version-min
+else case e in #(
+  e) _ios_version_min_flag=-mios-version-min ;;
+esac
+fi
+    as_fn_append CFLAGS " ${_ios_version_min_flag}=${IPHONEOS_DEPLOYMENT_TARGET}"
+    as_fn_append LDFLAGS " ${_ios_version_min_flag}=${IPHONEOS_DEPLOYMENT_TARGET}"
    ;; #(
   *) :
      ;;

--- a/configure.ac
+++ b/configure.ac
@@ -1008,8 +1008,13 @@ AS_CASE([$host],
 dnl Add the compiler flag for the iOS minimum supported OS version.
 AS_CASE([$ac_sys_system],
   [iOS], [
-    AS_VAR_APPEND([CFLAGS], [" -mios-version-min=${IPHONEOS_DEPLOYMENT_TARGET}"])
-    AS_VAR_APPEND([LDFLAGS], [" -mios-version-min=${IPHONEOS_DEPLOYMENT_TARGET}"])
+    dnl -mios-version-min names the device platform; against the simulator SDK it
+    dnl makes the linker reject every dylib it resolves there.
+    AS_IF([test "x$_host_device" = "xsimulator"],
+      [_ios_version_min_flag=-mios-simulator-version-min],
+      [_ios_version_min_flag=-mios-version-min])
+    AS_VAR_APPEND([CFLAGS], [" ${_ios_version_min_flag}=${IPHONEOS_DEPLOYMENT_TARGET}"])
+    AS_VAR_APPEND([LDFLAGS], [" ${_ios_version_min_flag}=${IPHONEOS_DEPLOYMENT_TARGET}"])
   ],
 )
 

--- a/configure.ac
+++ b/configure.ac
@@ -1006,15 +1006,14 @@ AS_CASE([$host],
 )
 
 dnl Add the compiler flag for the iOS minimum supported OS version.
-AS_CASE([$ac_sys_system],
-  [iOS], [
-    dnl -mios-version-min names the device platform; against the simulator SDK it
-    dnl makes the linker reject every dylib it resolves there.
-    AS_IF([test "x$_host_device" = "xsimulator"],
-      [_ios_version_min_flag=-mios-simulator-version-min],
-      [_ios_version_min_flag=-mios-version-min])
-    AS_VAR_APPEND([CFLAGS], [" ${_ios_version_min_flag}=${IPHONEOS_DEPLOYMENT_TARGET}"])
-    AS_VAR_APPEND([LDFLAGS], [" ${_ios_version_min_flag}=${IPHONEOS_DEPLOYMENT_TARGET}"])
+AS_CASE([$host],
+  [*-apple-ios*-simulator], [
+    AS_VAR_APPEND([CFLAGS], [" -mios-simulator-version-min=${IPHONEOS_DEPLOYMENT_TARGET}"])
+    AS_VAR_APPEND([LDFLAGS], [" -mios-simulator-version-min=${IPHONEOS_DEPLOYMENT_TARGET}"])
+  ],
+  [*-apple-ios*], [
+    AS_VAR_APPEND([CFLAGS], [" -mios-version-min=${IPHONEOS_DEPLOYMENT_TARGET}"])
+    AS_VAR_APPEND([LDFLAGS], [" -mios-version-min=${IPHONEOS_DEPLOYMENT_TARGET}"])
   ],
 )
 


### PR DESCRIPTION
`configure` appends `-mios-version-min` to CFLAGS/LDFLAGS for every iOS build. That is the device flag (an alias for `-miphoneos-version-min`), so against the simulator SDK the linker rejects everything it resolves there:

```
ld: building for 'iOS', but linking in dylib (.../iPhoneSimulator.sdk/usr/lib/libiconv.2.tbd) built for 'iOS-simulator'
```

`_host_device` is already derived from the host triple at `configure.ac:794`, so this selects the flag from it: `-mios-simulator-version-min` for the simulator, `-mios-version-min` unchanged for the device.

The wrappers in `Platforms/Apple/iOS/Resources/bin` hide this, because they pass `--target=arm64-apple-ios-simulator` and that pins the platform regardless of the later flag. Driving clang directly with `-isysroot`, as a cross-compiling build system typically does, hits it.

It is a quiet failure rather than a loud one. On unpatched `main`, a simulator configure still exits 0, but `config.log` holds 17 failed conftest links and features come out misdetected:

```
< /* #undef HAVE_ICONV */
< /* #undef HAVE_LIBSQLITE3 */
< /* #undef HAVE_ZLIB_COPY */
< /* #undef PY_SQLITE_HAVE_SERIALIZE */
---
> #define HAVE_ICONV 1
> #define HAVE_LIBSQLITE3 1
> #define HAVE_ZLIB_COPY 1
> #define PY_SQLITE_HAVE_SERIALIZE 1
```

With a library on `LDFLAGS` before the first compiler check it fails outright with `configure: error: C compiler cannot create executables`.

Verified on macOS/arm64: the simulator build emits `-mios-simulator-version-min=12.0` and detects all four features; the device build still emits `-mios-version-min=12.0` and is otherwise unchanged.

<!-- gh-issue-number: gh-156115 -->
* Issue: gh-156115
<!-- /gh-issue-number -->
