### PR TITLE
gh-130821: Add type info to error message in Modules/_abc.c

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-20-15-00-00.gh-issue-130821.abc-item-type.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-20-15-00-00.gh-issue-130821.abc-item-type.rst
@@ -1,0 +1,3 @@
+Include the type name in the :exc:`TypeError` raised when an item yielded by
+``items()`` is not iterable during abstract method computation in
+:mod:`abc`. Patch by Jason Mak.

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -383,10 +383,17 @@ compute_abstract_methods(PyObject *self)
     }
     assert(PyList_Check(items));
     for (Py_ssize_t pos = 0; pos < PyList_GET_SIZE(items); pos++) {
+        PyObject *item = PyList_GET_ITEM(items, pos);
         PyObject *it = PySequence_Fast(
-                PyList_GET_ITEM(items, pos),
+                item,
                 "items() returned non-iterable");
         if (!it) {
+            if (PyErr_ExceptionMatches(PyExc_TypeError)) {
+                PyErr_Format(PyExc_TypeError,
+                             "items() must yield iterable (key, value) "
+                             "pairs, not %T",
+                             item);
+            }
             goto error;
         }
         if (PySequence_Fast_GET_SIZE(it) != 2) {


### PR DESCRIPTION
Supersedes the `Modules/_abc.c` portion of gh-144737, which has gone stale (no activity since a 2026-05-06 stale-bot ping, still unmerged). This picks up that piece specifically, using the type-information convention established by the merged gh-130835.

## Change

When an item yielded by a class namespace's `items()` isn't iterable during abstract-method computation, the raised `TypeError` now includes the offending item's type:

```
items() must yield iterable (key, value) pairs, not int
```

## Why not just reuse gh-144737's diff verbatim

gh-144737's `_abc.c` hunk passes `NULL` as the message argument to `PySequence_Fast()`:

```c
PyObject *it = PySequence_Fast(item, NULL);
```

`PySequence_Fast()` calls `PyErr_SetString()` with that message when the failure is a `TypeError`, and `PyErr_SetString(exc, NULL)` dereferences a null `char *` inside `PyUnicode_FromString()`. This is reachable if `self.__dict__` (or `ns` from a custom metaclass namespace) yields an item that isn't iterable and whose iteration failure is a `TypeError` — the exact case this PR is fixing.

This PR instead keeps a real fallback message on `PySequence_Fast()` and only replaces it via `PyErr_Format()` after checking `PyErr_ExceptionMatches(PyExc_TypeError)`, so no NULL ever reaches `PyErr_SetString()`, and non-TypeError failures (e.g. a raising `__iter__`) propagate unmodified instead of being overwritten.

## Scope

This intentionally covers only `Modules/_abc.c`, not the other six files gh-144737 touched (`_csv.c`, `_datetimemodule.c`, `_io/*.c`, `_pickle.c`). That PR's `_pickle.c` hunk had an open reviewer question (ValueError vs. TypeError for `read()`'s return-type check) that never reached a resolution, and gh-130821 itself is still marked by @serhiy-storchaka as needing wider consensus for a repo-wide sweep (see the stalled https://discuss.python.org/t/error-messages-for-methods/83362). Keeping this PR narrow avoids re-opening either of those unresolved questions.

<!-- gh-issue-number: gh-130821 -->
* Issue: gh-130821
<!-- /gh-issue-number -->
