### PR TITLE
gh-156121: Fix crash on bad AttributeError args in crossinterp

### DIFF
--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -1741,6 +1741,28 @@ class TestInterpreterCall(TestBase):
             with self.assertRaises(interpreters.NotShareableError):
                 interp.call(func, op, 'eggs!')
 
+    def test_call_unpickle_bad_attribute_error(self):
+        # gh-156121: unpickling in the other interpreter may fail
+        # with an AttributeError whose message is not a str
+        # or cannot be encoded as UTF-8.
+        interp = interpreters.create()
+        script = dedent("""
+            x = 1
+            def f():
+                return x  # forces the pickle fallback
+            """)
+        with defined_in___main__('f', script) as func:
+            for arg in (42, '\ud800'):
+                with self.subTest(arg):
+                    interp.exec(dedent(f"""
+                        import pickle
+                        def loads(data):
+                            raise AttributeError({arg!r})
+                        pickle.loads = loads
+                        """))
+                    with self.assertRaises(interpreters.NotShareableError):
+                        interp.call(func)
+
     def test_callable_requires_frame(self):
         # There are various functions that require a current frame.
         interp = interpreters.create()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-21-00-52-18.gh-issue-156121.xrGUcF.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-21-00-52-18.gh-issue-156121.xrGUcF.rst
@@ -1,0 +1,3 @@
+Fix a crash in cross-interpreter unpickling
+when the :exc:`AttributeError` raised by :func:`pickle.loads`
+has a non-string argument or a message that cannot be encoded as UTF-8.

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -651,7 +651,7 @@ check_missing___main___attr(PyObject *exc)
     PyObject *args = PyException_GetArgs(exc);
     if (args == NULL || args == Py_None || PyObject_Size(args) < 1) {
         Py_XDECREF(args);
-        assert(!PyErr_Occurred());
+        PyErr_Clear();
         return 0;
     }
     PyObject *msgobj = args;
@@ -662,8 +662,17 @@ check_missing___main___attr(PyObject *exc)
             PyErr_Clear();
             return 0;
         }
+        if (!PyUnicode_Check(msgobj)) {
+            Py_DECREF(msgobj);
+            return 0;
+        }
     }
     const char *err = PyUnicode_AsUTF8(msgobj);
+    if (err == NULL) {
+        Py_DECREF(msgobj);
+        PyErr_Clear();
+        return 0;
+    }
 
     // Check if it's a missing __main__ attr.
     int cmp = strncmp(err, "module '__main__' has no attribute '", 36);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156121 -->
* Issue: gh-156121
<!-- /gh-issue-number -->
