### PR TITLE
gh-156117: Fix crash on non-UTF-8 gil in interpreter config

### DIFF
--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -2071,6 +2071,10 @@ class LowLevelTests(TestBase):
             with self.subTest(f'bad override (gil={value!r})'):
                 with self.assertRaises(ValueError):
                     _interpreters.new_config(gil=value)
+        with self.subTest('bad override (gil=lone surrogate)'):
+            # gh-156117: a lone surrogate cannot be encoded as UTF-8
+            with self.assertRaises(UnicodeEncodeError):
+                _interpreters.new_config(gil='\ud800')
 
     def test_get_main(self):
         interpid, whence = _interpreters.get_main()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-21-01-10-18.gh-issue-156117.MEgefB.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-21-01-10-18.gh-issue-156117.MEgefB.rst
@@ -1,0 +1,2 @@
+Fix a crash in :func:`!_interpreters.new_config`
+when the ``gil`` argument cannot be encoded as UTF-8.

--- a/Python/interpconfig.c
+++ b/Python/interpconfig.c
@@ -133,7 +133,12 @@ _config_dict_copy_str(PyObject *dict, const char *name,
         config_dict_invalid_type(name);
         return -1;
     }
-    strncpy(buf, PyUnicode_AsUTF8(item), bufsize-1);
+    const char *str = PyUnicode_AsUTF8(item);
+    if (str == NULL) {
+        Py_DECREF(item);
+        return -1;
+    }
+    strncpy(buf, str, bufsize-1);
     buf[bufsize-1] = '\0';
     Py_DECREF(item);
     return 0;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156117 -->
* Issue: gh-156117
<!-- /gh-issue-number -->
