### PR TITLE
gh-156057: Wrap compression library exceptions in tarfile.ReadError

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -661,13 +661,15 @@ class _FileInFile(object):
        object.
     """
 
-    def __init__(self, fileobj, offset, size, name, blockinfo=None):
+    def __init__(self, fileobj, offset, size, name, blockinfo=None,
+            exception=OSError):
         self.fileobj = fileobj
         self.offset = offset
         self.size = size
         self.position = 0
         self.name = name
         self.closed = False
+        self.exception = exception
 
         if blockinfo is None:
             blockinfo = [(0, size)]
@@ -744,7 +746,10 @@ class _FileInFile(object):
             length = min(size, stop - self.position)
             if data:
                 self.fileobj.seek(offset + (self.position - start))
-                b = self.fileobj.read(length)
+                try:
+                    b = self.fileobj.read(length)
+                except self.exception as e:
+                    raise ReadError(f"invalid compressed data: {e}") from e
                 if len(b) != length:
                     raise ReadError("unexpected end of data")
                 buf += b
@@ -767,7 +772,8 @@ class ExFileObject(io.BufferedReader):
 
     def __init__(self, tarfile, tarinfo):
         fileobj = _FileInFile(tarfile.fileobj, tarinfo.offset_data,
-                tarinfo.size, tarinfo.name, tarinfo.sparse)
+                tarinfo.size, tarinfo.name, tarinfo.sparse,
+                exception=tarfile.exception)
         super().__init__(fileobj)
 #class ExFileObject
 
@@ -1789,6 +1795,12 @@ class TarFile(object):
 
     fileobject = ExFileObject   # The file-object for extractfile().
 
+    exception = OSError         # The exception raised by the underlying
+                                 # fileobj.read() on corrupt compressed
+                                 # data past the header (see gzopen() etc.
+                                 # for the more specific exception types
+                                 # used by each compression format).
+
     extraction_filter = None    # The default filter for extraction.
 
     def __init__(self, name=None, mode="r", fileobj=None, format=None,
@@ -2034,6 +2046,7 @@ class TarFile(object):
 
         try:
             from gzip import GzipFile
+            import zlib
         except ImportError:
             raise CompressionError("gzip module is not available") from None
 
@@ -2056,6 +2069,7 @@ class TarFile(object):
             fileobj.close()
             raise
         t._extfileobj = False
+        t.exception = zlib.error
         return t
 
     @classmethod
@@ -2112,6 +2126,7 @@ class TarFile(object):
             fileobj.close()
             raise
         t._extfileobj = False
+        t.exception = LZMAError
         return t
 
     @classmethod
@@ -2147,6 +2162,7 @@ class TarFile(object):
             fileobj.close()
             raise
         t._extfileobj = False
+        t.exception = ZstdError
         return t
 
     # All *open() methods are registered here.

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1191,6 +1191,72 @@ class GzipBrokenHeaderCorrectException(GzipTest, unittest.TestCase):
             tarfile.open(fileobj=f, mode='r|gz')
 
 
+class FileInFileExceptionWrappingTest(unittest.TestCase):
+    """
+    See: https://github.com/python/cpython/issues/156057
+
+    _FileInFile.read() must wrap whatever exception type its
+    underlying fileobj.read() raises for corrupt compressed data,
+    using the exception class attribute each TarFile.*open()
+    classmethod configures, in tarfile.ReadError -- and must not
+    swallow an exception of an unconfigured type.
+    """
+
+    class _FakeFileobj:
+        def __init__(self, exc):
+            self.exc = exc
+
+        def seek(self, position):
+            pass
+
+        def read(self, size):
+            raise self.exc
+
+    def test_wraps_configured_exception_type(self):
+        class Boom(Exception):
+            pass
+
+        fif = tarfile._FileInFile(
+            self._FakeFileobj(Boom("simulated corrupt compressed data")),
+            offset=0, size=10, name="member", exception=Boom)
+        with self.assertRaises(tarfile.ReadError):
+            fif.read()
+
+    def test_does_not_wrap_unconfigured_exception_type(self):
+        class Boom(Exception):
+            pass
+
+        class Unrelated(Exception):
+            pass
+
+        fif = tarfile._FileInFile(
+            self._FakeFileobj(Unrelated("not the configured exception type")),
+            offset=0, size=10, name="member", exception=Boom)
+        with self.assertRaises(Unrelated):
+            fif.read()
+
+
+@support.requires_gzip()
+class GzipExtractfileWrapsCompressionErrorTest(unittest.TestCase):
+    """
+    See: https://github.com/python/cpython/issues/156057
+
+    Confirms the real gzopen() -> ExFileObject -> _FileInFile wiring:
+    a zlib.error raised while reading a member's compressed data past
+    the header surfaces as tarfile.ReadError, not the raw zlib.error.
+    """
+
+    def test_extractfile_read_wraps_zlib_error(self):
+        with tarfile.open(gzipname, mode='r:gz') as tar:
+            tarinfo = tar.getmember("ustar/regtype")
+            with tar.extractfile(tarinfo) as fobj:
+                with unittest.mock.patch.object(
+                        tar.fileobj, "read",
+                        side_effect=zlib.error("simulated corrupt data")):
+                    with self.assertRaises(tarfile.ReadError):
+                        fobj.read()
+
+
 class MemberReadTest(ReadTest, unittest.TestCase):
 
     def _test_member(self, tarinfo, chksum=None, **kwargs):

--- a/Misc/NEWS.d/next/Library/2026-08-21-06-00-00.gh-issue-156057.tarfile-wrap-comp-err.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-21-06-00-00.gh-issue-156057.tarfile-wrap-comp-err.rst
@@ -2,4 +2,4 @@ Wrap the underlying compression library's exception in :exc:`tarfile.ReadError`
 when a member's compressed data is corrupt past its header, for all of
 :mod:`tarfile`'s supported compression formats (gzip, bzip2, lzma, zstd).
 Previously the raw exception (e.g. :exc:`zlib.error`) could leak through
-:meth:`TarFile.extractfile`. Patch by Jason Mak.
+:meth:`tarfile.TarFile.extractfile`. Patch by Jason Mak.

--- a/Misc/NEWS.d/next/Library/2026-08-21-06-00-00.gh-issue-156057.tarfile-wrap-comp-err.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-21-06-00-00.gh-issue-156057.tarfile-wrap-comp-err.rst
@@ -1,0 +1,5 @@
+Wrap the underlying compression library's exception in :exc:`tarfile.ReadError`
+when a member's compressed data is corrupt past its header, for all of
+:mod:`tarfile`'s supported compression formats (gzip, bzip2, lzma, zstd).
+Previously the raw exception (e.g. :exc:`zlib.error`) could leak through
+:meth:`TarFile.extractfile`. Patch by Jason Mak.


### PR DESCRIPTION
Fixes gh-156057.

## The bug

`TarFile.extractfile()` reads a member's payload through `_FileInFile.read()`, which calls the underlying compressed `fileobj.read()` (a `gzip.GzipFile`/`bz2.BZ2File`/`lzma.LZMAFile`/`zstd.ZstdFile` for seekable-mode `r:gz`/`r:bz2`/`r:xz`/`r:zst` archives) with no exception handling. If the member's compressed data is corrupted *after* the header was already read successfully (rather than at initial archive-open time), the codec's own exception - `zlib.error`, `OSError` from bz2, `lzma.LZMAError`, or `zstd.ZstdError` - leaks straight through to the caller instead of being wrapped in `tarfile.ReadError`.

The streaming-mode (`r|gz` etc.) code path already handles this correctly: `_Stream` sets a `self.exception` attribute to the specific codec's error type and catches it around its own `decompress()` calls. The seekable-mode path via `_FileInFile` had no equivalent.

## The fix

Give `TarFile` (and `_FileInFile`) the same per-codec `exception` attribute pattern already used by `_Stream`:
- `TarFile.exception` defaults to `OSError` (correct for `bz2`, and for uncompressed `tar` mode where it's simply unused).
- `gzopen()`/`xzopen()`/`zstopen()` set it to the specific type (`zlib.error`, `LZMAError`, `ZstdError`) after a successful open, mirroring what they already do for `t._extfileobj`.
- `ExFileObject.__init__` passes `tarfile.exception` through to `_FileInFile`, which now wraps its `fileobj.read()` call and re-raises as `tarfile.ReadError`.

## Verification

Reproduced the leak against current `main` for gzip, bzip2, and xz (couldn't test zstd locally - no `compression.zstd` module in the Python available here) using a corrupted-mid-stream archive for each, confirming all three previously leaked the raw codec exception. Same test against the patched version confirms all three now raise `tarfile.ReadError` instead. Also ran a full write/read/extract round-trip across all four compression modes (uncompressed, gzip, bzip2, xz) to confirm no regression in normal operation.