### PR TITLE
gh-149167: PyREPL autocomplete imports to only display public members

### DIFF
--- a/Lib/_pyrepl/_module_completer.py
+++ b/Lib/_pyrepl/_module_completer.py
@@ -221,7 +221,10 @@ class ModuleCompleter:
         if not imported_module:
             return [], None, self._get_import_completion_action(path)
         try:
-            module_attributes = dir(imported_module)
+            if hasattr(imported_module, '__all__'): # Use __all__ if available, otherwise use dir()
+                module_attributes = imported_module.__all__
+            else:
+                module_attributes = dir(imported_module)
         except Exception:
             module_attributes = []
         # Filter out invalid attribute names, such as dashes that cannot be

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1771,17 +1771,13 @@ class TestPyReplModuleCompleter(TestCase):
     def test_find_attributes_uses_all(self):
         """Test that _find_attributes respects __all__ when available."""
         completer = ModuleCompleter()
-        
         # json module has __all__ defined
         attrs, module, _ = completer._find_attributes('json', '')
-        
         # Should match __all__ contents, not dir() which includes methods
         expected = sorted(json.__all__)
         self.assertEqual(sorted(attrs), expected)
-        
         # Should NOT contain __all__
         self.assertNotIn('__all__', attrs)
-        
         # Verify we got the actual module object
         self.assertIs(module, sys.modules.get('json'))
 

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -2,6 +2,7 @@ import contextlib
 import importlib
 import io
 import itertools
+lazy import json
 import os
 import pathlib
 import pkgutil
@@ -1766,6 +1767,23 @@ class TestPyReplModuleCompleter(TestCase):
             f"{module_color}mock{R}",
         ])
         self.assertIsNone(action)
+
+    def test_find_attributes_uses_all(self):
+        """Test that _find_attributes respects __all__ when available."""
+        completer = ModuleCompleter()
+        
+        # json module has __all__ defined
+        attrs, module, _ = completer._find_attributes('json', '')
+        
+        # Should match __all__ contents, not dir() which includes methods
+        expected = sorted(json.__all__)
+        self.assertEqual(sorted(attrs), expected)
+        
+        # Should NOT contain __all__
+        self.assertNotIn('__all__', attrs)
+        
+        # Verify we got the actual module object
+        self.assertIs(module, sys.modules.get('json'))
 
 
 # Audit hook used to check for stdlib modules import side-effects

--- a/Misc/NEWS.d/next/Library/2026-08-21-05-46-17.gh-issue-149167.JcHCCr.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-21-05-46-17.gh-issue-149167.JcHCCr.rst
@@ -1,1 +1,1 @@
-Updates PyREPL autocomplete on import statements to only expose public members if declared with `__all__`
+Updates PyREPL autocomplete on import statements to only expose public members if declared with ``__all__``

--- a/Misc/NEWS.d/next/Library/2026-08-21-05-46-17.gh-issue-149167.JcHCCr.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-21-05-46-17.gh-issue-149167.JcHCCr.rst
@@ -1,0 +1,1 @@
+Updates PyREPL autocomplete on import statements to only expose public members if declared with `__all__`


### PR DESCRIPTION
Updates PyREPL autocomplete on import statements to only expose public members if declared with `__all__`

## Before
<img width="815" height="538" alt="Screenshot 2026-08-20 at 10 42 50 p m" src="https://github.com/user-attachments/assets/2bd125d9-564d-452a-8059-1474f328822b" />

## After
<img width="815" height="538" alt="Screenshot 2026-08-20 at 10 39 22 p m" src="https://github.com/user-attachments/assets/43ecb9b4-d4c3-4d1b-b5bf-c23f0cc1abe6" />

<!-- gh-issue-number: gh-149167 -->
* Issue: gh-149167
<!-- /gh-issue-number -->
