### PR TITLE
[3.13] gh-156099: Fix a crash when deleting SSLContext.keylog_filename (GH-156103)

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -5146,6 +5146,12 @@ class TestSSLDebug(unittest.TestCase):
         with self.assertRaises(TypeError):
             ctx.keylog_filename = 1
 
+        ctx.keylog_filename = os_helper.TESTFN
+        with self.assertRaisesRegex(AttributeError, 'cannot be deleted'):
+            del ctx.keylog_filename
+        # a failed deletion does not change the value
+        self.assertEqual(ctx.keylog_filename, os_helper.TESTFN)
+
     @requires_keylog
     def test_keylog_filename(self):
         self.addCleanup(os_helper.unlink, os_helper.TESTFN)

--- a/Misc/NEWS.d/next/Library/2026-08-20-12-00-00.gh-issue-156099.Kp4vRt.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-20-12-00-00.gh-issue-156099.Kp4vRt.rst
@@ -1,0 +1,3 @@
+Fix a crash when deleting the ``keylog_filename`` attribute of
+:class:`ssl.SSLContext`.
+It now raises :exc:`AttributeError`.

--- a/Modules/_ssl/debughelpers.c
+++ b/Modules/_ssl/debughelpers.c
@@ -166,6 +166,12 @@ static int
 _PySSLContext_set_keylog_filename(PySSLContext *self, PyObject *arg, void *c) {
     FILE *fp;
 
+    if (arg == NULL) {
+        PyErr_Format(PyExc_AttributeError,
+                     "attribute 'keylog_filename' of '%.100s' objects "
+                     "cannot be deleted", Py_TYPE(self)->tp_name);
+        return -1;
+    }
 #if defined(MS_WINDOWS) && defined(_DEBUG)
     PyErr_SetString(PyExc_NotImplementedError,
                     "set_keylog_filename: unavailable on Windows debug build");


### PR DESCRIPTION
Manual backport of #156103 to 3.13: the setter has a different signature there, so the cherry-pick did not apply cleanly.