### PR TITLE
gh-155397: Raise InvalidFileException for malformed XML plists

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -67,7 +67,7 @@ import itertools
 import os
 import re
 import struct
-from xml.parsers.expat import ParserCreate
+from xml.parsers.expat import ExpatError, ParserCreate
 
 
 PlistFormat = enum.Enum('PlistFormat', 'FMT_XML FMT_BINARY', module=__name__)
@@ -185,7 +185,14 @@ class _PlistParser:
         self.parser.EndElementHandler = self.handle_end_element
         self.parser.CharacterDataHandler = self.handle_data
         self.parser.EntityDeclHandler = self.handle_entity_decl
-        self.parser.ParseFile(fileobj)
+        try:
+            self.parser.ParseFile(fileobj)
+        except ExpatError as e:
+            raise InvalidFileException(str(e)) from e
+        except LookupError as e:
+            # An <?xml ... ?> declaration naming an encoding that Python's
+            # codec registry does not know raises LookupError from expat.
+            raise InvalidFileException(str(e)) from e
         return self.root
 
     def handle_entity_decl(self, entity_name, is_parameter_entity, value, base, system_id, public_id, notation_name):

--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -191,7 +191,13 @@ class _PlistParser:
             raise InvalidFileException(str(e)) from e
         except LookupError as e:
             # An <?xml ... ?> declaration naming an encoding that Python's
-            # codec registry does not know raises LookupError from expat.
+            # codec registry does not know raises a plain LookupError.  A
+            # KeyError or IndexError from caller-provided code (e.g. a custom
+            # dict_type or file object) is a LookupError subclass and must not
+            # be masked as a malformed-file error, so only translate the exact
+            # LookupError type and let subclasses propagate unchanged.
+            if type(e) is not LookupError:
+                raise
             raise InvalidFileException(str(e)) from e
         return self.root
 

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -916,6 +916,20 @@ class TestPlistlib(unittest.TestCase):
         with self.assertRaises(plistlib.InvalidFileException):
             plistlib.loads(b"these are not plist file contents")
 
+    def test_xml_plist_not_well_formed(self):
+        # gh-155397: a not-well-formed XML plist must raise the documented
+        # InvalidFileException, not a raw xml.parsers.expat.ExpatError.
+        with self.assertRaises(plistlib.InvalidFileException):
+            plistlib.loads(b"<plist><foo></bar></plist>", fmt=plistlib.FMT_XML)
+
+    def test_xml_plist_unknown_encoding(self):
+        # gh-155397: an <?xml ... ?> declaration naming an encoding that
+        # Python does not know must raise the documented InvalidFileException,
+        # not a raw LookupError.
+        data = b'<?xml version="1.0" encoding="BogusEncoding"?><plist></plist>'
+        with self.assertRaises(plistlib.InvalidFileException):
+            plistlib.loads(data, fmt=plistlib.FMT_XML)
+
     def test_modified_uid_negative(self):
         neg_uid = UID(1)
         neg_uid.data = -1  # dodge the negative check in the constructor

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -930,6 +930,22 @@ class TestPlistlib(unittest.TestCase):
         with self.assertRaises(plistlib.InvalidFileException):
             plistlib.loads(data, fmt=plistlib.FMT_XML)
 
+    def test_xml_plist_dict_type_lookup_error_propagates(self):
+        # gh-155397: a KeyError/IndexError raised by caller-supplied code (here
+        # a custom dict_type) is a LookupError subclass but signals a bug in the
+        # caller, not a malformed file.  It must propagate unchanged rather than
+        # be masked as InvalidFileException, matching the pre-fix behaviour and
+        # the binary parser.  Only a plain codec-registry LookupError (unknown
+        # declared encoding) is translated.
+        class RaisingDict(dict):
+            def __setitem__(self, key, value):
+                raise KeyError("boom from caller code")
+
+        data = (b'<?xml version="1.0"?><plist><dict>'
+                b'<key>a</key><string>b</string></dict></plist>')
+        with self.assertRaises(KeyError):
+            plistlib.loads(data, fmt=plistlib.FMT_XML, dict_type=RaisingDict)
+
     def test_modified_uid_negative(self):
         neg_uid = UID(1)
         neg_uid.data = -1  # dodge the negative check in the constructor

--- a/Misc/NEWS.d/next/Library/2026-08-21-17-45-42.gh-issue-155397.wet1xZ.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-21-17-45-42.gh-issue-155397.wet1xZ.rst
@@ -1,0 +1,1 @@
+:func:`plistlib.load` and :func:`plistlib.loads` now raise :exc:`plistlib.InvalidFileException` for XML plists that are not well-formed or that declare an unknown encoding, instead of leaking the underlying :exc:`~xml.parsers.expat.ExpatError` or :exc:`LookupError`.


### PR DESCRIPTION
`plistlib.load()`/`loads()` is documented to raise `plistlib.InvalidFileException` when a file cannot be parsed, but `_PlistParser.parse()` called expat's `ParseFile()` with no exception translation. Two classes of malformed XML plist leaked the underlying exception instead:

* XML that is not well-formed raised `xml.parsers.expat.ExpatError`.
* An `<?xml ... ?>` declaration naming an encoding unknown to Python's codec registry raised `LookupError`.

Neither is a subclass of `ValueError` (`InvalidFileException`'s base), so callers following the documented contract did not catch them. This translates both into `InvalidFileException` and adds regression tests.

Fixes #155397.

<!-- gh-issue-number: gh-155397 -->
* Issue: gh-155397
<!-- /gh-issue-number -->
