### PR TITLE
gh-156131: threading: add run() and run_daemon() to start threads easily

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -220,6 +220,17 @@ This module defines the following functions:
    .. versionadded:: 3.4
 
 
+.. function:: run(func, /, *args, **kwargs)
+              run_daemon(func, /, *args, **kwargs)
+
+   Run `func(*args, **kwargs)` in a thread and return the corresponding
+   :class:`Thread` object.  The thread is started automatically.
+
+   With :func:`run_daemon` the thread is set as daemonic.
+
+   .. versionadded:: 3.16
+
+
 .. function:: settrace(func)
 
    .. index:: single: trace function

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -223,12 +223,28 @@ This module defines the following functions:
 .. function:: run(func, /, *args, **kwargs)
               run_daemon(func, /, *args, **kwargs)
 
-   Run `func(*args, **kwargs)` in a thread and return the corresponding
+   Run ``func(*args, **kwargs)`` in a thread and return the corresponding
    :class:`Thread` object.  The thread is started automatically.
 
-   With :func:`run_daemon` the thread is set as daemonic.
+   With :func:`run_daemon`, the thread is set as daemonic.
 
-   .. versionadded:: 3.16
+   Example:
+
+   .. code-block:: python
+
+      import threading, urllib
+
+      def fetch(url, data=None):
+          response = urllib.request.urlopen(url, data)
+          # further processing...
+
+      t1 = threading.run(fetch, 'https://example.com/')
+      t2 = threading.run(fetch, 'https://example.com/post', data=payload)
+
+      t1.join()
+      t2.join()
+
+   .. versionadded:: next
 
 
 .. function:: settrace(func)

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -220,11 +220,14 @@ This module defines the following functions:
    .. versionadded:: 3.4
 
 
-.. function:: run(func, /, *args, **kwargs)
-              run_daemon(func, /, *args, **kwargs)
+.. function:: run([config, ]func, /, *args, **kwargs)
+              run_daemon([config, ]func, /, *args, **kwargs)
 
    Run ``func(*args, **kwargs)`` in a thread and return the corresponding
    :class:`Thread` object.  The thread is started automatically.
+
+   *config* is an optional dict which can be used to pass additional
+   arguments to the :class:`Thread` constructor.
 
    With :func:`run_daemon`, the thread is set as daemonic.
 
@@ -240,9 +243,12 @@ This module defines the following functions:
 
       t1 = threading.run(fetch, 'https://example.com/')
       t2 = threading.run(fetch, 'https://example.com/post', data=payload)
-
       t1.join()
       t2.join()
+
+      # with configuration
+      t = threading.run({'name': 'http-worker'}, fetch, 'https://example.com/')
+      t.join()
 
    .. versionadded:: next
 

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -482,6 +482,14 @@ symtable
   (Contributed by Serhiy Storchaka in :gh:`153844`.)
 
 
+threading
+---------
+
+* Add :func:`threading.run` and :func:`threading.run_daemon`
+  as a convenient way to start threads.
+  (Contributed by Romain Vavassori in :gh:`156131`.)
+
+
 tkinter
 -------
 

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1519,6 +1519,21 @@ class ThreadTests(BaseTestCase):
         self.assertEqual(err, b"")
         self.assertEqual(out.strip(), b"Exiting...")
 
+    def test_run(self):
+        def func(x, y):
+            z.append(x + y)
+
+        z = []
+        thread = threading.run(func, 5, y=3)
+        thread.join()
+        self.assertEqual(z, [8])
+
+        z = []
+        thread = threading.run_daemon(func, 8, y=4)
+        thread.join()
+        self.assertEqual(z, [12])
+        self.assertEqual(thread.daemon, True)
+
 class ThreadJoinOnShutdown(BaseTestCase):
 
     def _run_and_join(self, script):

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1529,10 +1529,23 @@ class ThreadTests(BaseTestCase):
         self.assertEqual(z, [8])
 
         z = []
+        thread = threading.run({'name': 'run-func'}, func, 5, y=3)
+        thread.join()
+        self.assertEqual(z, [8])
+        self.assertEqual(thread.name, 'run-func')
+
+        z = []
         thread = threading.run_daemon(func, 8, y=4)
         thread.join()
         self.assertEqual(z, [12])
         self.assertEqual(thread.daemon, True)
+
+        z = []
+        thread = threading.run_daemon({'name': 'run-func'}, func, 8, y=4)
+        thread.join()
+        self.assertEqual(z, [12])
+        self.assertEqual(thread.daemon, True)
+        self.assertEqual(thread.name, 'run-func')
 
 class ThreadJoinOnShutdown(BaseTestCase):
 

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -30,7 +30,8 @@ __all__ = ['get_ident', 'active_count', 'Condition', 'current_thread',
            'setprofile', 'settrace', 'local', 'stack_size',
            'excepthook', 'ExceptHookArgs', 'gettrace', 'getprofile',
            'serialize_iterator', 'synchronized_iterator', 'concurrent_tee',
-           'setprofile_all_threads','settrace_all_threads']
+           'setprofile_all_threads','settrace_all_threads',
+           'run', 'run_daemon']
 
 # Rename some stuff so "from threading import *" is safe
 _start_joinable_thread = _thread.start_joinable_thread
@@ -1663,6 +1664,19 @@ def enumerate():
     """
     with _active_limbo_lock:
         return list(_active.values()) + list(_limbo.values())
+
+def run(func, /, *args, **kwargs):
+    """Return a running Thread object of func(*args, **kwargs)."""
+    thread = Thread(target=func, name=func.__name__, args=args, kwargs=kwargs)
+    thread.start()
+    return thread
+
+def run_daemon(func, /, *args, **kwargs):
+    """Return a running daemonic Thread object of func(*args, **kwargs)."""
+    thread = Thread(target=func, name=func.__name__, args=args, kwargs=kwargs)
+    thread.daemon = True
+    thread.start()
+    return thread
 
 
 _threading_atexits = []

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1665,18 +1665,51 @@ def enumerate():
     with _active_limbo_lock:
         return list(_active.values()) + list(_limbo.values())
 
-def run(func, /, *args, **kwargs):
-    """Return a running Thread object of func(*args, **kwargs)."""
-    thread = Thread(target=func, name=func.__name__, args=args, kwargs=kwargs)
+def run(x, /, *args, **kwargs):
+    """
+    run(func, /, *args, **kwargs) -> Thread object
+    run(config, func, /, *args, **kwargs) -> Thread object
+
+    Return a running thread of func(*args, **kwargs).
+
+    *config* is an optional dict which can be used to pass additional
+    arguments to the Thread constructor.
+
+    """
+    if isinstance(x, dict):
+        if callable(x):
+            raise TypeError("ambiguous first argument: cannot determine if 'func' or 'config'")
+        if not args:
+            raise TypeError("missing positional argument 'func' after 'config'")
+
+        config = x
+        func, *args = args
+    else:
+        config = {}
+        func = x
+
+    thread = Thread(target=func, args=args, kwargs=kwargs, **config)
     thread.start()
     return thread
 
-def run_daemon(func, /, *args, **kwargs):
-    """Return a running daemonic Thread object of func(*args, **kwargs)."""
-    thread = Thread(target=func, name=func.__name__, args=args, kwargs=kwargs)
-    thread.daemon = True
-    thread.start()
-    return thread
+def run_daemon(x, /, *args, **kwargs):
+    """
+    run_daemon(func, /, *args, **kwargs) -> Thread object
+    run_daemon(config, func, /, *args, **kwargs) -> Thread object
+
+    Return a running daemonic thread of func(*args, **kwargs).
+
+    *config* is an optional dict which can be used to pass additional
+    arguments to the Thread constructor.
+
+    """
+    if isinstance(x, dict):
+        if callable(x):
+            raise TypeError("ambiguous first argument: cannot determine if 'func' or 'config'")
+
+        return run({'daemon': True} | x, *args, **kwargs)
+    else:
+        return run({'daemon': True}, x, *args, **kwargs)
 
 
 _threading_atexits = []

--- a/Misc/NEWS.d/next/Library/2026-08-21-12-14-00.gh-issue-156131.KElflR.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-21-12-14-00.gh-issue-156131.KElflR.rst
@@ -1,0 +1,2 @@
+Add :func:`threading.run` and :func:`threading.run_daemon` functions as
+a convenient way to start threads.


### PR DESCRIPTION
Add
- `threading.run(func, /, *args, **kwargs)`
- `threading.run_daemon(func, /, *args, **kwargs)`

to replace the often used recipe of

```python
t = threading.Thread(target=func, args=args, kwargs=kwargs)
t.daemon = True
t.start()
```

<!-- gh-issue-number: gh-156131 -->
* Issue: gh-156131
<!-- /gh-issue-number -->
