### PR TITLE
gh-148750: Unfreeze encodings module to avoid import errors with zipped stdlib

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1661,11 +1661,6 @@ FROZEN_FILES_IN = \
 		Lib/zipimport.py \
 		Lib/abc.py \
 		Lib/codecs.py \
-		Lib/encodings/__init__.py \
-		Lib/encodings/aliases.py \
-		Lib/encodings/utf_8.py \
-		Lib/encodings/_win_cp_codecs.py \
-		Lib/encodings/_iconv_codecs.py \
 		Lib/io.py \
 		Lib/_collections_abc.py \
 		Lib/_sitebuiltins.py \
@@ -1692,11 +1687,6 @@ FROZEN_FILES_OUT = \
 		Python/frozen_modules/zipimport.h \
 		Python/frozen_modules/abc.h \
 		Python/frozen_modules/codecs.h \
-		Python/frozen_modules/encodings.h \
-		Python/frozen_modules/encodings.aliases.h \
-		Python/frozen_modules/encodings.utf_8.h \
-		Python/frozen_modules/encodings._win_cp_codecs.h \
-		Python/frozen_modules/encodings._iconv_codecs.h \
 		Python/frozen_modules/io.h \
 		Python/frozen_modules/_collections_abc.h \
 		Python/frozen_modules/_sitebuiltins.h \
@@ -1745,21 +1735,6 @@ Python/frozen_modules/abc.h: Lib/abc.py $(FREEZE_MODULE_DEPS)
 
 Python/frozen_modules/codecs.h: Lib/codecs.py $(FREEZE_MODULE_DEPS)
 	$(FREEZE_MODULE) codecs $(srcdir)/Lib/codecs.py Python/frozen_modules/codecs.h
-
-Python/frozen_modules/encodings.h: Lib/encodings/__init__.py $(FREEZE_MODULE_DEPS)
-	$(FREEZE_MODULE) encodings $(srcdir)/Lib/encodings/__init__.py Python/frozen_modules/encodings.h
-
-Python/frozen_modules/encodings.aliases.h: Lib/encodings/aliases.py $(FREEZE_MODULE_DEPS)
-	$(FREEZE_MODULE) encodings.aliases $(srcdir)/Lib/encodings/aliases.py Python/frozen_modules/encodings.aliases.h
-
-Python/frozen_modules/encodings.utf_8.h: Lib/encodings/utf_8.py $(FREEZE_MODULE_DEPS)
-	$(FREEZE_MODULE) encodings.utf_8 $(srcdir)/Lib/encodings/utf_8.py Python/frozen_modules/encodings.utf_8.h
-
-Python/frozen_modules/encodings._win_cp_codecs.h: Lib/encodings/_win_cp_codecs.py $(FREEZE_MODULE_DEPS)
-	$(FREEZE_MODULE) encodings._win_cp_codecs $(srcdir)/Lib/encodings/_win_cp_codecs.py Python/frozen_modules/encodings._win_cp_codecs.h
-
-Python/frozen_modules/encodings._iconv_codecs.h: Lib/encodings/_iconv_codecs.py $(FREEZE_MODULE_DEPS)
-	$(FREEZE_MODULE) encodings._iconv_codecs $(srcdir)/Lib/encodings/_iconv_codecs.py Python/frozen_modules/encodings._iconv_codecs.h
 
 Python/frozen_modules/io.h: Lib/io.py $(FREEZE_MODULE_DEPS)
 	$(FREEZE_MODULE) io $(srcdir)/Lib/io.py Python/frozen_modules/io.h

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-21-14-38-06.gh-issue-148750.xBijjR.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-21-14-38-06.gh-issue-148750.xBijjR.rst
@@ -1,0 +1,2 @@
+:mod:`encodings` is no longer frozen, due to issues importing submodules
+when using a zipped standard library.

--- a/PCbuild/_freeze_module.vcxproj
+++ b/PCbuild/_freeze_module.vcxproj
@@ -317,31 +317,6 @@
       <IntFile>$(IntDir)codecs.g.h</IntFile>
       <OutFile>$(GeneratedFrozenModulesDir)Python\frozen_modules\codecs.h</OutFile>
     </None>
-    <None Include="..\Lib\encodings\__init__.py">
-      <ModName>encodings</ModName>
-      <IntFile>$(IntDir)encodings.g.h</IntFile>
-      <OutFile>$(GeneratedFrozenModulesDir)Python\frozen_modules\encodings.h</OutFile>
-    </None>
-    <None Include="..\Lib\encodings\aliases.py">
-      <ModName>encodings.aliases</ModName>
-      <IntFile>$(IntDir)encodings.aliases.g.h</IntFile>
-      <OutFile>$(GeneratedFrozenModulesDir)Python\frozen_modules\encodings.aliases.h</OutFile>
-    </None>
-    <None Include="..\Lib\encodings\utf_8.py">
-      <ModName>encodings.utf_8</ModName>
-      <IntFile>$(IntDir)encodings.utf_8.g.h</IntFile>
-      <OutFile>$(GeneratedFrozenModulesDir)Python\frozen_modules\encodings.utf_8.h</OutFile>
-    </None>
-    <None Include="..\Lib\encodings\_win_cp_codecs.py">
-      <ModName>encodings._win_cp_codecs</ModName>
-      <IntFile>$(IntDir)encodings._win_cp_codecs.g.h</IntFile>
-      <OutFile>$(GeneratedFrozenModulesDir)Python\frozen_modules\encodings._win_cp_codecs.h</OutFile>
-    </None>
-    <None Include="..\Lib\encodings\_iconv_codecs.py">
-      <ModName>encodings._iconv_codecs</ModName>
-      <IntFile>$(IntDir)encodings._iconv_codecs.g.h</IntFile>
-      <OutFile>$(GeneratedFrozenModulesDir)Python\frozen_modules\encodings._iconv_codecs.h</OutFile>
-    </None>
     <None Include="..\Lib\io.py">
       <ModName>io</ModName>
       <IntFile>$(IntDir)io.g.h</IntFile>

--- a/PCbuild/_freeze_module.vcxproj.filters
+++ b/PCbuild/_freeze_module.vcxproj.filters
@@ -558,21 +558,6 @@
     <None Include="..\Lib\codecs.py">
       <Filter>Python Files</Filter>
     </None>
-    <None Include="..\Lib\encodings\__init__.py">
-      <Filter>Python Files</Filter>
-    </None>
-    <None Include="..\Lib\encodings\aliases.py">
-      <Filter>Python Files</Filter>
-    </None>
-    <None Include="..\Lib\encodings\utf_8.py">
-      <Filter>Python Files</Filter>
-    </None>
-    <None Include="..\Lib\encodings\_win_cp_codecs.py">
-      <Filter>Python Files</Filter>
-    </None>
-    <None Include="..\Lib\encodings\_iconv_codecs.py">
-      <Filter>Python Files</Filter>
-    </None>
     <None Include="..\Lib\io.py">
       <Filter>Python Files</Filter>
     </None>

--- a/Python/frozen.c
+++ b/Python/frozen.c
@@ -46,11 +46,6 @@
 #include "frozen_modules/zipimport.h"
 #include "frozen_modules/abc.h"
 #include "frozen_modules/codecs.h"
-#include "frozen_modules/encodings.h"
-#include "frozen_modules/encodings.aliases.h"
-#include "frozen_modules/encodings.utf_8.h"
-#include "frozen_modules/encodings._win_cp_codecs.h"
-#include "frozen_modules/encodings._iconv_codecs.h"
 #include "frozen_modules/io.h"
 #include "frozen_modules/_collections_abc.h"
 #include "frozen_modules/_sitebuiltins.h"
@@ -82,11 +77,6 @@ static const struct _frozen stdlib_modules[] = {
     /* stdlib - startup, without site (python -S) */
     {"abc", _Py_M__abc, (int)sizeof(_Py_M__abc), false},
     {"codecs", _Py_M__codecs, (int)sizeof(_Py_M__codecs), false},
-    {"encodings", _Py_M__encodings, (int)sizeof(_Py_M__encodings), true},
-    {"encodings.aliases", _Py_M__encodings_aliases, (int)sizeof(_Py_M__encodings_aliases), false},
-    {"encodings.utf_8", _Py_M__encodings_utf_8, (int)sizeof(_Py_M__encodings_utf_8), false},
-    {"encodings._win_cp_codecs", _Py_M__encodings__win_cp_codecs, (int)sizeof(_Py_M__encodings__win_cp_codecs), false},
-    {"encodings._iconv_codecs", _Py_M__encodings__iconv_codecs, (int)sizeof(_Py_M__encodings__iconv_codecs), false},
     {"io", _Py_M__io, (int)sizeof(_Py_M__io), false},
 
     /* stdlib - startup, with site */

--- a/Tools/build/freeze_modules.py
+++ b/Tools/build/freeze_modules.py
@@ -50,11 +50,13 @@ FROZEN = [
     ('stdlib - startup, without site (python -S)', [
         'abc',
         'codecs',
-        '<encodings>',
-        'encodings.aliases',
-        'encodings.utf_8',
-        'encodings._win_cp_codecs',
-        'encodings._iconv_codecs',
+        # gh-148750: Partially freezing encodings causes import errors of
+        # submodules when using a zipped standard library.
+        #'<encodings>',
+        #'encodings.aliases',
+        #'encodings.utf_8',
+        #'encodings._win_cp_codecs',
+        #'encodings._iconv_codecs',
         'io',
         ]),
     ('stdlib - startup, with site', [


### PR DESCRIPTION


<!-- gh-issue-number: gh-148750 -->
* Issue: gh-148750
<!-- /gh-issue-number -->
