### PR TITLE
gh-156187: Fix the warning stacklevel inside a nested set operand

### DIFF
--- a/Lib/re/_parser.py
+++ b/Lib/re/_parser.py
@@ -606,7 +606,7 @@ def _parse_operand(source, state, nested, here, allow_nested):
     if allow_nested and sourcematch("["):
         # A nested set after an operator is the whole operand, used as-is (not
         # wrapped in a group); it cannot be combined with loose members.
-        compound = _parse_charset(source, state, nested + 1)
+        compound = _parse_charset(source, state, nested + 2)
     while True:
         this = sourceget()
         if this is None:

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1537,6 +1537,10 @@ class ReTests(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter('error', FutureWarning)
             re.compile(r'[a-z--[aeiou]]')
+        # A reserved construct inside a nested operand warns against the caller.
+        with self.assertWarnsRegex(FutureWarning, 'Possible nested set ') as w:
+            re.compile(r'[a--[[b]]]')
+        self.assertEqual(w.filename, __file__)
 
         # Set union  A||B == A or B (an explicit form of [AB]); flat operands
         # merge into one charset, otherwise the operations are alternated.
@@ -1557,6 +1561,10 @@ class ReTests(unittest.TestCase):
             self.assertEqual(re.findall(r'[\d~~1]', s), list('0123456789~'))
         self.assertEqual(w.filename, __file__)
         self.assertEqual(re.findall(r'[~~1]', s), list('1~'))
+        with self.assertWarnsRegex(FutureWarning,
+                                   'Possible set symmetric difference ') as w:
+            re.compile(r'[a||[c~~d]]')
+        self.assertEqual(w.filename, __file__)
 
     def test_search_coverage(self):
         self.assertEqual(re.search(r"\s(b)", " b").group(1), "b")

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1563,7 +1563,7 @@ class ReTests(unittest.TestCase):
         self.assertEqual(re.findall(r'[~~1]', s), list('1~'))
         with self.assertWarnsRegex(FutureWarning,
                                    'Possible set symmetric difference ') as w:
-            re.compile(r'[a||[c~~d]]')
+            re.compile(r'[\w--[\d~~1]]')
         self.assertEqual(w.filename, __file__)
 
     def test_search_coverage(self):

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1539,7 +1539,7 @@ class ReTests(unittest.TestCase):
             re.compile(r'[a-z--[aeiou]]')
         # A reserved construct inside a nested operand warns against the caller.
         with self.assertWarnsRegex(FutureWarning, 'Possible nested set ') as w:
-            re.compile(r'[a--[[b]]]')
+            re.compile(r'[\w--[[:digit:]]]')
         self.assertEqual(w.filename, __file__)
 
         # Set union  A||B == A or B (an explicit form of [AB]); flat operands


### PR DESCRIPTION
`_parse_operand()` now passes `nested + 2` to the inner `_parse_charset()`, matching the two frames the nested-operand path adds, so a `FutureWarning` raised inside a nested set operand is reported against the caller at every depth. `test_set_operations` pins the reported file for the nested-set and the `~~` spelling.

```
$ ./python -m test test_re -v -m test_set_operations
test_set_operations (test.test_re.ReTests.test_set_operations) ... ok
Total tests: run=1 (filtered)
Result: SUCCESS
$ ./python -m test test_re
Total tests: run=169 skipped=3
Result: SUCCESS
```

No news entry: set operations in character classes are new in 3.16 and have not shipped, so this folds into the gh-152100 entry.


<!-- gh-issue-number: gh-156187 -->
* Issue: gh-156187
<!-- /gh-issue-number -->
