### PR TITLE
[3.13] gh-156189: Fix a crash when deleting frame.f_trace_opcodes

### DIFF
--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -219,6 +219,14 @@ class FrameAttrsTest(unittest.TestCase):
         self.assertEqual(outer.f_locals, {})
         self.assertEqual(inner.f_locals, {})
 
+    def test_f_trace_opcodes_del(self):
+        f, _, _ = self.make_frames()
+        f.f_trace_opcodes = True
+        with self.assertRaisesRegex(AttributeError, 'cannot delete attribute'):
+            del f.f_trace_opcodes
+        # a failed deletion does not change the value
+        self.assertIs(f.f_trace_opcodes, True)
+
     def test_f_lineno_del_segfault(self):
         f, _, _ = self.make_frames()
         with self.assertRaises(AttributeError):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-21-16-00-00.gh-issue-156189.Zt4nQp.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-21-16-00-00.gh-issue-156189.Zt4nQp.rst
@@ -1,0 +1,2 @@
+Fix a crash when deleting the :attr:`~frame.f_trace_opcodes` attribute of
+a frame object.  It now raises :exc:`AttributeError`.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -979,6 +979,11 @@ frame_gettrace_opcodes(PyFrameObject *f, void *closure)
 static int
 frame_settrace_opcodes(PyFrameObject *f, PyObject* value, void *Py_UNUSED(ignored))
 {
+    if (value == NULL) {
+        PyErr_SetString(PyExc_AttributeError,
+                        "cannot delete attribute f_trace_opcodes");
+        return -1;
+    }
     if (!PyBool_Check(value)) {
         PyErr_SetString(PyExc_TypeError,
                         "attribute value type must be bool");


### PR DESCRIPTION
The setter passed the value to `PyBool_Check()` without checking it for `NULL`, so `del frame.f_trace_opcodes` crashed. It now raises `AttributeError`, like in 3.14, where the accessor is generated by Argument Clinic.


<!-- gh-issue-number: gh-156189 -->
* Issue: gh-156189
<!-- /gh-issue-number -->
