### PR TITLE
gh-150942: Speed up Py_BuildValue dict construction

### DIFF
--- a/Python/modsupport.c
+++ b/Python/modsupport.c
@@ -3,6 +3,7 @@
 
 #include "Python.h"
 #include "pycore_abstract.h"   // _PyIndex_Check()
+#include "pycore_dict.h"       // _PyDict_SetItem_Take2()
 #include "pycore_object.h"     // _PyType_IsReady()
 #include "pycore_unicodeobject.h"     // _PyUnicodeWriter_FormatV()
 
@@ -174,15 +175,17 @@ do_mkdict(const char **p_format, va_list *p_va, char endchar, Py_ssize_t n)
             return NULL;
         }
         v = do_mkvalue(p_format, p_va);
-        if (v == NULL || PyDict_SetItem(d, k, v) < 0) {
+        if (v == NULL) {
             do_ignore(p_format, p_va, endchar, n - i - 2);
             Py_DECREF(k);
-            Py_XDECREF(v);
             Py_DECREF(d);
             return NULL;
         }
-        Py_DECREF(k);
-        Py_DECREF(v);
+        if (_PyDict_SetItem_Take2((PyDictObject *)d, k, v) < 0) {
+            do_ignore(p_format, p_va, endchar, n - i - 2);
+            Py_DECREF(d);
+            return NULL;
+        }
     }
     if (!check_end(p_format, endchar)) {
         Py_DECREF(d);


### PR DESCRIPTION
Speed up `Py_BuildValue()` dictionary construction by using `_PyDict_SetItem_Take2()` in `do_mkdict()`.

Both the key and value returned by `do_mkvalue()` are owned references. Transferring them directly to the dictionary avoids the INCREF/DECREF round trips performed by `PyDict_SetItem()` for each pair.

The `v == NULL` path remains separate so that insertion is only attempted
after both objects have been created successfully.

## Microbenchmarks

`pyperf 2.10.0` on macOS x86_64, Intel Core i7-1068NG7, Apple Clang 17.
Reverse-order runs were also performed.

| Benchmark | Baseline | Patched | Result | Reverse |
| --- | ---: | ---: | ---: | ---: |
| integer dict, 3 pairs | 461 ns | 439 ns | **1.05x faster** | **1.02x faster** |
| integer dict, 5 pairs | 624 ns | 615 ns | **1.01x faster** | **1.02x faster** |
| existing objects, 3 pairs | 326 ns | 321 ns | **1.01x faster** | **1.02x faster** |
| existing objects, 5 pairs | 420 ns | 409 ns | **1.03x faster** | **1.01x faster** |
| duplicate key, 3 pairs | 317 ns | 311 ns | **1.02x faster** | **1.01x faster** |

The gains are small but repeatable across the tested `Py_BuildValue()` dictionary workloads.

## Validation

- `test_capi` and `test_dict`
- debug refleak runs with `-R 3:3`
- success, insertion-failure, and replacement-path ownership stress tests
- `make patchcheck`
- `git diff --check`

<!-- gh-issue-number: gh-150942 -->
* Issue: gh-150942
<!-- /gh-issue-number -->