### PR TITLE
Fix OOB write in ctypes array assignment after __class__ swap

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5206,13 +5206,20 @@ Array_ass_item_lock_held(PyObject *myself, Py_ssize_t index, PyObject *value)
     }
     assert(stginfo); /* Cannot be NULL for array object instances */
 
-    if (index < 0 || index >= stginfo->length) {
-        PyErr_SetString(PyExc_IndexError,
-                        "invalid index");
+    if (stginfo->length == 0) {
+        PyErr_SetString(PyExc_IndexError, "invalid index");
         return -1;
     }
     size = stginfo->size / stginfo->length;
     offset = index * size;
+
+    /* Guard against out-of-bounds access when __class__ has been swapped
+       to a type with a larger declared size than the actual buffer.
+       The actual allocation size is tracked in self->b_size. */
+    if (index < 0 || offset + size > self->b_size) {
+        PyErr_SetString(PyExc_IndexError, "invalid index");
+        return -1;
+    }
     ptr = self->b_ptr + offset;
 
     return PyCData_set(st, myself, stginfo->proto, stginfo->setfunc, value,


### PR DESCRIPTION
Fixes python/cpython#143005

Array_ass_item_lock_held() in Modules/_ctypes/_ctypes.c used stginfo->length
(from the type) for bounds checking, not the actual buffer size. When
__class__ is swapped to a wider subclass via __class__ assignment, the
type's stginfo->length and stginfo->size reflect the new (larger) type,
allowing writes past the actual allocation (heap-buffer-overflow).

Fix: use self->b_size (the actual buffer size) for bounds checking,
consistent with Array_item_lock_held which already uses self->b_length.

PoC:
from ctypes import c_long
Base = c_long * 3
Wide = c_long * 5
victim = Base(1, 2, 3)
victim.__class__ = Wide  # Type now thinks length is 5
victim[4] = 42  # OOB write — fixed, now raises IndexError