### PR TITLE
gh-95779: Refuse to run `make doctest` under a mismatched Python

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -132,6 +132,14 @@ coverage: build
 .PHONY: doctest
 doctest: BUILDER = doctest
 doctest:
+	@venv_version=$$($(VENVDIR)/bin/python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])'); \
+	tree_version=$$($(PYTHON) tools/extensions/patchlevel.py --short); \
+	if [ "$$venv_version" != "$$tree_version" ]; then \
+		echo "The venv runs Python $$venv_version, but this source tree is Python $$tree_version."; \
+		echo "The doctests are executed by the venv interpreter, so they would test"; \
+		echo "Python $$venv_version rather than the code documented here."; \
+		exit 1; \
+	fi
 	@$(MAKE) build BUILDER=$(BUILDER) || { \
 	echo "Testing of doctests in the sources finished, look at the" \
 	     "results in build/doctest/output.txt"; \

--- a/Doc/make.bat
+++ b/Doc/make.bat
@@ -9,6 +9,19 @@ call ..\PCbuild\find_python.bat %PYTHON%
 
 if not defined PYTHON set PYTHON=py
 
+if "%1" NEQ "doctest" goto :skipversioncheck
+for /f "usebackq" %%v in (`%PYTHON% -c "import sys; print(sys.version_info[0], sys.version_info[1], sep='.')"`) do set PYVERSION=%%v
+for /f "usebackq" %%v in (`%PYTHON% tools/extensions/patchlevel.py --short`) do set TREEVERSION=%%v
+if "%PYVERSION%" NEQ "%TREEVERSION%" (
+    echo.
+    echo.%PYTHON% is Python %PYVERSION%, but this source tree is Python %TREEVERSION%.
+    echo.The doctests are executed by that interpreter, so they would test
+    echo.Python %PYVERSION% rather than the code documented here.
+    popd
+    exit /B 1
+)
+:skipversioncheck
+
 if not defined SPHINXBUILD (
     %PYTHON% -c "import sphinx" > nul 2> nul
     if errorlevel 1 (


### PR DESCRIPTION
The `make.bat` changes need a careful review, as I'm not particularly familiar with batch files and I don't have a machine set up to test.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-95779 -->
* Issue: gh-95779
<!-- /gh-issue-number -->
