### PR TITLE
gh-156207: Fix curses Textbox.gather() for double-width characters

### DIFF
--- a/Lib/curses/textpad.py
+++ b/Lib/curses/textpad.py
@@ -204,10 +204,8 @@ class Textbox:
             stop = self._end_of_line(y)
             if stop == 0 and self.stripspaces:
                 continue
-            for x in range(self.maxx+1):
-                if self.stripspaces and x > stop:
-                    break
-                result = result + str(self.win.in_wch(y, x))
+            count = stop+1 if self.stripspaces else self.maxx+1
+            result = result + str(self.win.in_wchstr(y, 0, count))
             if self.maxy > 0:
                 result = result + "\n"
         return result

--- a/Lib/curses/textpad.py
+++ b/Lib/curses/textpad.py
@@ -200,12 +200,16 @@ class Textbox:
         result = ""
         self._update_max_yx()
         for y in range(self.maxy+1):
-            self.win.move(y, 0)
-            stop = self._end_of_line(y)
-            if stop == 0 and self.stripspaces:
-                continue
-            count = stop+1 if self.stripspaces else self.maxx+1
-            result = result + str(self.win.in_wchstr(y, 0, count))
+            # The whole line: in_wstr() reads a double-width character once,
+            # skipping the continuation cell that holds its other half.
+            line = self.win.in_wstr(y, 0)
+            if self.stripspaces:
+                stripped = line.rstrip(' ')
+                if not stripped:
+                    continue
+                # Keep the blank the cursor rests on past the last character.
+                line = stripped + ' ' if len(stripped) < len(line) else stripped
+            result = result + line
             if self.maxy > 0:
                 result = result + "\n"
         return result

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -2660,6 +2660,22 @@ class TestCurses(unittest.TestCase):
                 box.do_command(ch)
             self.assertEqual(box.gather(), text + ' ')
 
+    @requires_wide_build
+    def test_textbox_double_width(self):
+        # A double-width (East Asian) character occupies two cells.  gather()
+        # reads a whole line at a time so that the second cell, which holds
+        # the same character, is not reported as another one.
+        text = '你好'
+        if self._encodable(text):
+            box, win = self._make_textbox(1, 12)
+            for ch in text:
+                box.do_command(ch)
+            self.assertEqual(box.gather(), text + ' ')
+            box, win = self._make_textbox(1, 12, stripspaces=0)
+            for ch in text:
+                box.do_command(ch)
+            self.assertEqual(box.gather(), text + ' ' * 8)
+
     def test_textbox_edit_wide(self):
         # edit() reads characters through get_wch().  Each character is pushed
         # with unget_wch(), which on a narrow build requires it to encode to a

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -2666,15 +2666,16 @@ class TestCurses(unittest.TestCase):
         # reads a whole line at a time so that the second cell, which holds
         # the same character, is not reported as another one.
         text = '你好'
-        if self._encodable(text):
-            box, win = self._make_textbox(1, 12)
-            for ch in text:
-                box.do_command(ch)
-            self.assertEqual(box.gather(), text + ' ')
-            box, win = self._make_textbox(1, 12, stripspaces=0)
-            for ch in text:
-                box.do_command(ch)
-            self.assertEqual(box.gather(), text + ' ' * 8)
+        if not self._encodable(text):
+            self.skipTest('the locale cannot encode %r' % text)
+        box, win = self._make_textbox(1, 12)
+        for ch in text:
+            box.do_command(ch)
+        self.assertEqual(box.gather(), text + ' ')
+        box, win = self._make_textbox(1, 12, stripspaces=False)
+        for ch in text:
+            box.do_command(ch)
+        self.assertEqual(box.gather(), text + ' ' * 8)
 
     def test_textbox_edit_wide(self):
         # edit() reads characters through get_wch().  Each character is pushed


### PR DESCRIPTION
`gather()` now reads each line with `in_wchstr()`, whose count is a cell count and which skips a double-width character's continuation cell, instead of reading one cell at a time and reporting that second cell as another copy of the character.

This fixes only the `gather()` symptom of gh-156207. The insert-mode corruption and the `curses.error` at the last column are untouched: both need `_insert_printable_char()` to know a character's display width, which is a larger change.

```
$ ./python -m test test_curses -u curses
Using random seed: 2577236069
0:00:00 load avg: 3.88 mem: 22.8 MiB Run 1 test sequentially in a single process
0:00:00 load avg: 3.88 mem: 22.8 MiB [1/1] test_curses
== Tests result: SUCCESS ==
Total tests: run=181
Result: SUCCESS
```

The duplication only exists on the main branch, where `gather()` started reading cells with `in_wch()`, so there is no NEWS entry.
