### PR TITLE
gh-156122: Fix crash in `Interpreter.call()` with lone surrogate in `__main__.__file__`

### DIFF
--- a/Include/internal/pycore_moduleobject.h
+++ b/Include/internal/pycore_moduleobject.h
@@ -72,7 +72,7 @@ static inline PyObject* _PyModule_GetDict(PyObject *mod) {
 }
 
 extern PyObject * _PyModule_GetFilenameObject(PyObject *);
-extern Py_ssize_t _PyModule_GetFilenameUTF8(
+extern Py_ssize_t _PyModule_GetFilename(
         PyObject *module,
         char *buffer,
         Py_ssize_t maxlen);

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -1875,11 +1875,18 @@ class TestInterpreterCall(TestBase):
 
     def test_call_with_surrogate_in_main_filename(self):
         # https://github.com/python/cpython/issues/156122
-        import __main__
-        __main__.__file__ = "bad\ud800.py"
+        script = dedent(r"""
+            import __main__
+            from concurrent import interpreters
 
-        interp = interpreters.create()
-        interp.call(lambda x: x, [1])
+            __main__.__file__ = "bad\ud800.py"
+            interp = interpreters.create()
+            interp.call(lambda x: x, [1])
+        """)
+        with os_helper.temp_dir() as tempdir:
+            filename = script_helper.make_script(tempdir, 'my-script', script)
+            res = script_helper.assert_python_ok(filename)
+            self.assertEqual(res.out, b'')
 
 class TestIsShareable(TestBase):
 

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -1873,6 +1873,13 @@ class TestInterpreterCall(TestBase):
             t.join()
         self.assertIsNotNone(ctx.caught)
 
+    def test_call_with_surrogate_in_main_filename(self):
+        # https://github.com/python/cpython/issues/156122
+        import __main__
+        __main__.__file__ = "bad\ud800.py"
+
+        interp = interpreters.create()
+        interp.call(lambda x: x, [1])
 
 class TestIsShareable(TestBase):
 

--- a/Misc/NEWS.d/next/Library/2026-08-22-14-40-04.gh-issue-156122.J1b673.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-22-14-40-04.gh-issue-156122.J1b673.rst
@@ -1,2 +1,2 @@
-Fix a crash in :method:`concurrent.interpreters.Interpreter.call` when
+Fix a crash in :meth:`concurrent.interpreters.Interpreter.call` when
 ``__main__.__file__`` contains lone surrogates.

--- a/Misc/NEWS.d/next/Library/2026-08-22-14-40-04.gh-issue-156122.J1b673.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-22-14-40-04.gh-issue-156122.J1b673.rst
@@ -1,0 +1,2 @@
+Fix a crash in :method:`concurrent.interpreters.Interpreter.call` when
+``__main__.__file__`` contains lone surrogates.

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -975,7 +975,7 @@ PyModule_GetFilename(PyObject *m)
 }
 
 Py_ssize_t
-_PyModule_GetFilenameUTF8(PyObject *mod, char *buffer, Py_ssize_t maxlen)
+_PyModule_GetFilename(PyObject *mod, char *buffer, Py_ssize_t maxlen)
 {
     // We "return" an empty string for an invalid module
     // and for a missing, empty, or invalid filename.
@@ -991,8 +991,15 @@ _PyModule_GetFilenameUTF8(PyObject *mod, char *buffer, Py_ssize_t maxlen)
         size = 0;
     }
     else {
-        const char *filename = PyUnicode_AsUTF8AndSize(filenameobj, &size);
-        assert(size >= 0);
+        char *filename;
+        PyObject *bytes = PyUnicode_EncodeFSDefault(filenameobj);
+        if (bytes == NULL) {
+            goto exit;
+        }
+        if (PyBytes_AsStringAndSize(bytes, &filename, &size) < 0) {
+            Py_DECREF(bytes);
+            goto exit;
+        }
         if (size > maxlen) {
             size = -1;
             PyErr_SetString(PyExc_ValueError, "__file__ too long");
@@ -1000,7 +1007,9 @@ _PyModule_GetFilenameUTF8(PyObject *mod, char *buffer, Py_ssize_t maxlen)
         else {
             (void)strcpy(buffer, filename);
         }
+        Py_DECREF(bytes);
     }
+exit:
     Py_DECREF(filenameobj);
     return size;
 }

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -1000,7 +1000,7 @@ _PyModule_GetFilename(PyObject *mod, char *buffer, Py_ssize_t maxlen)
             Py_DECREF(bytes);
             goto exit;
         }
-        if (size > maxlen) {
+        if (size >= maxlen) {
             size = -1;
             PyErr_SetString(PyExc_ValueError, "__file__ too long");
         }

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -28,7 +28,7 @@ _Py_GetMainfile(char *buffer, size_t maxlen)
         Py_XDECREF(module);
         return -1;
     }
-    Py_ssize_t size = _PyModule_GetFilenameUTF8(module, buffer, maxlen);
+    Py_ssize_t size = _PyModule_GetFilename(module, buffer, maxlen);
     Py_DECREF(module);
     return size;
 }


### PR DESCRIPTION
This PR changes `_PyModule_GetFilenameUTF8()` to use `PyUnicode_EncodeFSDefault()` to get the filename, instead of assuming the filename is UTF-8 encoded and using `PyUnicode_AsUTF8AndSize()`.

<!-- gh-issue-number: gh-156122 -->
* Issue: gh-156122
<!-- /gh-issue-number -->
