### PR TITLE
gh-156122: Allow lone surrogates in module filenames for crossinterp

### DIFF
--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -1683,6 +1683,25 @@ class TestInterpreterCall(TestBase):
         self.assertEqual(after, 0)
         self.assertEqual(counts, [0, 1, 4])
 
+    def test_surrogate_filename_in___main__(self):
+        interp = interpreters.create()
+        import __main__
+        orig_file = getattr(__main__, '__file__', None)
+        try:
+            for surrogate in ('\ud800', '\udcff'):
+                with self.subTest(surrogate=ascii(surrogate)):
+                    __main__.__file__ = f'my_script_{surrogate}.py'
+                    res = interp.call(lambda x: x, [1])
+                    self.assertEqual(res, [1])
+        finally:
+            if orig_file is None:
+                try:
+                    del __main__.__file__
+                except AttributeError:
+                    pass
+            else:
+                __main__.__file__ = orig_file
+
     def test_raises(self):
         interp = interpreters.create()
         with self.assertRaises(ExecutionFailed):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-22-03-54-22.gh-issue-156122.lYvmDy.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-22-03-54-22.gh-issue-156122.lYvmDy.rst
@@ -1,0 +1,2 @@
+Fix crash when module filenames containing lone surrogates are used during
+cross-interpreter unpickling.

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -991,14 +991,17 @@ _PyModule_GetFilenameUTF8(PyObject *mod, char *buffer, Py_ssize_t maxlen)
         size = 0;
     }
     else {
-        const char *filename = PyUnicode_AsUTF8AndSize(filenameobj, &size);
-        assert(size >= 0);
-        if (size > maxlen) {
-            size = -1;
-            PyErr_SetString(PyExc_ValueError, "__file__ too long");
-        }
-        else {
-            (void)strcpy(buffer, filename);
+        PyObject *bytes = PyUnicode_EncodeFSDefault(filenameobj);
+        if (bytes != NULL) {
+            size = PyBytes_GET_SIZE(bytes);
+            if (size > maxlen) {
+                size = -1;
+                PyErr_SetString(PyExc_ValueError, "__file__ too long");
+            }
+            else {
+                memcpy(buffer, PyBytes_AS_STRING(bytes), size + 1);
+            }
+            Py_DECREF(bytes);
         }
     }
     Py_DECREF(filenameobj);

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -41,7 +41,13 @@ runpy_run_path(const char *filename, const char *modname)
     if (run_path == NULL) {
         return NULL;
     }
-    PyObject *args = Py_BuildValue("(sOs)", filename, Py_None, modname);
+    PyObject *path = PyUnicode_DecodeFSDefault(filename);
+    if (path == NULL) {
+        Py_DECREF(run_path);
+        return NULL;
+    }
+    PyObject *args = Py_BuildValue("(OOs)", path, Py_None, modname);
+    Py_DECREF(path);
     if (args == NULL) {
         Py_DECREF(run_path);
         return NULL;


### PR DESCRIPTION
<!-- gh-issue-number: gh-156122 -->
* Issue: gh-156122

### The Problem
When cross-interpreter calls pickle arguments via `_PyPickle_GetXIData()`, `_set_pickle_xid_context()` invokes `_Py_GetMainfile()` -> `_PyModule_GetFilenameUTF8()` to record `__main__.__file__` in case the module needs to be re-executed upon unpickling.

`_PyModule_GetFilenameUTF8()` previously used `PyUnicode_AsUTF8AndSize()`, which strictly rejects surrogate code points. If `__main__.__file__` contained a lone surrogate (e.g. from an undecodable filesystem path like `\udcff` or `\ud800`), `PyUnicode_AsUTF8AndSize()` failed with `UnicodeEncodeError` and left `size = -1`, resulting in an assertion failure (`assert(size >= 0)`) in debug builds or undefined behavior in release builds.

### The Solution
- Updated `_PyModule_GetFilenameUTF8()` in `Objects/moduleobject.c` to encode filenames using `PyUnicode_EncodeFSDefault()` instead of `PyUnicode_AsUTF8AndSize()`, matching standard filesystem encoding handling with `surrogateescape`.
- Added defensive NULL checking on the resulting bytes object: if encoding fails, `size` remains `-1` and the caller `_set_pickle_xid_context()` safely clears the exception with `PyErr_Clear()`.
- Ensured balanced reference counts and strict diff minimization.

### Adding Tests & Verification
- Added `test_surrogate_filename_in___main__` in `Lib/test/test_interpreters/test_api.py` covering both:
  - `\udcff` (low surrogate / PEP 383 `surrogateescape` range).
  - `\ud800` (high surrogate / unencodable error-handling path).
- Verified with CPython's reference leak detector (`./python.exe -m test -v -R 3:3 test_interpreters -m test_surrogate_filename_in___main__` -> 0 leaks).
- Added corresponding NEWS entry under `Misc/NEWS.d/next/Core_and_Builtins/`.