### PR TITLE
[3.15] gh-155911: Fix curses detection with libraries in LIBS (GH-156130)

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-08-20-17-41-11.gh-issue-155911.yL3z8q.rst
+++ b/Misc/NEWS.d/next/Build/2026-08-20-17-41-11.gh-issue-155911.yL3z8q.rst
@@ -1,0 +1,2 @@
+Fix curses detection when a curses library is already in ``LIBS``.
+Patch by Shamil Abdulaev.

--- a/configure
+++ b/configure
@@ -29428,8 +29428,9 @@ fi
 
 
   # Check that we're able to link with crucial curses/panel functions. This
-  # also serves as a fallback in case pkg-config failed.
-  as_fn_append LIBS " $CURSES_LIBS $PANEL_LIBS"
+  # also serves as a fallback in case pkg-config failed. Extension modules are
+  # not linked with LIBS, so exclude it to get the required libraries.
+  LIBS="$CURSES_LIBS $PANEL_LIBS"
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing initscr" >&5
 printf %s "checking for library containing initscr... " >&6; }
 if test ${ac_cv_search_initscr+y}

--- a/configure.ac
+++ b/configure.ac
@@ -7149,8 +7149,9 @@ WITH_SAVE_ENV([
   ]))
 
   # Check that we're able to link with crucial curses/panel functions. This
-  # also serves as a fallback in case pkg-config failed.
-  AS_VAR_APPEND([LIBS], [" $CURSES_LIBS $PANEL_LIBS"])
+  # also serves as a fallback in case pkg-config failed. Extension modules are
+  # not linked with LIBS, so exclude it to get the required libraries.
+  LIBS="$CURSES_LIBS $PANEL_LIBS"
   AC_SEARCH_LIBS([initscr], [ncursesw ncurses],
     [AS_VAR_IF([have_curses], [no],
       [AS_VAR_SET([have_curses], [yes])


### PR DESCRIPTION
Backport of GH-156130.

`AC_SEARCH_LIBS` tries linking with no extra library first, so a curses library already in `LIBS` made the search report `none required`, which then became the module's link flag.

`--with-curses` does not exist on this branch, so the NEWS entry mentions only the `LIBS` half.


<!-- gh-issue-number: gh-155911 -->
* Issue: gh-155911
<!-- /gh-issue-number -->
