### PR TITLE
Fix typos in asyncio Task state invariant comments

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -58,7 +58,7 @@ class Task(futures._PyFuture):  # Inherit Python Task implementation
 
     """A coroutine wrapped in a Future."""
 
-    # An important invariant maintained while a Task not done:
+    # An important invariant maintained while a Task is not done:
     # _fut_waiter is either None or a Future.  The Future
     # can be either done() or not done().
     # The task can be in any of 3 states:
@@ -73,7 +73,7 @@ class Task(futures._PyFuture):  # Inherit Python Task implementation
     # * In state 1, one of the callbacks of __fut_waiter must be __wakeup().
     # * The transition from 1 to 2 happens when _fut_waiter becomes done(),
     #   as it schedules __wakeup() to be called (which calls __step() so
-    #   we way that __step() is scheduled).
+    #   we say that __step() is scheduled).
     # * It transitions from 2 to 3 when __step() is executed, and it clears
     #   _fut_waiter to None.
 


### PR DESCRIPTION
Small typo fixes in the state invariant comment block in `Lib/asyncio/tasks.py`:
- Changed "while a Task not done:" to "while a Task is not done:"
- Changed "so we way that __step() is scheduled" to "so we say that __step() is scheduled"