### PR TITLE
gh-78292: Improve python-config build script to respect symbolic link.

### DIFF
--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -8,6 +8,7 @@ import shutil
 import json
 import textwrap
 from unittest.mock import patch
+import tempfile
 from copy import copy
 
 from test import support
@@ -759,6 +760,46 @@ class TestSysConfig(unittest.TestCase, VirtualEnvironmentMixin):
         self.assertEqual(config_vars['base'], sys.prefix)
         self.assertEqual(config_vars['exec_prefix'], sys.exec_prefix)
         self.assertEqual(config_vars['platbase'], sys.exec_prefix)
+
+    @unittest.skipUnless(
+        os.name == "posix" and sys.platform != "darwin",
+        "requires shell python-config",
+    )
+    @skip_unless_symlink
+    @requires_subprocess()
+    def test_python_config_symlink(self):
+        if not is_python_build():
+            self.skipTest("requires a CPython build directory")
+
+        python_config = os.path.join(_PROJECT_BASE, "python-config")
+        if not os.path.isfile(python_config):
+            self.skipTest("python-config was not built")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            real_prefix = os.path.join(tmpdir, "real")
+            real_bindir = os.path.join(real_prefix, "bin")
+            os.makedirs(real_bindir)
+
+            real_config = os.path.join(real_bindir, "python-config")
+            shutil.copyfile(python_config, real_config)
+
+            link_prefix = os.path.join(tmpdir, "link")
+            link_bindir = os.path.join(link_prefix, "bin")
+            os.makedirs(link_bindir)
+
+            linked_config = os.path.join(link_bindir, "python-config")
+            os.symlink(real_config, linked_config)
+
+            def get_prefix(config):
+                return subprocess.check_output(
+                    ["/bin/sh", config, "--prefix"],
+                    text=True,
+                ).strip()
+
+            expected = os.path.realpath(real_prefix)
+
+            self.assertEqual(get_prefix(real_config), expected)
+            self.assertEqual(get_prefix(linked_config), expected)
 
 
 class MakefileTests(unittest.TestCase):

--- a/Misc/python-config.sh.in
+++ b/Misc/python-config.sh.in
@@ -21,7 +21,7 @@ fi
 # Returns the actual prefix where this script was installed to.
 installed_prefix ()
 {
-    RESULT=$(dirname $(cd $(dirname "$1") && pwd -P))
+    RESULT=$(dirname $(cd $(dirname $(realpath "$1")) && pwd -P))
     if which readlink >/dev/null 2>&1 ; then
         if readlink -f "$RESULT" >/dev/null 2>&1; then
           RESULT=$(readlink -f "$RESULT")


### PR DESCRIPTION

## Description

This PR uses `realpath` so that we can get the actual path of the repository even if it is a symbolic link. This way the python-config script will produce the right paths even when it is linked to a different location. 

## Testing instructions

These are manual testing instructions that I followed to test the PR.

Without the changes in the PR:

1. `./configure --with-pydebug`
2. `make python-config`
3. 
```bash
mkdir -p /tmp/cpython-repro/bin

cp python-config /tmp/cpython-repro/bin/python3-config
chmod +x /tmp/cpython-repro/bin/python3-config
```
5. `/tmp/cpython-repro/bin/python3-config --prefix` will produce output `/tmp/cpython-repro`
6. `mkdir -p /tmp/elsewhere/bin`
7. `ln -s /tmp/cpython-repro/bin/python3-config /tmp/elsewhere/bin/python3-config`
8. `/tmp/elsewhere/bin/python3-config --prefix` this show produce the output `/tmp/elsewhere` which is the bug
9. Once you check out the PR and repeat the above steps the command `/tmp/elsewhere/bin/python3-config --prefix` will produce `/tmp/cpython-repro`, which is expected.

<!-- gh-issue-number: gh-78292 -->
* Issue: gh-78292
<!-- /gh-issue-number -->
