### PR TITLE
gh-155648: Fix IDLE tests that cannot fail

### DIFF
--- a/Lib/idlelib/idle_test/template.py
+++ b/Lib/idlelib/idle_test/template.py
@@ -21,8 +21,9 @@ class Test(unittest.TestCase):
         cls.root.destroy()
         del cls.root
 
+    @unittest.skip('Dummy test')
     def test_init(self):
-        self.assertTrue(self)
+        self.assertTrue(True)
 
 
 if __name__ == '__main__':

--- a/Lib/idlelib/idle_test/template.py
+++ b/Lib/idlelib/idle_test/template.py
@@ -22,7 +22,7 @@ class Test(unittest.TestCase):
         del cls.root
 
     def test_init(self):
-        self.assertTrue(True)
+        self.assertTrue(self)
 
 
 if __name__ == '__main__':

--- a/Lib/idlelib/idle_test/test_autocomplete.py
+++ b/Lib/idlelib/idle_test/test_autocomplete.py
@@ -238,8 +238,8 @@ class AutoCompleteTest(unittest.TestCase):
         # Test attributes
         s, b = acp.fetch_completions('', ac.ATTRS)
         self.assertLess(len(small), len(large))
-        self.assertFalse(any(x.startswith('_') for x in s))
-        self.assertTrue(any(x.startswith('_') for x in b))
+        self.assertFalse(any(x[0] == '_' for x in s))
+        self.assertTrue(any(x[0] == '_' for x in b))
 
         # Test smalll should respect to __all__.
         with patch.dict('__main__.__dict__', {'__all__': ['a', 'b']}):

--- a/Lib/idlelib/idle_test/test_autocomplete.py
+++ b/Lib/idlelib/idle_test/test_autocomplete.py
@@ -238,8 +238,8 @@ class AutoCompleteTest(unittest.TestCase):
         # Test attributes
         s, b = acp.fetch_completions('', ac.ATTRS)
         self.assertLess(len(small), len(large))
-        self.assertTrue(all(filter(lambda x: x.startswith('_'), s)))
-        self.assertTrue(any(filter(lambda x: x.startswith('_'), b)))
+        self.assertFalse(any(x.startswith('_') for x in s))
+        self.assertTrue(any(x.startswith('_') for x in b))
 
         # Test smalll should respect to __all__.
         with patch.dict('__main__.__dict__', {'__all__': ['a', 'b']}):

--- a/Lib/idlelib/idle_test/test_autocomplete.py
+++ b/Lib/idlelib/idle_test/test_autocomplete.py
@@ -230,16 +230,14 @@ class AutoCompleteTest(unittest.TestCase):
         # For file completion, a large list containing all files in the path,
         # and a small list containing files that do not start with '.'.
         acp = self.autocomplete
-        small, large = acp.fetch_completions(
-                '', ac.ATTRS)
-        if hasattr(__main__, '__file__') and __main__.__file__ != ac.__file__:
-            self.assertNotIn('AutoComplete', small)  # See issue 36405.
 
-        # Test attributes
-        s, b = acp.fetch_completions('', ac.ATTRS)
-        self.assertLess(len(small), len(large))
-        self.assertFalse(any(x[0] == '_' for x in s))
-        self.assertTrue(any(x[0] == '_' for x in b))
+        # Test current module (what='') attributes.
+        small, large = acp.fetch_completions('', ac.ATTRS)
+        if hasattr(__main__, '__file__') and __main__.__file__ != ac.__file__:
+            self.assertNotIn('AutoComplete', small)  # See gh-80586.
+        self.assertLess(len(small), len(large))  # Not equal
+        self.assertFalse(any(a[:1] == '_' for a in small))
+        self.assertTrue(any(a[:1] == '_' for a in large))
 
         # Test smalll should respect to __all__.
         with patch.dict('__main__.__dict__', {'__all__': ['a', 'b']}):

--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -50,13 +50,14 @@ def tearDownModule():
     root = dialog = None
 
 
-##class ConfigDialogTest(unittest.TestCase):
-##
-##    def test_deactivate_current_config(self):
-##        pass
-##
-##    def activate_config_changes(self):
-##        pass
+@unittest.skip('Empty tests')
+class ConfigDialogTest(unittest.TestCase):
+
+    def test_deactivate_current_config(self):
+        pass
+
+    def activate_config_changes(self):
+        pass
 
 
 class ButtonTest(unittest.TestCase):

--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -50,13 +50,13 @@ def tearDownModule():
     root = dialog = None
 
 
-class ConfigDialogTest(unittest.TestCase):
-
-    def test_deactivate_current_config(self):
-        pass
-
-    def activate_config_changes(self):
-        pass
+##class ConfigDialogTest(unittest.TestCase):
+##
+##    def test_deactivate_current_config(self):
+##        pass
+##
+##    def activate_config_changes(self):
+##        pass
 
 
 class ButtonTest(unittest.TestCase):

--- a/Lib/idlelib/idle_test/test_editor.py
+++ b/Lib/idlelib/idle_test/test_editor.py
@@ -211,30 +211,31 @@ class IndentSearcherTest(unittest.TestCase):
                 self.assertEqual(actual_pair, expected_pair)
 
 
-##class RMenuTest(unittest.TestCase):
-##
-##    @classmethod
-##    def setUpClass(cls):
-##        requires('gui')
-##        cls.root = Tk()
-##        cls.root.withdraw()
-##        cls.window = Editor(root=cls.root)
-##
-##    @classmethod
-##    def tearDownClass(cls):
-##        cls.window._close()
-##        del cls.window
-##        cls.root.update_idletasks()
-##        for id in cls.root.after_info():
-##            cls.root.after_cancel(id)
-##        cls.root.destroy()
-##        del cls.root
-##
-##    class DummyRMenu:
-##        def tk_popup(x, y): pass
-##
-##    def test_rclick(self):
-##        pass  # Comment out because cannot fail; gh-155648.
+@unittest.skip('Empty test')
+class RMenuTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        requires('gui')
+        cls.root = Tk()
+        cls.root.withdraw()
+        cls.window = Editor(root=cls.root)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.window._close()
+        del cls.window
+        cls.root.update_idletasks()
+        for id in cls.root.after_info():
+            cls.root.after_cancel(id)
+        cls.root.destroy()
+        del cls.root
+
+    class DummyRMenu:
+        def tk_popup(x, y): pass
+
+    def test_rclick(self):
+        pass
 
 
 if __name__ == '__main__':

--- a/Lib/idlelib/idle_test/test_editor.py
+++ b/Lib/idlelib/idle_test/test_editor.py
@@ -211,30 +211,30 @@ class IndentSearcherTest(unittest.TestCase):
                 self.assertEqual(actual_pair, expected_pair)
 
 
-class RMenuTest(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        requires('gui')
-        cls.root = Tk()
-        cls.root.withdraw()
-        cls.window = Editor(root=cls.root)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.window._close()
-        del cls.window
-        cls.root.update_idletasks()
-        for id in cls.root.after_info():
-            cls.root.after_cancel(id)
-        cls.root.destroy()
-        del cls.root
-
-    class DummyRMenu:
-        def tk_popup(x, y): pass
-
-    def test_rclick(self):
-        pass
+##class RMenuTest(unittest.TestCase):
+##
+##    @classmethod
+##    def setUpClass(cls):
+##        requires('gui')
+##        cls.root = Tk()
+##        cls.root.withdraw()
+##        cls.window = Editor(root=cls.root)
+##
+##    @classmethod
+##    def tearDownClass(cls):
+##        cls.window._close()
+##        del cls.window
+##        cls.root.update_idletasks()
+##        for id in cls.root.after_info():
+##            cls.root.after_cancel(id)
+##        cls.root.destroy()
+##        del cls.root
+##
+##    class DummyRMenu:
+##        def tk_popup(x, y): pass
+##
+##    def test_rclick(self):
+##        pass  # Comment out because cannot fail; gh-155648.
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
DD bug 26:
test_autocomplete.py:241 passes when proper because `any([]) is True` is true.  It would also pass if small only had underscored words because the filter got reversed.  Change logic and replace filter with generator expression 
using slice instead of startswith.  Change line 242 to match.

test_editor.py:236 and test_configdialog.py:55 have empty tests ('pass'); skip them for now.
PR-#156260 add real tests.

template.py:25 tests `True == True`; skip it.  With this, the bug scanner should be satisfied while allowing
setUpClass and tearDownClass to run and be verified.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-155648 -->
* Issue: gh-155648
<!-- /gh-issue-number -->
