### PR TITLE
gh-156275: Fix asyncio losing received TLS data for a bytearray buffer

### DIFF
--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -773,8 +773,10 @@ class SSLProtocol(protocols.BufferedProtocol):
 
             if count > 0:
                 offset = count
+                # gh-156275: a bytearray slice is a copy, slice a view instead
+                view = memoryview(buf)
                 while offset < wants:
-                    count = self._sslobj.read(wants - offset, buf[offset:])
+                    count = self._sslobj.read(wants - offset, view[offset:])
                     if count > 0:
                         offset += count
                     else:

--- a/Lib/test/test_asyncio/test_ssl.py
+++ b/Lib/test/test_asyncio/test_ssl.py
@@ -921,13 +921,16 @@ class TestSSL(test_utils.TestCase):
         async def run():
             server = await asyncio.start_server(
                 serve, '127.0.0.1', 0, ssl=test_utils.simple_server_sslcontext())
-            self.addCleanup(server.close)
-            done = self.loop.create_future()
-            await self.loop.create_connection(
-                lambda: ClientProto(done),
-                *server.sockets[0].getsockname()[:2],
-                ssl=test_utils.simple_client_sslcontext())
-            self.assertEqual(await done, b''.join(CHUNKS))
+            try:
+                done = self.loop.create_future()
+                await self.loop.create_connection(
+                    lambda: ClientProto(done),
+                    *server.sockets[0].getsockname()[:2],
+                    ssl=test_utils.simple_client_sslcontext())
+                self.assertEqual(await done, b''.join(CHUNKS))
+            finally:
+                self.loop.call_soon(server.close)
+                await server.wait_closed()
 
         self.loop.run_until_complete(asyncio.wait_for(run(), timeout=self.TIMEOUT))
 

--- a/Lib/test/test_asyncio/test_ssl.py
+++ b/Lib/test/test_asyncio/test_ssl.py
@@ -894,6 +894,43 @@ class TestSSL(test_utils.TestCase):
                 asyncio.wait_for(client(srv.addr),
                                  timeout=self.TIMEOUT))
 
+    def test_buffered_proto_bytearray(self):
+        # gh-156275: decrypt into the caller's buffer, not a copy of a slice
+        CHUNKS = [b'A' * 30, b'B' * 30, b'C' * 30]
+
+        class ClientProto(asyncio.BufferedProtocol):
+            def __init__(self, done):
+                self.done = done
+                self.buf = bytearray(100)
+                self.data = b''
+
+            def get_buffer(self, sizehint):
+                return self.buf
+
+            def buffer_updated(self, nbytes):
+                self.data += self.buf[:nbytes]
+
+            def connection_lost(self, exc):
+                self.done.set_result(self.data)
+
+        async def serve(reader, writer):
+            for chunk in CHUNKS:
+                writer.write(chunk)
+            writer.close()
+
+        async def run():
+            server = await asyncio.start_server(
+                serve, '127.0.0.1', 0, ssl=test_utils.simple_server_sslcontext())
+            self.addCleanup(server.close)
+            done = self.loop.create_future()
+            await self.loop.create_connection(
+                lambda: ClientProto(done),
+                *server.sockets[0].getsockname()[:2],
+                ssl=test_utils.simple_client_sslcontext())
+            self.assertEqual(await done, b''.join(CHUNKS))
+
+        self.loop.run_until_complete(asyncio.wait_for(run(), timeout=self.TIMEOUT))
+
     def test_start_tls_slow_client_cancel(self):
         HELLO_MSG = b'1' * self.PAYLOAD_SIZE
 

--- a/Misc/NEWS.d/next/Library/2026-08-23-12-53-34.gh-issue-156275.Kor1LU.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-23-12-53-34.gh-issue-156275.Kor1LU.rst
@@ -1,0 +1,2 @@
+Fix :mod:`asyncio` losing received TLS data when
+:meth:`~asyncio.BufferedProtocol.get_buffer` returns a :class:`bytearray`.

--- a/Misc/NEWS.d/next/Library/2026-08-23-12-53-34.gh-issue-156275.Kor1LU.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-23-12-53-34.gh-issue-156275.Kor1LU.rst
@@ -1,2 +1,0 @@
-Fix :mod:`asyncio` losing received TLS data when
-:meth:`~asyncio.BufferedProtocol.get_buffer` returns a :class:`bytearray`.

--- a/Misc/NEWS.d/next/Library/2026-08-23-13-10-54.gh-issue-156276.rQeeS5.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-23-13-10-54.gh-issue-156276.rQeeS5.rst
@@ -1,0 +1,2 @@
+Fix :mod:`asyncio` losing received TLS data when
+:meth:`~asyncio.BufferedProtocol.get_buffer` returns a :class:`bytearray`.


### PR DESCRIPTION
Fix asyncio losing received TLS data for a bytearray buffer

For more details see gh-156275