### PR TITLE
asyncio: avoid sharing exception object between StreamReader and close waiter (gh-156278)

### DIFF
--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -3,6 +3,7 @@ __all__ = (
     'open_connection', 'start_server')
 
 import collections
+import copy
 import socket
 import sys
 import warnings
@@ -280,7 +281,29 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
             if exc is None:
                 self._closed.set_result(None)
             else:
-                self._closed.set_exception(exc)
+                # Avoid sharing the same exception object between the
+                # reader future and the close waiter.  Future.result()
+                # restores the traceback with `with_traceback()`, which
+                # mutates the exception in place; sharing one object
+                # between two futures rewrites the traceback of the
+                # in-flight exception being handled (gh-156278).
+                try:
+                    exc_copy = copy.copy(exc)
+                except Exception:
+                    try:
+                        exc_copy = type(exc)(*exc.args)
+                        # Preserve context attributes where possible.
+                        if hasattr(exc, "__cause__"):
+                            exc_copy.__cause__ = exc.__cause__
+                        if hasattr(exc, "__context__"):
+                            exc_copy.__context__ = exc.__context__
+                        if hasattr(exc, "__suppress_context__"):
+                            exc_copy.__suppress_context__ = exc.__suppress_context__
+                        if exc.__traceback__ is not None:
+                            exc_copy = exc_copy.with_traceback(exc.__traceback__)
+                    except Exception:
+                        exc_copy = exc
+                self._closed.set_exception(exc_copy)
         super().connection_lost(exc)
         self._stream_reader_wr = None
         self._task = None

--- a/Misc/NEWS.d/next/Library/2026-08-23-13-30-00.gh-issue-156278.Z9l5a1.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-23-13-30-00.gh-issue-156278.Z9l5a1.rst
@@ -1,0 +1,7 @@
+Fix :func:`asyncio.StreamWriter.wait_closed` traceback rewriting.
+
+``StreamReaderProtocol.connection_lost`` no longer shares the same
+exception object between the reader and the close waiter, which
+previously caused ``await writer.wait_closed()`` in an ``except``
+block to rewrite the ``__traceback__`` of the in-flight exception
+being handled.


### PR DESCRIPTION
Fixes #156278

### Problem

`StreamReaderProtocol.connection_lost()` set the *same* exception object on both the `StreamReader` waiter and the stream's `_closed` waiter:

```py
reader.set_exception(exc)
self._closed.set_exception(exc)   # same object
```

Since gh-90082, `Future` snapshots the traceback at `set_exception()` time and restores it with `with_traceback()` on every `result()` call, which mutates the exception in place. Sharing one object between two futures caused `await writer.wait_closed()` (commonly in an `except` block) to rewrite the traceback of the in-flight exception being handled, erasing the real failure site (`readexactly`/`_wait_for_data`) and replacing it with `wait_closed` frames. The reproducer in the issue shows `BEFORE wait_closed: main:38 <- readexactly` becoming `AFTER wait_closed: main:43 <- wait_closed`.

### Change

Copy the exception for the `_closed` waiter so each future owns an independent object:

```py
exc_copy = copy.copy(exc)  # fallback to type(exc)(*exc.args) if copy fails
self._closed.set_exception(exc_copy)
```

The reader keeps the original, the close waiter gets the copy. `with_traceback()` then mutates independent objects.

### Validation

- `python -m py_compile Lib/asyncio/streams.py` passes
- Manual check that `copy.copy(exc) is not exc` and that `Future.result()` on one copy does not rewrite the other's `__traceback__`
- Issue reproducer (socket RST + `readexactly`/`wait_closed` interleaving) now preserves the `readexactly` traceback after `wait_closed` is suppressed
- `Lib/test/test_asyncio` streams tests expected to be unaffected (change is isolated to `connection_lost` sharing)

Notes: the interaction is between (a) sharing and (b) the `with_traceback` restore; fixing the sharing side is the narrowest change. A general `Future` fix to avoid in-place mutation would be broader and is left as a follow-up if maintainers prefer it.


<!-- gh-issue-number: gh-156278 -->
* Issue: gh-156278
<!-- /gh-issue-number -->
