### PR TITLE
gh-151126: Set  `MemoryError` on allocation failure in CJK codec macros

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-08-23-16-33-00.gh-issue-151126.GUvtG7.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-23-16-33-00.gh-issue-151126.GUvtG7.rst
@@ -1,0 +1,2 @@
+Raise :exc:`MemoryError` on allocation failure during CJK codec module
+initialisation.

--- a/Modules/cjkcodecs/cjkcodecs.h
+++ b/Modules/cjkcodecs/cjkcodecs.h
@@ -237,6 +237,7 @@ add_mappings(cjkcodecs_module_state *st)                            \
     st->num_mappings = NUM;                                         \
     st->mapping_list = PyMem_Calloc(NUM, sizeof(struct dbcs_map));  \
     if (st->mapping_list == NULL) {                                 \
+        PyErr_NoMemory();                                           \
         return -1;                                                  \
     }
 
@@ -261,6 +262,7 @@ add_codecs(cjkcodecs_module_state *st)                          \
     st->num_codecs = NUM;                                       \
     st->codec_list = PyMem_Calloc(NUM, sizeof(MultibyteCodec)); \
     if (st->codec_list == NULL) {                               \
+        PyErr_NoMemory();                                       \
         return -1;                                              \
     }
 


### PR DESCRIPTION
Relates to #151126.

<!-- gh-issue-number: gh-151126 -->
* Issue: gh-151126
<!-- /gh-issue-number -->
