### PR TITLE
gh-151126: Set `MemoryError` on alloc failure in `_PyXIData_InitWithSize`

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-23-16-31-00.gh-issue-151126.phAWIG.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-23-16-31-00.gh-issue-151126.phAWIG.rst
@@ -1,0 +1,2 @@
+Raise :exc:`MemoryError` on allocation failure in
+``_PyXIData_InitWithSize``.

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -388,6 +388,7 @@ _PyXIData_InitWithSize(_PyXIData_t *xidata,
     _PyXIData_Init(xidata, interp, NULL, obj, new_object);
     xidata->data = PyMem_RawCalloc(1, size);
     if (xidata->data == NULL) {
+        PyErr_NoMemory();
         return -1;
     }
     xidata->free = PyMem_RawFree;


### PR DESCRIPTION
Relates to #151126.

<!-- gh-issue-number: gh-151126 -->
* Issue: gh-151126
<!-- /gh-issue-number -->
