### PR TITLE
gh-155193: Fix the *canonical* decoder lists in the 3.15 What's New and NEWS

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -1009,7 +1009,7 @@ base64
 
 * Added the *canonical* parameter in
   :func:`~base64.b32decode`, :func:`~base64.b32hexdecode`,
-  :func:`~base64.b64decode`, :func:`~base64.urlsafe_b64decode`,
+  :func:`~base64.b64decode`,
   :func:`~base64.a85decode`, :func:`~base64.b85decode`, and
   :func:`~base64.z85decode`,
   to reject encodings with non-zero padding bits or other non-canonical

--- a/Misc/NEWS.d/3.15.0b1.rst
+++ b/Misc/NEWS.d/3.15.0b1.rst
@@ -1081,10 +1081,10 @@ Deprecate :meth:`http.cookies.Morsel.js_output` and
 .. nonce: iHWO0v
 .. section: Library
 
-Add a *canonical* keyword-only parameter to the base16, base32, base64,
-base85, ascii85, and Z85 decoders in :mod:`base64` and :mod:`binascii`. When
-true, encodings with non-zero padding bits (base16/32/64) or non-canonical
-encodings (base85/ascii85) are rejected.  Single-character final groups in
+Add a *canonical* keyword-only parameter to the base32, base64, base85,
+ascii85, and Z85 decoders in :mod:`base64` and :mod:`binascii`. When true,
+encodings with non-zero padding bits (base32/64) or non-canonical encodings
+(base85/ascii85) are rejected.  Single-character final groups in
 :func:`binascii.a2b_ascii85` and :func:`binascii.a2b_base85` are now always
 rejected as encoding violations, regardless of *canonical*; previously they
 were silently ignored and produced no output bytes.


### PR DESCRIPTION
The 3.15 What's New lists `urlsafe_b64decode()` as one of the decoders that got *canonical*, but it never got the parameter:

```
>>> base64.urlsafe_b64decode(b'aGk=', canonical=True)
TypeError: urlsafe_b64decode() got an unexpected keyword argument 'canonical'
```

It doesn't call `b64decode()`, it calls `binascii.a2b_base64()` directly with a fixed set of arguments, so widening `b64decode()` in GH-146312 didn't affect it. This drops it from the bullet, per gpshead on the issue.

I went through the other bullets in the base64 section and checked them against the signatures. This is the only one that's off.

The NEWS entry for the same change (now in `Misc/NEWS.d/3.15.0b1.rst`) says the base16 decoders got *canonical*, but none did: `b16decode()` and `binascii.a2b_hex()` are unchanged. Removed base16 from that entry too.

Docs only, so `skip news`. Needs a backport to 3.15.

<!-- gh-issue-number: gh-155193 -->
* Issue: gh-155193
<!-- /gh-issue-number -->
