### PR TITLE
gh-155912: Catch OSError from os.sysconf in _check_system_limits

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -707,8 +707,9 @@ def _check_system_limits():
         raise NotImplementedError(_system_limited)
     try:
         nsems_max = os.sysconf("SC_SEM_NSEMS_MAX")
-    except (AttributeError, ValueError):
-        # sysconf not available or setting not available
+    except (AttributeError, ValueError, OSError):
+        # sysconf not available, setting not available, or the read was
+        # denied (e.g. a sandbox profile that denies sysctl reads on macOS)
         return
     if nsems_max == -1:
         # indetermined limit, assume that limit is determined

--- a/Lib/test/test_concurrent_futures/test_process_pool.py
+++ b/Lib/test/test_concurrent_futures/test_process_pool.py
@@ -8,6 +8,7 @@ import unittest
 import unittest.mock
 import weakref
 from concurrent import futures
+from concurrent.futures import process as futures_process
 from concurrent.futures.process import BrokenProcessPool
 
 from test import support
@@ -541,6 +542,46 @@ class ProcessPoolExecutorTest(ExecutorTest):
             for _ in support.sleeping_retry(support.SHORT_TIMEOUT):
                 if not worker_process.is_alive():
                     break
+
+
+class CheckSystemLimitsTest(unittest.TestCase):
+    # gh-155912: a denied sysconf read is the same condition as an
+    # unavailable one and must not be fatal.
+
+    def setUp(self):
+        saved = (futures_process._system_limits_checked,
+                 futures_process._system_limited)
+
+        def restore():
+            (futures_process._system_limits_checked,
+             futures_process._system_limited) = saved
+
+        self.addCleanup(restore)
+
+    def check(self, **kwargs):
+        futures_process._system_limits_checked = False
+        futures_process._system_limited = None
+        with unittest.mock.patch.object(os, "sysconf", **kwargs):
+            futures_process._check_system_limits()
+
+    def test_denied_read_is_not_fatal(self):
+        self.check(side_effect=PermissionError(1, "Operation not permitted"))
+
+    def test_other_oserror_is_not_fatal(self):
+        self.check(side_effect=OSError(5, "Input/output error"))
+
+    def test_unsupported_name_is_not_fatal(self):
+        self.check(side_effect=ValueError)
+
+    def test_indeterminate_limit_is_not_fatal(self):
+        self.check(return_value=-1)
+
+    def test_sufficient_semaphores(self):
+        self.check(return_value=87381)
+
+    def test_too_few_semaphores_still_raises(self):
+        with self.assertRaises(NotImplementedError):
+            self.check(return_value=10)
 
 
 create_executor_tests(globals(), ProcessPoolExecutorTest,

--- a/Lib/test/test_concurrent_futures/test_process_pool.py
+++ b/Lib/test/test_concurrent_futures/test_process_pool.py
@@ -544,11 +544,13 @@ class ProcessPoolExecutorTest(ExecutorTest):
                     break
 
 
+@unittest.skipUnless(hasattr(os, "sysconf"), "requires os.sysconf()")
 class CheckSystemLimitsTest(unittest.TestCase):
     # gh-155912: a denied sysconf read is the same condition as an
     # unavailable one and must not be fatal.
 
     def setUp(self):
+        support.skip_if_broken_multiprocessing_synchronize()
         saved = (futures_process._system_limits_checked,
                  futures_process._system_limited)
 

--- a/Misc/NEWS.d/next/Library/2026-08-23-14-54-39.gh-issue-155912.Hk7Qa2.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-23-14-54-39.gh-issue-155912.Hk7Qa2.rst
@@ -1,0 +1,3 @@
+Fix :class:`concurrent.futures.ProcessPoolExecutor` construction when
+:func:`os.sysconf` raises :exc:`OSError`, for instance when a sandbox denies
+the read.


### PR DESCRIPTION
<!--_check_system_limits() caught only AttributeError and ValueError, so a denied
sysconf read raised PermissionError out of ProcessPoolExecutor.__init__. Per the
os.sysconf docs an unsupported name raises OSError, so this catches OSError,
which covers both. Tests patch os.sysconf across six cases, including one
asserting the too-few-semaphores NotImplementedError still fires. Fixes #155912.
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-155912 -->
* Issue: gh-155912
<!-- /gh-issue-number -->
