### PR TITLE
gh-156185: Ignore all ASCII whitespace in re \p{} property names

### DIFF
--- a/Lib/re/_properties.py
+++ b/Lib/re/_properties.py
@@ -208,12 +208,17 @@ def _analytic_ranges():
     }
 
 
+# Characters that are not significant in a Unicode property or value name
+# (see _normalize): ASCII whitespace, hyphens and underscores.
+_NON_SIGNIFICANT = str.maketrans("", "", " \t\n\r\f\v_-")
+
+
 def _normalize(name):
-    # Unicode property and value names are matched loosely: case, spaces,
-    # hyphens and underscores are not significant, and an initial "is" prefix
-    # is ignored (UAX #44 5.9, "Matching Rules", UAX44-LM3;
+    # Unicode property and value names are matched loosely: case, whitespace,
+    # hyphens and underscores are not significant, and an initial "is"
+    # prefix is ignored (UAX #44 5.9, "Matching Rules", UAX44-LM3;
     # https://www.unicode.org/reports/tr44/).
-    name = name.lower().replace("_", "").replace("-", "").replace(" ", "")
+    name = name.lower().translate(_NON_SIGNIFICANT)
     # Strip a leading "is", unless "is" is the whole name and so not a prefix
     # (e.g. the Line_Break value lb=IS).
     if name != "is":

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -929,6 +929,12 @@ class ReTests(unittest.TestCase):
         self.assertTrue(re.fullmatch(r'\p{General_Category=Lu}+', 'ABC'))
         self.assertTrue(re.fullmatch(r'\p{ lu }+', 'ABC'))
         self.assertTrue(re.fullmatch(r'\p{LU}+', 'ABC'))
+        # All ASCII whitespace is ignored, not just spaces (UAX44-LM3;
+        # gh-156185).
+        for ws in " \t\n\r\f\v":
+            with self.subTest(ws=ws):
+                self.assertTrue(re.fullmatch(r'\p{L%su}+' % ws, 'ABC'))
+                self.assertTrue(re.fullmatch(r'\p{gc%s=L%su}+' % (ws, ws), 'ABC'))
         # An initial "is" prefix is ignored (UAX44-LM3), on the property name
         # and on a gc value; "is" alone is not a prefix (cf. lb=IS).
         self.assertTrue(re.fullmatch(r'\p{isLu}+', 'ABC'))


### PR DESCRIPTION
**Problem**
The docs (and the `_normalize` comment) promise that `\p{...}` property and value names are matched loosely — case, whitespace, hyphens and underscores are not significant (UAX #44, LM3). In practice only spaces were removed, so `\p{L\tu}` or `\p{G\nC=Lu}` raised `re.error: unknown property "L\ntu"` while the space form worked. (3.16-only feature, so no compatibility concern.)

**Solution**
`_normalize()` in `Lib/re/_properties.py` now drops all ASCII whitespace (` \t\n\r\f\v`), not just space; comment updated to match.

**Result**
Added a regression loop over all six whitespace characters in `test_re.py::test_property_escapes`; full `test_re` passes (169 tests) on a debug build, and the new assertions fail on the unpatched code. NEWS entry added.


<!-- gh-issue-number: gh-156185 -->
* Issue: gh-156185
<!-- /gh-issue-number -->
