### PR TITLE
gh-126253: Ignore unknown Windows file attribute bits in scandir test

### DIFF
--- a/Lib/test/test_os/test_os.py
+++ b/Lib/test/test_os/test_os.py
@@ -84,6 +84,17 @@ else:
 HAVE_WHEEL_GROUP = sys.platform.startswith('freebsd') and os.getgid() == 0
 
 
+def _get_file_attribute_mask():
+    mask = 0
+    for name in dir(stat):
+        if name.startswith("FILE_ATTRIBUTE_"):
+            mask |= getattr(stat, name)
+    return mask
+
+
+_FILE_ATTRIBUTE_MASK = _get_file_attribute_mask()
+
+
 def requires_os_func(name):
     return unittest.skipUnless(hasattr(os, name), 'requires os.%s' % name)
 
@@ -5004,8 +5015,15 @@ class TestScandir(unittest.TestCase):
                 if attr in ("st_dev", "st_ino", "st_nlink", "st_ctime",
                             "st_ctime_ns"):
                     continue
-                self.assertEqual(getattr(stat1, attr),
-                                 getattr(stat2, attr),
+                value1 = getattr(stat1, attr)
+                value2 = getattr(stat2, attr)
+                if attr == "st_file_attributes":
+                    # Filesystems may report attribute bits that aren't
+                    # exposed by the stat module.
+                    value1 &= _FILE_ATTRIBUTE_MASK
+                    value2 &= _FILE_ATTRIBUTE_MASK
+                self.assertEqual(value1,
+                                 value2,
                                  (stat1, stat2, attr))
         else:
             self.assertEqual(stat1, stat2)
@@ -5092,6 +5110,27 @@ class TestScandir(unittest.TestCase):
 
             entry = entries['symlink_file.txt']
             self.check_entry(entry, 'symlink_file.txt', False, True, True)
+
+    @unittest.skipUnless(sys.platform == 'win32', 'Windows-specific test')
+    def test_attributes_unknown_bits(self):
+        base = os.stat(self.path)
+        file_attributes = base.st_file_attributes
+        unknown_attribute = 0x10000000
+        self.assertFalse(unknown_attribute & _FILE_ATTRIBUTE_MASK)
+
+        stat1 = os.stat_result(
+            tuple(base), {"st_file_attributes": file_attributes})
+        stat2 = os.stat_result(
+            tuple(base),
+            {"st_file_attributes": file_attributes | unknown_attribute})
+        self.assert_stat_equal(stat1, stat2, True)
+
+        stat3 = os.stat_result(
+            tuple(base),
+            {"st_file_attributes":
+             file_attributes ^ stat.FILE_ATTRIBUTE_READONLY})
+        with self.assertRaises(AssertionError):
+            self.assert_stat_equal(stat1, stat3, True)
 
     @unittest.skipIf(sys.platform != 'win32', "Can only test junctions with creation on win32.")
     def test_attributes_junctions(self):


### PR DESCRIPTION
Closes #126253.

`os.scandir().stat()` and `os.stat()` can return different values for `st_file_attributes` when NTFS reports bits that are not exposed by Python's `stat` module. Limit the scandir test comparison to the public `stat.FILE_ATTRIBUTE_*` bits, while continuing to compare every public bit strictly.

The regression test constructs `os.stat_result` values with the reported `0x10000000` bit so the behavior is covered even on Windows builds where the filesystem does not naturally return it. It also verifies that a difference in `FILE_ATTRIBUTE_READONLY` still fails the comparison.

Tests:
- `PCbuild\amd64\python_d.exe -m test test_os.test_os -m "*attributes*" -v`
- `PCbuild\amd64\python_d.exe -m test -v test_os`
- `PCbuild\amd64\python_d.exe Tools\patchcheck\patchcheck.py`

This contribution was prepared with assistance from OpenAI Codex. I reviewed and tested the resulting changes.

<!-- gh-issue-number: gh-126253 -->
* Issue: gh-126253
<!-- /gh-issue-number -->
