### PR TITLE
gh-156233: Fix grammar in MRO documentation

### DIFF
--- a/Doc/howto/mro.rst
+++ b/Doc/howto/mro.rst
@@ -189,7 +189,7 @@ prescription:
   the tail of any of the other lists, then add it to the linearization
   of C and remove it from the lists in the merge, otherwise look at the
   head of the next list and take it, if it is a good head.  Then repeat
-  the operation until all the class are removed or it is impossible to
+  the operation until all the classes are removed or it is impossible to
   find good heads.  In this case, it is impossible to construct the
   merge, Python 2.3 will refuse to create the class C and will raise an
   exception.*


### PR DESCRIPTION
Fixes #156233

## Problem

Doc/howto/mro.rst contains a grammar typo:

> Then repeat the operation until **all the class** are removed or it is impossible to find good heads.

Singular "class" disagrees with plural verb "are". The sentence describes removing multiple classes during MRO merge, so plural "classes" is correct.

Issue: https://github.com/python/cpython/issues/156233
Source: `Doc/howto/mro.rst:192` (`Doc/howto/mro.html#python-2-3-mro`)

## Change

- Fix `Doc/howto/mro.rst:192` from `all the class are removed` → `all the classes are removed`
- Keep unrelated cleanup out of this PR

## Why this approach

Minimal one-line docs fix matching the issue's suggested correction. No code or behavior change.

## Testing

```text
command: git diff --check
result: clean

command: grep -n "all the class" Doc/howto/mro.rst
result: no matches (fixed)

command: grep -n "all the classes are removed" Doc/howto/mro.rst
result: 192:  the operation until all the classes are removed or it is impossible to
```

Doc build: `Doc/howto/mro.rst` renders as before with corrected grammar; no functional tests required for docs-only change.

## Documentation and release impact

- [x] User-facing documentation updated
- [x] Changelog/release note needed: docs fix, no NEWS blurb required per CPython docs-only convention (trivial typo)
- [ ] Migration or compatibility note needed
- [ ] No documentation impact

## Review notes

- Known limitations: none
- Follow-up issue, if any: none
- Security/licensing considerations: none


<!-- gh-issue-number: gh-156233 -->
* Issue: gh-156233
<!-- /gh-issue-number -->
