### PR TITLE
gh-133049: make pygettext match xgettext for empty input/no messages

### DIFF
--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -826,6 +826,10 @@ def main():
             expanded.extend(getFilesForName(arg))
     args = expanded
 
+    # xgettext-compatible: no input file given is an error
+    if not args:
+        usage(1, "pygettext: no input file given\nTry 'pygettext --help' for more information.")
+
     # slurp through all the files
     visitor = GettextVisitor(options)
     for filename in args:
@@ -840,6 +844,13 @@ def main():
                 source = fp.read()
 
         visitor.visit_file(source, filename)
+
+    # xgettext-compatible: no output is generated if there are no messages
+    if not visitor.messages:
+        if options.verbose:
+            print("No module matched or no strings to extract; no output file generated.",
+                  file=sys.stderr)
+        sys.exit(0)
 
     # write the output
     if options.outfile == '-':


### PR DESCRIPTION
Fixes #133049

## Problem

`Tools/i18n/pygettext.py` diverges from GNU `xgettext` in two empty-input cases:

1. **No input file given** — `xgettext` prints `xgettext: no input file given` and `Try 'xgettext --help' …` with exit 1. `pygettext` silently generated an empty `messages.pot` with only a header.

2. **No messages to extract** — `xgettext` produces no output when no strings are found. `pygettext` still wrote a header-only `messages.pot`.

Issue #133049 reports both; `tomasr8` confirmed the first is clear and should be fixed (input file should be required), while the second is debated but the issue requests xgettext-compatible behavior.

## Change

- In `Tools/i18n/pygettext.py:main()` — after expanding `args` via `getFilesForName`, check `if not args:` → `usage(1, "pygettext: no input file given\nTry 'pygettext --help' for more information.")`

- After visiting files, check `if not visitor.messages:` → verbose message to stderr and `sys.exit(0)` without creating/writing the output file (covers both `-o FILE` and `-` stdout cases). This matches `xgettext`'s "no output is generated if there are no messages".

Keep unrelated cleanup out of this PR.

## Why this approach

Minimal, xgettext-compatible, and respects the maintainer's lean: the first fix is uncontroversial and matches the exact `xgettext` error wording; the second implements the requested "no empty output" while remaining silent unless `-v` is given, so existing workflows that expect an empty POT can be detected via the exit and verbose hint.

## Testing

```text
command: python3.14 Tools/i18n/pygettext.py (no args)
result: prints __doc__ + "pygettext: no input file given\nTry 'pygettext --help' …" to stderr, exit 1 — matches xgettext

command: echo 'print("hello")' > /tmp/test.py && python3.14 Tools/i18n/pygettext.py -o /tmp/out.pot /tmp/test.py; ls /tmp/out.pot
result: no out.pot created, exit 0

command: echo '_("hello")' > /tmp/test2.py && python3.14 Tools/i18n/pygettext.py -o /tmp/out2.pot /tmp/test2.py; cat /tmp/out2.pot
result: header + msgid "hello" written correctly

command: python3.14 -m py_compile Tools/i18n/pygettext.py
result: ok (3.13/3.14; 3.9 fails on unrelated PEP 701 f-string syntax already on main)

command: git diff --check
result: clean
```

`make check` for `pygettext` is covered by `test.test_tools.test_i18n` (skipped in this env due to missing build dir, but `git diff --check` and manual checks pass).

## Documentation and release impact

- [x] User-facing behavior updated (CLI error / empty-output)
- [x] Changelog/release note needed: bug fix, no docs
- [ ] Migration or compatibility note needed
- [ ] No documentation impact

## Review notes

- Known limitations: verbose-only hint for empty-messages case
- Follow-up issue, if any: none
- Security/licensing considerations: none


<!-- gh-issue-number: gh-133049 -->
* Issue: gh-133049
<!-- /gh-issue-number -->
