### PR TITLE
gh-149746: Handle CIDRs in NO_PROXY env var

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -361,7 +361,8 @@ The following classes are provided:
    The :envvar:`no_proxy` environment variable can be used to specify hosts
    which shouldn't be reached via proxy; if set, it should be a comma-separated
    list of hostname suffixes, optionally with ``:port`` appended, for example
-   ``cern.ch,ncsa.uiuc.edu,some.host:8080``.
+   ``cern.ch,ncsa.uiuc.edu,some.host:8080``.  IP CIDR notation is also
+   supported.
 
    .. note::
 

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -263,6 +263,29 @@ class ProxyTests(unittest.TestCase):
         self.assertFalse(bypass('anotherdomain.com:8888\n'))
         self.assertFalse(bypass('newdomain.com:1234\n'))
 
+    def test_proxy_bypass_environment_cidrs(self):
+        bypass = lambda a, b: urllib.request.proxy_bypass_environment(a, {'no': b})
+
+        # IPv4 CIDRs
+        self.assertTrue(bypass('192.168.0.5', 'asdf.com,192.168.0.0/24'))
+        self.assertTrue(bypass('192.168.0.5', 'asdf.com,192.168.0.10/24'))
+        self.assertTrue(bypass('192.168.0.5:8443', 'asdf.com,192.168.0.0/24'))
+        self.assertTrue(bypass('192.168.0.5', 'asdf.com,192.168.0.5'))
+        self.assertTrue(bypass('192.168.0.5', 'asdf.com,192.168.0.5/32'))
+        self.assertFalse(bypass('10.1.2.3', 'asdf.com,192.168.0.0/24'))
+
+        # IPv6 CIDRs
+        self.assertTrue(bypass('2001:db8:85a3:1::10', 'asdf.com,2001:db8:85a3:1::/64'))
+        self.assertTrue(bypass('[2001:db8:85a3:1::10]', 'asdf.com,2001:db8:85a3:1::/64'))
+        self.assertTrue(bypass('[2001:db8:85a3:1::10]:443', 'asdf.com,2001:db8:85a3:1::/64'))
+        self.assertTrue(bypass('2001:db8:85a3:1::10', 'asdf.com,2001:db8:85a3:1::10'))
+        self.assertTrue(bypass('2001:db8:85a3:1::10', 'asdf.com,2001:db8:85a3:1::10/128'))
+        self.assertFalse(bypass('1001:db8:85a3:1::10', 'asdf.com,2001:db8:85a3:1::10/128'))
+
+        # Invalid CIDRs should be ignored
+        self.assertFalse(bypass('192.168.0.5', 'asdf.com,192.168.0.5/40'))
+        self.assertFalse(bypass('2001:db8:85a3:1::10', 'asdf.com,2001:db8:85a3:1::/150'))
+
 
 class ProxyTests_withOrderedEnv(unittest.TestCase):
 

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -1843,6 +1843,7 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splitport('parrot:cheese'), ('parrot:cheese', None))
         self.assertEqual(splitport('[::1]:88'), ('[::1]', '88'))
         self.assertEqual(splitport('[::1]'), ('[::1]', None))
+        self.assertEqual(splitport('::1'), ('::1', None))
         self.assertEqual(splitport(':88'), ('', '88'))
 
     def test_splitnport(self):

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -1314,6 +1314,15 @@ def splitport(host):
 _portprog = None
 def _splitport(host):
     """splitport('host:port') --> 'host', 'port'."""
+    # Handle bare IPv6 addresses with : (e.g. ::1)
+    if host.count(':') > 1 and not host.startswith('['):
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+            pass
+        else:
+            return host, None
+
     global _portprog
     if _portprog is None:
         _portprog = re.compile('(.*):([0-9]*)', re.DOTALL)

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1948,7 +1948,7 @@ class _ProxyBypassEnvSettings:
     def __init__(self, data):
         self.matches = set()
         self.cidrs = []
-        
+
         for elem in data.split(','):
             elem = elem.strip()
 

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -96,6 +96,8 @@ import sys
 import time
 import tempfile
 
+from functools import lru_cache
+from ipaddress import ip_address, ip_network
 
 from urllib.error import URLError, HTTPError, ContentTooShortError
 from urllib.parse import (
@@ -1924,7 +1926,8 @@ def proxy_bypass_environment(host, proxies=None):
     """Test if proxies should not be used for a particular host.
 
     Checks the proxy dict for the value of no_proxy, which should
-    be a list of comma separated DNS suffixes, or '*' for all hosts.
+    be a list of comma separated DNS suffixes and IP CIDRs, or
+    '*' for all hosts.
 
     """
     if proxies is None:
@@ -1937,22 +1940,61 @@ def proxy_bypass_environment(host, proxies=None):
     # '*' is special case for always bypass
     if no_proxy == '*':
         return True
-    host = host.lower()
-    # strip port off host
-    hostonly, port = _splitport(host)
-    # check if the host ends with any of the DNS suffixes
-    for name in no_proxy.split(','):
-        name = name.strip()
-        if name:
-            name = name.lstrip('.')  # ignore leading dots
-            name = name.lower()
-            if hostonly == name or host == name:
+
+    return _ProxyBypassEnvSettings.cached(no_proxy).should_bypass(host)
+
+
+class _ProxyBypassEnvSettings:
+    def __init__(self, data):
+        self.matches = set()
+        self.cidrs = []
+        
+        for elem in data.split(','):
+            elem = elem.strip()
+
+            if not elem:
+                continue
+
+            try:
+                block = ip_network(elem, strict=False)
+            except ValueError:
+                self.matches.add(elem.lstrip('.').lower())
+            else:
+                self.cidrs.append(block)
+
+    def should_bypass(self, host):
+        host = host.lower()
+        hostonly, _ = _splitport(host)
+
+        try:
+            ip = ip_address(hostonly.strip('[]'))
+        except ValueError:
+            pass
+        else:
+            if any(ip in cidr for cidr in self.cidrs):
                 return True
-            name = '.' + name
-            if hostonly.endswith(name) or host.endswith(name):
+
+        if host in self.matches or hostonly in self.matches:
+            return True
+
+        for match in self.matches:
+            dot_match = '.' + match
+            if host.endswith(dot_match) or hostonly.endswith(dot_match):
                 return True
-    # otherwise, don't bypass
-    return False
+
+        return False
+
+    @classmethod
+    @lru_cache
+    def cached(cls, data):
+        """Initializer with cache.
+
+        The vast majority of the time, NO_PROXY won't change.
+
+        This function caches the string manipulations so they don't repeat on
+        every single proxy check.
+        """
+        return cls(data)
 
 
 # This code tests an OSX specific data structure but is testable on all

--- a/Misc/NEWS.d/next/Library/2026-08-24-16-32-20.gh-issue-149746.ctIq-G.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-24-16-32-20.gh-issue-149746.ctIq-G.rst
@@ -1,2 +1,2 @@
 urllib now allows IP CIDRs to be excluded from proxying by including the
-CIDR in the `NO_PROXY` env var.  Contributed by Neal Turett.
+CIDR in the ``no_proxy`` env var.  Contributed by Neal Turett.

--- a/Misc/NEWS.d/next/Library/2026-08-24-16-32-20.gh-issue-149746.ctIq-G.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-24-16-32-20.gh-issue-149746.ctIq-G.rst
@@ -1,0 +1,2 @@
+urllib now allows IP CIDRs to be excluded from proxying by including the
+CIDR in the `NO_PROXY` env var.  Contributed by Neal Turett.


### PR DESCRIPTION
# The change

This PR allows IPv4 & IPv6 CIDRs to be specified in `NO_PROXY`.  This is a fairly common convention, as described in #149746.

With this change, if the following env var is set:
```
NO_PROXY=192.168.0.0/16
```
the proxy will not be used for any IP address in that range (e.g. `192.168.4.4`).

# Caching

Since parsing `NO_PROXY` involves a non-trivial amount of string manipulation, object allocation, and attempts to parse, it turned out significantly more expensive for long `NO_PROXY` strings than I expected.  Since I would expect the environment to change very infrequently, I added a `lru_cache` around the repeated parsing of the same `NO_PROXY` string.  In the overwhelming majority of production instances, I would expect the size of the cache to sit at 1, and the number of cache hits to be high (e.g. one per request).

# Tightly coupled bug
Along the way, I discovered a bug in `urllib.parse.splitport`, which is deprecated but still used heavily internally:
```
>>> urllib.parse.splitport('::1')
<python-input-4>:1: DeprecationWarning: urllib.parse.splitport() is deprecated as of 3.8, use urllib.parse.urlparse() instead
(':', '1')
```
I tried to work around this issue throughout my PR, but it kept getting uglier and I decided to bundle the fix with this  change together.  If you'd like a different approach (e.g. 2 stacked PRs) just let me know and I'm happy to refactor.

# Existing Issue & PR

I foolishly wrote this PR before looking for existing issues (it started as a monkey-patch to fix an urgent issue in prod).  When I found the issue, I also found an existing PR #149744.

The big difference in our approach seems to be that I focused solely on the environment variable, and not on environment-specific settings.  It seems like Windows doesn't support CIDRs in the [registry value](https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-ie-clientnetworkprotocolimplementation-hklmproxyoverride), and I couldn't find a clear indicator that MacOS supports it either.

I went back and forth about posting this, but figured if its not helpful the close button is right there :).

# Final notes

This is my first attempt to upstream code to Python.  If I missed anything important or violated convention somewhere along the way, please let me know - I'm happy to amend my PR as needed.

<!-- gh-issue-number: gh-149746 -->
* Issue: gh-149746
<!-- /gh-issue-number -->
