### PR TITLE
gh-154923: Serialize Tcl interpreter creation in _tkinter

### DIFF
--- a/Lib/test/test_tcl.py
+++ b/Lib/test/test_tcl.py
@@ -5,6 +5,8 @@ import os
 from test import support
 from test.support import import_helper
 from test.support import os_helper
+from test.support import script_helper
+from test.support import threading_helper
 
 # Skip this test if the _tkinter module wasn't built.
 _tkinter = import_helper.import_module('_tkinter')
@@ -32,6 +34,40 @@ class TkinterTest(unittest.TestCase):
         # (issue44608: there were leaks in the following cases)
         self.assertRaises(TypeError, _tkinter._flatten, 'string')
         self.assertRaises(TypeError, _tkinter._flatten, {'set'})
+
+    @unittest.skipUnless(support.Py_GIL_DISABLED,
+                         "gh-154923 is a free-threading race")
+    @threading_helper.requires_working_threading()
+    def test_create_concurrent(self):
+        # Concurrent _tkinter.create() races Tcl's first-time library
+        # init and can double-free tcl_lock (gh-154923). Run in a
+        # subprocess so Tcl has not already been initialized.
+        script = """\
+import _tkinter
+import threading
+nthreads = 4
+rounds = 8
+start = threading.Barrier(nthreads)
+errors = []
+
+def worker():
+    try:
+        start.wait()
+        for _ in range(rounds):
+            app = _tkinter.create(None, '', 'Tk', False, 1, False, False, None)
+            del app
+    except Exception as e:
+        errors.append(repr(e))
+
+threads = [threading.Thread(target=worker) for _ in range(nthreads)]
+for t in threads:
+    t.start()
+for t in threads:
+    t.join()
+if errors:
+    raise SystemExit('\\n'.join(errors))
+"""
+        script_helper.assert_python_ok('-c', script, __isolated=False)
 
 
 class TclTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2026-08-25-09-15-00.gh-issue-154923.tKcr8Q.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-25-09-15-00.gh-issue-154923.tKcr8Q.rst
@@ -1,0 +1,2 @@
+Fix a data race when creating Tcl interpreters concurrently via
+``_tkinter.create()`` on the :term:`free-threaded build`.

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -291,12 +291,6 @@ Tkinter_TkInit(Tcl_Interp *interp)
 
 static PyThread_type_lock tcl_lock = 0;
 
-/* Serializes Tcl_CreateInterp() and the one-time tcl_lock free.
-   tcl_lock itself cannot be used for that: it is discarded once Tcl is
-   threaded, and Tcl's first CreateInterp lazily initializes process-wide
-   mutexes that are not safe to race (gh-154923). */
-static PyMutex tcl_create_mutex = {0};
-
 #ifdef TCL_THREADS
 static Tcl_ThreadDataKey state_key;
 #define tcl_tstate \
@@ -650,6 +644,7 @@ Tkapp_New(const char *screenName, const char *className,
        Tcl_MutexLock initializing a static mutex). Concurrent callers race
        that init under free-threading; two threads can also both free
        tcl_lock. Serialize both (gh-154923). */
+    static PyMutex tcl_create_mutex;
     PyMutex_Lock(&tcl_create_mutex);
     v->interp = Tcl_CreateInterp();
     v->wantobjects = wantobjects;

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -291,6 +291,12 @@ Tkinter_TkInit(Tcl_Interp *interp)
 
 static PyThread_type_lock tcl_lock = 0;
 
+/* Serializes Tcl_CreateInterp() and the one-time tcl_lock free.
+   tcl_lock itself cannot be used for that: it is discarded once Tcl is
+   threaded, and Tcl's first CreateInterp lazily initializes process-wide
+   mutexes that are not safe to race (gh-154923). */
+static PyMutex tcl_create_mutex = {0};
+
 #ifdef TCL_THREADS
 static Tcl_ThreadDataKey state_key;
 #define tcl_tstate \
@@ -640,6 +646,11 @@ Tkapp_New(const char *screenName, const char *className,
     if (v == NULL)
         return NULL;
 
+    /* Tcl's first CreateInterp() runs process-wide lazy init (including
+       Tcl_MutexLock initializing a static mutex). Concurrent callers race
+       that init under free-threading; two threads can also both free
+       tcl_lock. Serialize both (gh-154923). */
+    PyMutex_Lock(&tcl_create_mutex);
     v->interp = Tcl_CreateInterp();
     v->wantobjects = wantobjects;
 #if TCL_MAJOR_VERSION >= 9
@@ -654,6 +665,7 @@ Tkapp_New(const char *screenName, const char *className,
 
 #ifndef TCL_THREADS
     if (v->threaded) {
+        PyMutex_Unlock(&tcl_create_mutex);
         PyErr_SetString(PyExc_RuntimeError,
                         "Tcl is threaded but _tkinter is not");
         Py_DECREF(v);
@@ -665,6 +677,7 @@ Tkapp_New(const char *screenName, const char *className,
         PyThread_free_lock(tcl_lock);
         tcl_lock = NULL;
     }
+    PyMutex_Unlock(&tcl_create_mutex);
 
     v->OldBooleanType = Tcl_GetObjType("boolean");
     {


### PR DESCRIPTION
Fixes #154923

On the free-threaded build, concurrent `_tkinter.create()` calls raced Tcl's first-time library initialization (a TSan data race on a lazily created Tcl mutex) and could also double-free the module-global `tcl_lock`.

Serialize `Tcl_CreateInterp()` and the one-time `tcl_lock` free behind a dedicated mutex. `tcl_lock` itself cannot be used for this because it is discarded once Tcl is threaded. Add a subprocess regression test so the first `CreateInterp` has not already run.

This does not touch the `event_tstate` path in #153020.


<!-- gh-issue-number: gh-154923 -->
* Issue: gh-154923
<!-- /gh-issue-number -->