### PR TITLE
gh-156347: Fix the documentation of curses `window.encoding`

### DIFF
--- a/Doc/howto/curses.rst
+++ b/Doc/howto/curses.rst
@@ -298,8 +298,7 @@ the next subsection.
 The :meth:`~curses.window.addstr` method takes a Python string or
 bytestring as the value to be displayed.  The contents of bytestrings
 are sent to the terminal as-is.  Strings are encoded to bytes using
-the value of the window's :attr:`~window.encoding` attribute; this defaults to
-the default system encoding as returned by :func:`locale.getencoding`.
+the encoding of the current locale (see :func:`locale.getencoding`).
 
 The :meth:`~curses.window.addch` methods take a character, which can be
 either a string of length 1, a bytestring of length 1, or an integer.

--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -2002,7 +2002,11 @@ Other
 
 .. attribute:: window.encoding
 
-   Encoding used to encode method arguments (Unicode strings and characters).
+   Encoding used to encode and decode method arguments and results
+   (Unicode strings and characters) on a narrow build.  It is not used on a
+   build linked against a wide-character version of the underlying curses
+   library, where strings are passed to curses as wide characters and the
+   encoding of the current locale determines the bytes.
    The encoding attribute is inherited from the parent window when a subwindow
    is created, for example with :meth:`window.subwin`.
    By default, current locale encoding is used (see :func:`locale.getencoding`).


### PR DESCRIPTION
Reword the two places that describe `window.encoding` as encoding `str` arguments. On a wide build it is not used for that, so the HOWTO now names the encoding of the current locale, and the attribute's own entry scopes the claim to a narrow build and covers results as well as arguments.

Documentation only, so no NEWS fragment.

```
$ python -m sphinxlint Doc/howto/curses.rst Doc/library/curses.rst
No problems found.
```


<!-- gh-issue-number: gh-156347 -->
* Issue: gh-156347
<!-- /gh-issue-number -->
