### PR TITLE
fix(configparser): restore space delimiter splitting option/value

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -670,7 +670,27 @@ class RawConfigParser(MutableMapping):
             self._optcre = self.OPTCRE_NV if allow_no_value else self.OPTCRE
         else:
             d = "|".join(re.escape(d) for d in delimiters)
-            if allow_no_value:
+            if any(dl.strip() == "" for dl in delimiters):
+                if allow_no_value:
+                    self._optcre = re.compile(
+                        r"""
+                        (?P<option>
+                            (?:(?!{delim})\S)+
+                        )
+                        \s*(?:
+                        (?P<vi>{delim})\s*
+                        (?P<value>.*))?$
+                        """.format(delim=d), re.VERBOSE)
+                else:
+                    self._optcre = re.compile(
+                        r"""
+                        (?P<option>
+                            (?:(?!{delim})\S)+
+                        )
+                        \s*(?P<vi>{delim})\s*
+                        (?P<value>.*)$
+                        """.format(delim=d), re.VERBOSE)
+            elif allow_no_value:
                 self._optcre = re.compile(self._OPT_NV_TMPL.format(delim=d),
                                           re.VERBOSE)
             else:

--- a/Misc/NEWS.d/next/Library/2026-08-25-22-13-36.gh-issue-156375.lB0UXs.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-25-22-13-36.gh-issue-156375.lB0UXs.rst
@@ -1,0 +1,3 @@
+Fix regression in :mod:`configparser` where using a space as a delimiter
+no longer split option and value correctly. Parsing ``"foo bar=baz"`` with
+``delimiters=(' ', '=')`` now correctly yields option ``"foo"``.


### PR DESCRIPTION
Fixes regression where space delimiter no longer splits option/value.

Bug: with delimiters=(' ', '=') parsing "foo bar=baz" yields option "foo bar" instead of "foo". The new regex from PR 146399 greedily consumes \s+word as part of option.

Fix: detect whitespace delimiters and use single-token option pattern for that case, preserving ReDoS protection for normal delimiters while restoring correct split. Multi-word options still work when delimiter is "=" or ":".

Evidence: RED->GREEN verified: before fix "foo bar=baz" -> option "foo bar", after fix -> option "foo", value "bar=baz". Normal case "foo bar = baz" with (=,:) still yields "foo bar".

Written in conjunction with my pair programmer Claude.