### PR TITLE
gh-156353: Fix configparser space delimiter parsing

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -618,7 +618,8 @@ class RawConfigParser(MutableMapping):
     _OPT_TMPL = r"""
         (?P<option>                        # very permissive!
             (?:(?!{delim})\S)*             # non-delimiter non-whitespace
-            (?:(?:(?!{delim})\s)+(?:(?!{delim})\S)+)*)    # optionally more words
+            (?:(?:(?!{delim})\s)+          # optionally more
+             (?:(?!{delim})\S)+)*)         #   space-separated words
         \s*(?P<vi>{delim})\s*              # any number of space/tab,
                                            # followed by any of the
                                            # allowed delimiters,
@@ -628,7 +629,8 @@ class RawConfigParser(MutableMapping):
     _OPT_NV_TMPL = r"""
         (?P<option>                        # very permissive!
             (?:(?!{delim})\S)*             # non-delimiter non-whitespace
-            (?:(?:(?!{delim})\s)+(?:(?!{delim})\S)+)*)    # optionally more words
+            (?:(?:(?!{delim})\s)+          # optionally more
+             (?:(?!{delim})\S)+)*)         #   space-separated words
         \s*(?:                             # any number of space/tab,
         (?P<vi>{delim})\s*                 # optionally followed by
                                            # any of the allowed

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -618,7 +618,7 @@ class RawConfigParser(MutableMapping):
     _OPT_TMPL = r"""
         (?P<option>                        # very permissive!
             (?:(?!{delim})\S)*             # non-delimiter non-whitespace
-            (?:\s+(?:(?!{delim})\S)+)*)    # optionally more words
+            (?:(?:(?!{delim})\s)+(?:(?!{delim})\S)+)*)    # optionally more words
         \s*(?P<vi>{delim})\s*              # any number of space/tab,
                                            # followed by any of the
                                            # allowed delimiters,
@@ -628,7 +628,7 @@ class RawConfigParser(MutableMapping):
     _OPT_NV_TMPL = r"""
         (?P<option>                        # very permissive!
             (?:(?!{delim})\S)*             # non-delimiter non-whitespace
-            (?:\s+(?:(?!{delim})\S)+)*)    # optionally more words
+            (?:(?:(?!{delim})\s)+(?:(?!{delim})\S)+)*)    # optionally more words
         \s*(?:                             # any number of space/tab,
         (?P<vi>{delim})\s*                 # optionally followed by
                                            # any of the allowed

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -359,10 +359,29 @@ boolean {0[0]} NO
                 the larch {0[1]} 1
             """.format(self.delimiters)))
 
-    def test_space_delimiter(self):
+    @support.subTests('data', [
+        'foo bar=baz',
+        'foo   bar=baz',
+        'foo=bar=baz',
+        'foo = bar=baz',
+        'foo\t \t=\t \tbar=baz',
+    ])
+    def test_space_delimiter(self, data):
         # gh-156353: Space should be accepted as a delimiter
         cf = self.newconfig(delimiters=(' ', '='))
-        cf.read_string("[all]\nfoo bar=baz")
+        cf.read_string(f"[all]\n{data}")
+        self.assertEqual(cf.options('all'), ['foo'])
+        self.assertEqual(cf.get('all', 'foo'), 'bar=baz')
+
+    @support.subTests('delimiter', ' =:;#x\t\0\N{RS}\N{CEDILLA}\N{CAT}')
+    @support.subTests('space_before', ['', ' ', '\t', ' \t'])
+    @support.subTests('space_after', ['', ' ', '\t', ' \t'])
+    def test_any_delimiter(self, delimiter, space_before, space_after):
+        cf = self.newconfig(
+            delimiters=(delimiter,),
+            inline_comment_prefixes=None,
+        )
+        cf.read_string(f"[all]\nfoo{space_before}{delimiter}{space_after}bar=baz")
         self.assertEqual(cf.options('all'), ['foo'])
         self.assertEqual(cf.get('all', 'foo'), 'bar=baz')
 

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -43,7 +43,7 @@ class CfgParserTestCaseClass:
     default_section = configparser.DEFAULTSECT
     interpolation = configparser._UNSET
 
-    def newconfig(self, defaults=None):
+    def newconfig(self, defaults=None, **kwargs):
         arguments = dict(
             defaults=defaults,
             allow_no_value=self.allow_no_value,
@@ -56,6 +56,7 @@ class CfgParserTestCaseClass:
             default_section=self.default_section,
             interpolation=self.interpolation,
         )
+        arguments.update(kwargs)
         instance = self.config_class(**arguments)
         return instance
 
@@ -1998,8 +1999,8 @@ class ConvertersTestCase(BasicTestCase, unittest.TestCase):
 
     config_class = configparser.ConfigParser
 
-    def newconfig(self, defaults=None):
-        instance = super().newconfig(defaults=defaults)
+    def newconfig(self, defaults=None, **kwargs):
+        instance = super().newconfig(defaults=defaults, **kwargs)
         instance.converters['list'] = lambda v: [e.strip() for e in v.split()
                                                  if e.strip()]
         return instance

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -358,6 +358,13 @@ boolean {0[0]} NO
                 the larch {0[1]} 1
             """.format(self.delimiters)))
 
+    def test_space_delimiter(self):
+        # gh-156353: Space should be accepted as a delimiter
+        cf = self.newconfig(delimiters=(' ', '='))
+        cf.read_string("[all]\nfoo bar=baz")
+        self.assertEqual(cf.options('all'), ['foo'])
+        self.assertEqual(cf.get('all', 'foo'), 'bar=baz')
+
     def test_basic_from_dict(self):
         config = {
             "Foo Bar": {

--- a/Misc/NEWS.d/next/Library/2026-08-26-02-30-00.gh-issue-156353.abcdef.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-26-02-30-00.gh-issue-156353.abcdef.rst
@@ -1,0 +1,1 @@
+Fix :mod:`configparser` space delimiter parsing when using ``delimiters=(' ', '=')``.

--- a/Misc/NEWS.d/next/Library/2026-08-26-02-30-00.gh-issue-156353.abcdef.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-26-02-30-00.gh-issue-156353.abcdef.rst
@@ -1,1 +1,1 @@
-Fix :mod:`configparser` space delimiter parsing when using ``delimiters=(' ', '=')``.
+Fix :mod:`configparser` parsing when using whitespace in *delimiters*.


### PR DESCRIPTION
## Problem
Between Python 3.14.4 and 3.14.5 (and similarly in 3.13), `configparser` stopped recognizing a space as a delimiter when `delimiters=(' ', '=')` was used. This regression was caused by gh-146333 which addressed a ReDoS vulnerability in the option parsing regex but inadvertently allowed the greedy `\s+` inside the option name group to consume whitespace characters even if they were valid delimiters.

## Solution
This PR adjusts `_OPT_TMPL` and `_OPT_NV_TMPL` to explicitly ensure that any whitespace character consumed as part of the option name is NOT a valid delimiter (`(?:(?!{delim})\s)+`).

This retains the catastrophic backtracking protection introduced in gh-146333 (the mutually exclusive possessive-like parsing structure remains intact) while restoring the ability to use spaces as delimiters.

* Issue: gh-156353