### PR TITLE
[3.13] gh-156369: Update CI to use latest SSL library versions (GH-156381)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -303,7 +303,7 @@ jobs:
         # Keep 1.1.1w in our list despite it being upstream EOL and otherwise
         # unsupported as it most resembles other 1.1.1-work-a-like ssl APIs
         # supported by important vendors such as AWS-LC.
-        openssl_ver: [1.1.1w, 3.0.21, 3.4.6, 3.5.7, 3.6.3]
+        openssl_ver: [1.1.1w, 3.0.22, 3.4.7, 3.5.8, 3.6.4]
         # See Tools/ssl/make_ssl_data.py for notes on adding a new version
     env:
       OPENSSL_VER: ${{ matrix.openssl_ver }}
@@ -378,7 +378,7 @@ jobs:
     needs: build-context
     if: needs.build-context.outputs.run-ubuntu == 'true'
     env:
-      OPENSSL_VER: 3.0.21
+      OPENSSL_VER: 3.0.22
       PYTHONSTRICTEXTENSIONBUILD: 1
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -485,7 +485,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
     env:
-      OPENSSL_VER: 3.0.21
+      OPENSSL_VER: 3.0.22
       PYTHONSTRICTEXTENSIONBUILD: 1
       ASAN_OPTIONS: detect_leaks=0:allocator_may_return_null=1:handle_segv=0
     steps:

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
     env:
-      OPENSSL_VER: 3.0.21
+      OPENSSL_VER: 3.0.22
       PYTHONSTRICTEXTENSIONBUILD: 1
       TERM: linux
     steps:

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -50,10 +50,10 @@ OPENSSL_OLD_VERSIONS = [
 ]
 
 OPENSSL_RECENT_VERSIONS = [
-    "3.0.21",
-    "3.4.6",
-    "3.5.7",
-    "3.6.3",
+    "3.0.22",
+    "3.4.7",
+    "3.5.8",
+    "3.6.4",
     # See make_ssl_data.py for notes on adding a new version.
 ]
 


### PR DESCRIPTION
(cherry picked from commit 369f04a1bcc26ddd05e2910d32d7008132b81a3c)

<!-- gh-issue-number: gh-156369 -->
* Issue: gh-156369
<!-- /gh-issue-number -->
