### PR TITLE
gh-156400: Close the socket or pipe when transport creation fails in asyncio datagram/pipe endpoints

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1499,13 +1499,13 @@ class BaseEventLoop(events.AbstractEventLoop):
 
         try:
             protocol = protocol_factory()
-            waiter = self.create_future()
-            transport = self._make_datagram_transport(
-                sock, protocol, r_addr, waiter)
         except:
-            # gh-156400: close the socket if the transport is never created.
+            # gh-156400: no transport owns the socket yet, so close it.
             sock.close()
             raise
+        waiter = self.create_future()
+        transport = self._make_datagram_transport(
+            sock, protocol, r_addr, waiter)
         if self._debug:
             if local_addr:
                 logger.info("Datagram endpoint local_addr=%r remote_addr=%r "
@@ -1721,12 +1721,12 @@ class BaseEventLoop(events.AbstractEventLoop):
     async def connect_read_pipe(self, protocol_factory, pipe):
         try:
             protocol = protocol_factory()
-            waiter = self.create_future()
-            transport = self._make_read_pipe_transport(pipe, protocol, waiter)
         except:
-            # gh-156400: close the pipe if the transport is never created.
+            # gh-156400: no transport owns the pipe yet, so close it.
             pipe.close()
             raise
+        waiter = self.create_future()
+        transport = self._make_read_pipe_transport(pipe, protocol, waiter)
 
         try:
             await waiter
@@ -1742,12 +1742,12 @@ class BaseEventLoop(events.AbstractEventLoop):
     async def connect_write_pipe(self, protocol_factory, pipe):
         try:
             protocol = protocol_factory()
-            waiter = self.create_future()
-            transport = self._make_write_pipe_transport(pipe, protocol, waiter)
         except:
-            # gh-156400: close the pipe if the transport is never created.
+            # gh-156400: no transport owns the pipe yet, so close it.
             pipe.close()
             raise
+        waiter = self.create_future()
+        transport = self._make_write_pipe_transport(pipe, protocol, waiter)
 
         try:
             await waiter

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1497,10 +1497,15 @@ class BaseEventLoop(events.AbstractEventLoop):
             else:
                 raise exceptions[0]
 
-        protocol = protocol_factory()
-        waiter = self.create_future()
-        transport = self._make_datagram_transport(
-            sock, protocol, r_addr, waiter)
+        try:
+            protocol = protocol_factory()
+            waiter = self.create_future()
+            transport = self._make_datagram_transport(
+                sock, protocol, r_addr, waiter)
+        except:
+            # gh-156400: close the socket if the transport is never created.
+            sock.close()
+            raise
         if self._debug:
             if local_addr:
                 logger.info("Datagram endpoint local_addr=%r remote_addr=%r "
@@ -1714,9 +1719,14 @@ class BaseEventLoop(events.AbstractEventLoop):
         return transport, protocol
 
     async def connect_read_pipe(self, protocol_factory, pipe):
-        protocol = protocol_factory()
-        waiter = self.create_future()
-        transport = self._make_read_pipe_transport(pipe, protocol, waiter)
+        try:
+            protocol = protocol_factory()
+            waiter = self.create_future()
+            transport = self._make_read_pipe_transport(pipe, protocol, waiter)
+        except:
+            # gh-156400: close the pipe if the transport is never created.
+            pipe.close()
+            raise
 
         try:
             await waiter
@@ -1730,9 +1740,14 @@ class BaseEventLoop(events.AbstractEventLoop):
         return transport, protocol
 
     async def connect_write_pipe(self, protocol_factory, pipe):
-        protocol = protocol_factory()
-        waiter = self.create_future()
-        transport = self._make_write_pipe_transport(pipe, protocol, waiter)
+        try:
+            protocol = protocol_factory()
+            waiter = self.create_future()
+            transport = self._make_write_pipe_transport(pipe, protocol, waiter)
+        except:
+            # gh-156400: close the pipe if the transport is never created.
+            pipe.close()
+            raise
 
         try:
             await waiter

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -2041,6 +2041,43 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         self.loop.run_until_complete(protocol.done)
         self.assertEqual('CLOSED', protocol.state)
 
+    def test_create_datagram_endpoint_transport_error_closes_sock(self):
+        # gh-156400: the socket is closed if the transport is never created.
+        sock = mock.Mock()
+        sock.type = socket.SOCK_DGRAM
+
+        def factory():
+            raise ZeroDivisionError
+
+        coro = self.loop.create_datagram_endpoint(factory, sock=sock)
+        with self.assertRaises(ZeroDivisionError):
+            self.loop.run_until_complete(coro)
+        self.assertTrue(sock.close.called)
+
+    def test_connect_read_pipe_transport_error_closes_pipe(self):
+        # gh-156400: the pipe is closed if the transport is never created.
+        pipe = mock.Mock()
+
+        def factory():
+            raise ZeroDivisionError
+
+        coro = self.loop.connect_read_pipe(factory, pipe)
+        with self.assertRaises(ZeroDivisionError):
+            self.loop.run_until_complete(coro)
+        self.assertTrue(pipe.close.called)
+
+    def test_connect_write_pipe_transport_error_closes_pipe(self):
+        # gh-156400: the pipe is closed if the transport is never created.
+        pipe = mock.Mock()
+
+        def factory():
+            raise ZeroDivisionError
+
+        coro = self.loop.connect_write_pipe(factory, pipe)
+        with self.assertRaises(ZeroDivisionError):
+            self.loop.run_until_complete(coro)
+        self.assertTrue(pipe.close.called)
+
     @unittest.skipUnless(hasattr(socket, 'AF_UNIX'), 'No UNIX Sockets')
     def test_create_datagram_endpoint_sock_unix(self):
         fut = self.loop.create_datagram_endpoint(

--- a/Misc/NEWS.d/next/Library/2026-08-26-13-58-01.gh-issue-156400.dGrmP1.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-26-13-58-01.gh-issue-156400.dGrmP1.rst
@@ -1,0 +1,6 @@
+Fix socket and pipe leaks in :mod:`asyncio` when ``protocol_factory()`` or
+transport creation fails in :meth:`loop.create_datagram_endpoint
+<asyncio.loop.create_datagram_endpoint>`, :meth:`loop.connect_read_pipe
+<asyncio.loop.connect_read_pipe>`, and :meth:`loop.connect_write_pipe
+<asyncio.loop.connect_write_pipe>`. The socket or pipe is now closed instead
+of leaking until garbage collection.

--- a/Misc/NEWS.d/next/Library/2026-08-26-13-58-01.gh-issue-156400.dGrmP1.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-26-13-58-01.gh-issue-156400.dGrmP1.rst
@@ -1,5 +1,5 @@
-Fix socket and pipe leaks in :mod:`asyncio` when ``protocol_factory()`` or
-transport creation fails in :meth:`loop.create_datagram_endpoint
+Fix socket and pipe leaks in :mod:`asyncio` when ``protocol_factory()`` raises
+in :meth:`loop.create_datagram_endpoint
 <asyncio.loop.create_datagram_endpoint>`, :meth:`loop.connect_read_pipe
 <asyncio.loop.connect_read_pipe>`, and :meth:`loop.connect_write_pipe
 <asyncio.loop.connect_write_pipe>`. The socket or pipe is now closed instead


### PR DESCRIPTION
`create_datagram_endpoint()`, `connect_read_pipe()` and `connect_write_pipe()` create or take ownership of a socket/pipe and then run `protocol_factory()` and transport creation. The only cleanup (`except: transport.close()`) covers `await waiter`, so if `protocol_factory()` or `_make_*_transport()` raises the resource is never closed and leaks until garbage collection.

Close the socket/pipe on that path, matching the `create_connection()` fix in gh-153133. The added regression tests fail without the fix and pass with it; the full `test_asyncio` suite passes.


<!-- gh-issue-number: gh-156400 -->
* Issue: gh-156400
<!-- /gh-issue-number -->
