### PR TITLE
gh-156703: Set LD_LIBRARY_PATH in SystemTap trace commands

### DIFF
--- a/Lib/test/test_dtrace.py
+++ b/Lib/test/test_dtrace.py
@@ -229,6 +229,17 @@ class SystemTapBackend(TraceBackend):
 
         return script.replace(self.PROBE_PLACEHOLDER, self.python_probe())
 
+    def generate_trace_command(self, script_file, subcommand=None):
+        probe_binary = get_probe_binary()
+        if subcommand and probe_binary != sys.executable:
+            library_path = os.path.dirname(probe_binary)
+            if existing_path := os.environ.get("LD_LIBRARY_PATH"):
+                library_path = os.pathsep.join((library_path, existing_path))
+            env = shlex.join(["env", f"LD_LIBRARY_PATH={library_path}"])
+            subcommand = f"{env} {subcommand}"
+
+        return super().generate_trace_command(script_file, subcommand)
+
     def trace(self, script_file, subcommand=None, *, timeout=None,
               check_returncode=False):
         with tempfile.NamedTemporaryFile(


### PR DESCRIPTION
Prefix commands passed to stap -c with LD_LIBRARY_PATH via env, when probes reside in libpython. This allows the interpreter to find libpython when staprun does not preserve the loader path.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156703 -->
* Issue: gh-156703
<!-- /gh-issue-number -->
