### PR TITLE
[3.14] Docs(build): linklint is now called sphinx_linklint (GH-156373)

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -40,7 +40,7 @@ extensions = [
 
 # Skip if downstream redistributors haven't installed them
 _OPTIONAL_EXTENSIONS = (
-    'linklint.ext',
+    'sphinx_linklint.ext',
     'notfound.extension',
     'sphinxext.opengraph',
     'sphinxcontrib.rsvgconverter',

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -11,13 +11,12 @@ sphinx<9.0.0
 
 blurb
 
-sphinxext-opengraph~=0.13.0
+sphinx-linklint
 sphinx-notfound-page~=1.0.0
+sphinxext-opengraph~=0.13.0
 
 # The theme used by the documentation is stored separately, so we need
 # to install that as well.
 python-docs-theme>=2023.3.1,!=2023.7
-
-linklint
 
 -c constraints.txt


### PR DESCRIPTION
* Docs(build): linklint is now called sphinx_linklint


---------
(cherry picked from commit 98bd716479dacb1e618a4271df10b2b67c010c4c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
