### PR TITLE
[3.13] gh-156369: Bump OpenSSL version for Android

### DIFF
--- a/Android/android.py
+++ b/Android/android.py
@@ -221,7 +221,7 @@ def unpack_deps(host, prefix_dir, cache_dir):
     for name_ver in [
         "bzip2-1.0.8-3",
         "libffi-3.4.4-3",
-        "openssl-3.0.21-0",
+        "openssl-3.0.22-0",
         "sqlite-3.50.4-0",
         "xz-5.4.6-1"
     ]:

--- a/Misc/NEWS.d/next/Build/2026-08-26-16-10-15.gh-issue-156369.55jGEj.rst
+++ b/Misc/NEWS.d/next/Build/2026-08-26-16-10-15.gh-issue-156369.55jGEj.rst
@@ -1,0 +1,1 @@
+Update Android build script to use OpenSSL 3.0.22.


### PR DESCRIPTION


<!-- gh-issue-number: gh-156369 -->
* Issue: gh-156369
<!-- /gh-issue-number -->
