### PR TITLE
gh-156434: Restore entry offsets when `repack()` fails

### DIFF
--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -2662,6 +2662,49 @@ class OtherRepackTests(unittest.TestCase):
         fz.seek(0)
         self.assertEqual(fz.read(), expected)
 
+    def test_repack_failed_write_restores_header_offsets(self):
+        # A failed repack() must leave the in-memory offsets describing the
+        # file that is actually on disk, so that a later close() does not
+        # commit a central directory pointing at data that was never written.
+        class FlakyBytesIO(io.BytesIO):
+            countdown = None
+
+            def write(self, data):
+                if self.countdown is not None:
+                    self.countdown -= 1
+                    if self.countdown < 0:
+                        raise OSError(errno.ENOSPC, 'No space left on device')
+                return super().write(data)
+
+        names = ['a.txt', 'b.txt', 'c.txt', 'd.txt']
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, 'w') as zh:
+            for name in names:
+                zh.writestr(name, name[0].upper().encode() * 5000)
+
+        fz = FlakyBytesIO(buf.getvalue())
+        with zipfile.ZipFile(fz, 'a') as zh:
+            zi = zh.remove('b.txt')
+            expected = [z.header_offset for z in zh.infolist()]
+            expected_removed = zi.header_offset
+
+            fz.countdown = 1
+            with self.assertRaises(OSError):
+                zh.repack([zi], chunk_size=4096)
+
+            self.assertEqual([z.header_offset for z in zh.infolist()], expected)
+            self.assertEqual(zi.header_offset, expected_removed)
+
+            # The archive is still usable once the write error clears.
+            fz.countdown = None
+
+        fz.seek(0)
+        with zipfile.ZipFile(fz) as zh:
+            self.assertIsNone(zh.testzip())
+            self.assertEqual(zh.namelist(), ['a.txt', 'c.txt', 'd.txt'])
+            for name in zh.namelist():
+                self.assertEqual(zh.read(name), name[0].upper().encode() * 5000)
+
 class ZipRepackerTests(unittest.TestCase):
     def _generate_local_file_entry(self, arcname, raw_bytes,
                                    compression=zipfile.ZIP_STORED,

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -2662,6 +2662,24 @@ class OtherRepackTests(unittest.TestCase):
         fz.seek(0)
         self.assertEqual(fz.read(), expected)
 
+    def test_repack_removed_iterator(self):
+        # A one-shot iterable of removed entries must still be repacked.
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, 'w') as zh:
+            for name in ['a.txt', 'b.txt', 'c.txt']:
+                zh.writestr(name, name[0].upper().encode() * 5000)
+        full_size = len(buf.getvalue())
+
+        fz = io.BytesIO(buf.getvalue())
+        with zipfile.ZipFile(fz, 'a') as zh:
+            zh.repack(iter([zh.remove('b.txt')]))
+
+        self.assertLess(len(fz.getvalue()), full_size - 5000)
+        fz.seek(0)
+        with zipfile.ZipFile(fz) as zh:
+            self.assertIsNone(zh.testzip())
+            self.assertEqual(zh.namelist(), ['a.txt', 'c.txt'])
+
     def test_repack_failed_write_restores_header_offsets(self):
         # A failed repack() must leave the in-memory offsets describing the
         # file that is actually on disk, so that a later close() does not

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -2434,6 +2434,11 @@ class ZipFile:
                 )
 
             self._writing = True
+            # *removed* is read twice below, so a one-shot iterable must not
+            # be consumed by the first read.  None (scan the archive) is not
+            # the same as an empty sequence, so keep it as is.
+            if removed is not None:
+                removed = list(removed)
             header_offsets = [(zinfo, zinfo.header_offset)
                               for zinfo in (*self.filelist, *(removed or ()))]
             try:

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -2434,12 +2434,18 @@ class ZipFile:
                 )
 
             self._writing = True
+            header_offsets = [(zinfo, zinfo.header_offset)
+                              for zinfo in (*self.filelist, *(removed or ()))]
             try:
                 repacker = _ZipRepacker(
                     strict_descriptor=strict_descriptor,
                     chunk_size=chunk_size,
                 )
                 repacker.repack(self, removed)
+            except BaseException:
+                for zinfo, header_offset in header_offsets:
+                    zinfo.header_offset = header_offset
+                raise
             finally:
                 self._writing = False
 


### PR DESCRIPTION
`ZipFile.repack()` now saves the `header_offset` of every entry it hands to the repacker, including the removed ones, and restores them if the repack raises. A failed move no longer leaves the in-memory offsets describing a layout that was never written, so a later `close()` no longer commits it.

```
$ ./python -m test test_zipfile -m test_repack_failed_write_restores_header_offsets -v
test_repack_failed_write_restores_header_offsets (test.test_zipfile.test_core.OtherRepackTests.test_repack_failed_write_restores_header_offsets) ... ok
Total tests: run=1 (filtered)
Result: SUCCESS

$ ./python -m test test_zipfile
Total tests: run=601 skipped=3
Result: SUCCESS
```

No changelog entry: `remove()` and `repack()` are new in 3.16 and have not been released, so this belongs with the original entry for gh-51067.


<!-- gh-issue-number: gh-156434 -->
* Issue: gh-156434
<!-- /gh-issue-number -->
