### PR TITLE
[3.14] gh-156369: Bump OpenSSL versions for iOS and Android (GH-156432)

### DIFF
--- a/Android/android.py
+++ b/Android/android.py
@@ -221,7 +221,7 @@ def unpack_deps(host, prefix_dir, cache_dir):
     for name_ver in [
         "bzip2-1.0.8-3",
         "libffi-3.4.4-3",
-        "openssl-3.5.7-0",
+        "openssl-3.5.8-0",
         "sqlite-3.50.4-0",
         "xz-5.4.6-1",
         "zstd-1.5.7-2"

--- a/Apple/__main__.py
+++ b/Apple/__main__.py
@@ -328,7 +328,7 @@ def unpack_deps(
     for name_ver in [
         "BZip2-1.0.8-2",
         "libFFI-3.4.7-2",
-        "OpenSSL-3.5.7-1",
+        "OpenSSL-3.5.8-1",
         "XZ-5.6.4-2",
         "mpdecimal-4.0.0-2",
         "zstd-1.5.7-1",

--- a/Misc/NEWS.d/next/Build/2026-08-26-16-10-15.gh-issue-156369.55jGEj.rst
+++ b/Misc/NEWS.d/next/Build/2026-08-26-16-10-15.gh-issue-156369.55jGEj.rst
@@ -1,0 +1,1 @@
+Update Android and iOS build scripts to use OpenSSL 3.5.8.


### PR DESCRIPTION
(cherry picked from commit fe3a26f43fad1d6eed20172d7f63ee2931ae2ce1)

<!-- gh-issue-number: gh-156369 -->
* Issue: gh-156369
<!-- /gh-issue-number -->
