### PR TITLE
gh-109714: Omit redundant arguments when raising OSError subclasses

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1325,8 +1325,8 @@ class BufferedWriter(_BufferedIOMixin):
                                    "should not raise BlockingIOError")
             if n is None:
                 raise BlockingIOError(
-                    errno.EAGAIN,
-                    "write could not complete without blocking", 0)
+                    "write could not complete without blocking",
+                    characters_written=0)
             if n > len(self._write_buf) or n < 0:
                 raise OSError("write() returned incorrect number of bytes")
             del self._write_buf[:n]
@@ -1629,8 +1629,7 @@ class FileIO(RawIOBase):
             self._stat_atopen = os.fstat(fd)
             try:
                 if stat.S_ISDIR(self._stat_atopen.st_mode):
-                    raise IsADirectoryError(errno.EISDIR,
-                                            os.strerror(errno.EISDIR), file)
+                    raise IsADirectoryError(filename=file)
             except AttributeError:
                 # Ignore the AttributeError if stat.S_ISDIR or errno.EISDIR
                 # don't exist.

--- a/Lib/_pyrepl/terminfo.py
+++ b/Lib/_pyrepl/terminfo.py
@@ -1,7 +1,6 @@
 """Pure Python curses-like terminal capability queries."""
 
 from dataclasses import dataclass, field
-import errno
 import os
 from pathlib import Path
 import re
@@ -151,7 +150,7 @@ def _read_terminfo_file(terminal_name: str) -> bytes:
         if path.is_file():
             return path.read_bytes()
 
-    raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), filename)
+    raise FileNotFoundError(filename=filename)
 
 
 # Hard-coded terminal capabilities for common terminals

--- a/Lib/multiprocessing/shared_memory.py
+++ b/Lib/multiprocessing/shared_memory.py
@@ -11,7 +11,6 @@ __all__ = [ 'SharedMemory', 'ShareableList' ]
 from functools import partial
 import mmap
 import os
-import errno
 import struct
 import secrets
 import types
@@ -143,10 +142,8 @@ class SharedMemory:
                         if last_error_code == _winapi.ERROR_ALREADY_EXISTS:
                             if name is not None:
                                 raise FileExistsError(
-                                    errno.EEXIST,
-                                    os.strerror(errno.EEXIST),
-                                    name,
-                                    _winapi.ERROR_ALREADY_EXISTS
+                                    filename=name,
+                                    winerror=_winapi.ERROR_ALREADY_EXISTS
                                 )
                             else:
                                 continue

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1245,7 +1245,7 @@ def make_archive(base_name, format, root_dir=None, base_dir=None, verbose=0,
         root_dir = os.fspath(root_dir)
         stmd = os.stat(root_dir).st_mode
         if not stat.S_ISDIR(stmd):
-            raise NotADirectoryError(errno.ENOTDIR, 'Not a directory', root_dir)
+            raise NotADirectoryError(filename=root_dir)
 
         if supports_root_dir:
             kwargs['root_dir'] = root_dir


### PR DESCRIPTION
Depends on #156430, which makes the `OSError` constructor default *errno* to the error code of the exception class and derive *strerror* from it.

With that in place, passing them explicitly adds nothing:

* `_pyio` and `_pyrepl.terminfo` drop *errno* and `os.strerror(errno)`, which is exactly what the constructor derives.
* `_pyio` also passes the number of characters written as the *characters_written* keyword argument, because without *errno* the third positional argument would be the file name.
* `multiprocessing.shared_memory` passes only the Windows error code, from which both *errno* and *strerror* are derived.
* `shutil` drops the message which merely repeated `os.strerror(ENOTDIR)`.


<!-- gh-issue-number: gh-109714 -->
* Issue: gh-109714
<!-- /gh-issue-number -->
