### PR TITLE
gh-156369: Update macOS installer to use OpenSSL 3.5.8.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -246,9 +246,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 3.5.7",
-              url="https://github.com/openssl/openssl/releases/download/openssl-3.5.7/openssl-3.5.7.tar.gz",
-              checksum="a8c0d28a529ca480f9f36cf5792e2cd21984552a3c8e4aa11a24aa31aeac98e8",
+              name="OpenSSL 3.5.8",
+              url="https://github.com/openssl/openssl/releases/download/openssl-3.5.8/openssl-3.5.8.tar.gz",
+              checksum="a8f84a39918ec6415ce765d9b429d313ba97b8143169c172e734b9514464f5b2",
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/macOS/2026-08-27-03-19-21.gh-issue-156369.FKlSGY.rst
+++ b/Misc/NEWS.d/next/macOS/2026-08-27-03-19-21.gh-issue-156369.FKlSGY.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use OpenSSL 3.5.8.


### PR DESCRIPTION


<!-- gh-issue-number: gh-156369 -->
* Issue: gh-156369
<!-- /gh-issue-number -->
