### PR TITLE
gh-156413: Let a `None`-valued non-callable member keep the Protocol fast path

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3894,22 +3894,32 @@ class ProtocolTests(BaseTestCase):
         # class out of ABCMeta's cache and made every isinstance() call walk
         # all of the protocol members again.
         @runtime_checkable
-        class P(Protocol):
+        class PAttr(Protocol):
             x = 1
+
+        @runtime_checkable
+        class PProperty(Protocol):
+            @property
+            def x(self) -> int: ...
 
         class B:
             x = None
 
-        self.assertIsInstance(B(), P)
-
-        # The first check must have cached B as a subclass of P, so the second
-        # one may not touch the members at all.
-        typing._lazy_load_getattr_static.cache_clear()
-        try:
-            with patch.object(inspect, "getattr_static", side_effect=AssertionError):
+        for P in (PAttr, PProperty):
+            with self.subTest(protocol=P.__name__):
+                self.assertIn("x", P.__non_callable_proto_members__)
                 self.assertIsInstance(B(), P)
-        finally:
-            typing._lazy_load_getattr_static.cache_clear()
+
+                # The first check must have cached B as a subclass of P, so
+                # the second one may not touch the members at all.
+                typing._lazy_load_getattr_static.cache_clear()
+                try:
+                    with patch.object(
+                        inspect, "getattr_static", side_effect=AssertionError
+                    ):
+                        self.assertIsInstance(B(), P)
+                finally:
+                    typing._lazy_load_getattr_static.cache_clear()
 
     def test_none_on_callable_blocks_implementation(self):
         @runtime_checkable

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3888,6 +3888,29 @@ class ProtocolTests(BaseTestCase):
         self.assertIsInstance(B(), P)
         self.assertIsInstance(C(), P)
 
+    def test_none_on_non_callable_doesnt_defeat_the_abc_cache(self):
+        # gh-156413: a None-valued non-callable member used to be rejected by
+        # _proto_hook even though __instancecheck__ accepts it, which kept the
+        # class out of ABCMeta's cache and made every isinstance() call walk
+        # all of the protocol members again.
+        @runtime_checkable
+        class P(Protocol):
+            x = 1
+
+        class B:
+            x = None
+
+        self.assertIsInstance(B(), P)
+
+        # The first check must have cached B as a subclass of P, so the second
+        # one may not touch the members at all.
+        typing._lazy_load_getattr_static.cache_clear()
+        try:
+            with patch.object(inspect, "getattr_static", side_effect=AssertionError):
+                self.assertIsInstance(B(), P)
+        finally:
+            typing._lazy_load_getattr_static.cache_clear()
+
     def test_none_on_callable_blocks_implementation(self):
         @runtime_checkable
         class P(Protocol):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2127,11 +2127,15 @@ def _proto_hook(cls, other):
     if not cls.__dict__.get('_is_protocol', False):
         return NotImplemented
 
+    # Setting a member to None only means "explicitly not implemented" for
+    # *callable* members; this mirrors _ProtocolMeta.__instancecheck__.
+    non_callable_members = cls.__dict__.get('__non_callable_proto_members__') or ()
     for attr in cls.__protocol_attrs__:
         for base in other.__mro__:
             # Check if the members appears in the class dictionary...
             if attr in base.__dict__:
-                if base.__dict__[attr] is None:
+                if (base.__dict__[attr] is None
+                        and attr not in non_callable_members):
                     return NotImplemented
                 break
 

--- a/Misc/NEWS.d/next/Library/2026-08-27-09-40-00.gh-issue-156413.Kq7Xm2.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-27-09-40-00.gh-issue-156413.Kq7Xm2.rst
@@ -1,0 +1,5 @@
+Make :func:`isinstance` checks against a :func:`runtime-checkable
+<typing.runtime_checkable>` :class:`typing.Protocol` take the cached fast path
+when the object's class sets a non-callable protocol member to ``None``. Such a
+class already passed the check, but was excluded from :class:`abc.ABCMeta`'s
+cache and so re-examined every protocol member on every call.


### PR DESCRIPTION
`_ProtocolMeta.__instancecheck__` treats a member set to `None` as "explicitly not implemented" only for callable members:

```python
if val is None and attr not in cls.__non_callable_proto_members__:
    break
```

`_proto_hook` applies the same sentinel to every member, callable or not. So a class that sets a non-callable protocol member to `None` passes `isinstance()` but is rejected by the subclass hook. It lands in `ABCMeta`'s negative cache instead of the positive one, and every subsequent `isinstance()` call falls through to the `getattr_static` loop over all protocol members.

```python
>>> [r() for r in _abc._get_dump(P)[1]], [r() for r in _abc._get_dump(P)[2]]
([<class 'Good'>], [<class 'Bad'>])   # positive, negative
```

This makes the check O(N) in the number of protocol members, on every call, for a class that conforms.

### Performance

Release build of this branch, macOS on Apple silicon, best of 11 runs of 20,000 `isinstance()` calls, ns/call. `P` has N property members; `Bad` differs from `Good` only in setting the last one to `None`.

| N | `Good` | `Bad`, before | `Bad`, after |
| ---: | ---: | ---: | ---: |
| 2 | 178 | 1334 (7.5x) | 162 (1.0x) |
| 5 | 166 | 2861 (17x) | 170 (1.0x) |
| 20 | 167 | 10704 (64x) | 169 (1.0x) |
| 50 | 183 | 26882 (147x) | 172 (1.0x) |
| 110 | 192 | 55820 (291x) | 186 (1.0x) |

The before column scales at roughly 500 ns per protocol member. After the change `Bad` is a cache hit like `Good`, and `Good` itself is unaffected.

This gives `_proto_hook` the same rule, so such a class is cached like any other. `None`-valued *method* members are still rejected, and a missing attribute still fails.

The only externally visible change is via `_allow_reckless_class_checks`: an `issubclass()` originating in `abc`, `functools` or `_py_abc` now returns `True` where it returned `False`, which is what `isinstance()` already answers for the same pair. A direct `issubclass()` still raises `TypeError` for protocols with non-method members, so user-facing behaviour is unchanged.


<!-- gh-issue-number: gh-156413 -->
* Issue: gh-156413
<!-- /gh-issue-number -->
