### PR TITLE
[3.15] Docs: remove __path__ discussion from tutorial (GH-156426)

### DIFF
--- a/Doc/tools/removed-ids.txt
+++ b/Doc/tools/removed-ids.txt
@@ -6,6 +6,8 @@ c-api/file.html: deprecated-api
 
 library/asyncio-task.html: terminating-a-task-group
 
+tutorial/modules.html: packages-in-multiple-directories
+
 # Removed APIs
 c-api/import.html: c.PyImport_LazyImportsMode.PyImport_LAZY_NONE
 

--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -584,20 +584,6 @@ Since the main module does not have a package, modules intended for use
 as the main module of a Python application must always use absolute imports.
 
 
-Packages in Multiple Directories
---------------------------------
-
-Packages support one more special attribute, :attr:`~module.__path__`.  This is
-initialized to be a :term:`sequence` of strings containing the name of the
-directory holding the
-package's :file:`__init__.py` before the code in that file is executed.  This
-variable can be modified; doing so affects future searches for modules and
-subpackages contained in the package.
-
-While this feature is not often needed, it can be used to extend the set of
-modules found in a package.
-
-
 .. rubric:: Footnotes
 
 .. [#] In fact function definitions are also 'statements' that are 'executed'; the


### PR DESCRIPTION
* Docs: remove __path__ discussion from tutorial

This isn't the current best way to make namespace packages; almost no one needs to make namespace packages; the deleted text even says "while this feature is not often needed".  It doesn't belong in the tutorial.

* add removed id to removed-ids.txt (cherry picked from commit 79f41dd9f312ab960e492c34b85f02e84cf1f556)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
