### PR TITLE
gh-156459: Fix cleanup on error in compiler_set_qualname

### DIFF
--- a/Include/internal/pycore_compile.h
+++ b/Include/internal/pycore_compile.h
@@ -137,6 +137,7 @@ int _PyCompile_EnterScope(struct _PyCompiler *c, identifier name, int scope_type
                           void *key, int lineno, PyObject *private,
                           _PyCompile_CodeUnitMetadata *umd);
 void _PyCompile_ExitScope(struct _PyCompiler *c);
+int _PyCompile_SetQualname(struct _PyCompiler *c);
 Py_ssize_t _PyCompile_AddConst(struct _PyCompiler *c, PyObject *o);
 _PyInstructionSequence *_PyCompile_InstrSequence(struct _PyCompiler *c);
 int _PyCompile_StartAnnotationSetup(struct _PyCompiler *c);

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -683,6 +683,7 @@ codegen_enter_scope(compiler *c, identifier name, int scope_type,
 {
     RETURN_IF_ERROR(
         _PyCompile_EnterScope(c, name, scope_type, key, lineno, private, umd));
+    RETURN_IF_ERROR_IN_SCOPE(c, _PyCompile_SetQualname(c));
     location loc = LOCATION(lineno, lineno, 0, 0);
     if (scope_type == COMPILE_SCOPE_MODULE) {
         loc.lineno = 0;

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -233,12 +233,16 @@ _PyCompile_MaybeAddStaticAttributeToClass(compiler *c, expr_ty e)
     return SUCCESS;
 }
 
-static int
-compiler_set_qualname(compiler *c)
+int
+_PyCompile_SetQualname(compiler *c)
 {
     Py_ssize_t stack_size;
     struct compiler_unit *u = c->u;
     PyObject *name, *base;
+
+    if (u->u_scope_type == COMPILE_SCOPE_MODULE) {
+        return SUCCESS;
+    }
 
     base = NULL;
     stack_size = PyList_GET_SIZE(c->c_stack);
@@ -724,9 +728,6 @@ _PyCompile_EnterScope(compiler *c, identifier name, int scope_type,
     u->u_private = Py_XNewRef(private);
 
     c->u = u;
-    if (scope_type != COMPILE_SCOPE_MODULE) {
-        RETURN_IF_ERROR(compiler_set_qualname(c));
-    }
     return SUCCESS;
 }
 


### PR DESCRIPTION

Move the operation to `_PyCompile_SetQualname` and call it after `_PyCompile_EnterScope` returns (with cleanup if it fails).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156459 -->
* Issue: gh-156459
<!-- /gh-issue-number -->
