### PR TITLE
[3.14] gh-155468: Distinguish empty quoted tokens from EOF in netrc(GH-155471)

### DIFF
--- a/Lib/netrc.py
+++ b/Lib/netrc.py
@@ -48,11 +48,12 @@ class _netrclex:
     def get_token(self):
         if self.pushback:
             return self.pushback.pop(0)
-        token = ""
+        token = None
         fiter = iter(self._read_char, "")
         for ch in fiter:
             if ch in self.whitespace:
                 continue
+            token = ""
             if ch == '"':
                 for ch in fiter:
                     if ch == '"':
@@ -96,9 +97,9 @@ class netrc:
             # Look for a machine, default, or macdef top-level keyword
             saved_lineno = lexer.lineno
             toplevel = tt = lexer.get_token()
-            if not tt:
+            if tt is None:
                 break
-            elif tt[0] == '#':
+            elif tt.startswith('#'):
                 if lexer.lineno == saved_lineno and len(tt) == 1:
                     lexer.instream.readline()
                 continue
@@ -135,20 +136,20 @@ class netrc:
             while 1:
                 prev_lineno = lexer.lineno
                 tt = lexer.get_token()
-                if tt.startswith('#'):
+                if tt is not None and tt.startswith('#'):
                     if lexer.lineno == prev_lineno:
                         lexer.instream.readline()
                     continue
-                if tt in {'', 'machine', 'default', 'macdef'}:
+                if tt in {None, 'machine', 'default', 'macdef'}:
                     self.hosts[entryname] = (login, account, password)
                     lexer.push_token(tt)
                     break
                 elif tt == 'login' or tt == 'user':
-                    login = lexer.get_token()
+                    login = lexer.get_token() or ''
                 elif tt == 'account':
-                    account = lexer.get_token()
+                    account = lexer.get_token() or ''
                 elif tt == 'password':
-                    password = lexer.get_token()
+                    password = lexer.get_token() or ''
                 else:
                     raise NetrcParseError("bad follower token %r" % tt,
                                           file, lexer.lineno)

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -59,6 +59,9 @@ class NetrcTestCase(unittest.TestCase):
             "machine host.domain.com login",
             "machine host.domain.com account",
             "machine host.domain.com password",
+            "machine host.domain.com login \"\"",
+            "machine host.domain.com account \"\"",
+            "machine host.domain.com password \"\"",
             "machine host.domain.com login \"\" account",
             "machine host.domain.com login \"\" password",
             "machine host.domain.com account \"\" password"
@@ -71,6 +74,9 @@ class NetrcTestCase(unittest.TestCase):
             "default login",
             "default account",
             "default password",
+            "default login \"\"",
+            "default account \"\"",
+            "default password \"\"",
             "default login \"\" account",
             "default login \"\" password",
             "default account \"\" password"
@@ -78,6 +84,15 @@ class NetrcTestCase(unittest.TestCase):
         for item in data:
             nrc = self.make_nrc(item)
             self.assertEqual(nrc.hosts['default'], ('', '', ''))
+
+    def test_empty_quoted_token_is_not_eof(self):
+        data = (
+            '"" invalid',
+            'machine host.domain.com "" invalid',
+        )
+        for item in data:
+            with self.subTest(item=item):
+                self.assertRaises(netrc.NetrcParseError, self.make_nrc, item)
 
     def test_invalid_tokens(self):
         data = (

--- a/Misc/NEWS.d/next/Library/2026-08-10-15-24-13.gh-issue-155468.W7qL2p.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-10-15-24-13.gh-issue-155468.W7qL2p.rst
@@ -1,0 +1,2 @@
+Fix :mod:`netrc` to distinguish empty quoted tokens from end-of-file, so
+malformed files no longer cause the remaining content to be silently ignored.


### PR DESCRIPTION
Manually backport it to Python 3.14
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-155468 -->
* Issue: gh-155468
<!-- /gh-issue-number -->
