### PR TITLE
gh-156399: Don't specialize LOAD_ATTR_MODULE for module subclasses

### DIFF
--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -2211,6 +2211,35 @@ class TestSpecializer(TestBase):
 
     @cpython_only
     @requires_specialization
+    def test_load_attr_module_subclass_with_data_descriptor(self):
+        # gh-156399: a types.ModuleType subclass inherits
+        # PyModule_Type.tp_getattro, so guarding specialization on tp_getattro
+        # alone let subclasses take LOAD_ATTR_MODULE. That reads the module
+        # dict directly, silently bypassing a data descriptor defined on the
+        # subclass once the instruction had specialized.
+        class Descriptor:
+            def __get__(self, instance, owner=None):
+                return "from descriptor"
+
+            def __set__(self, instance, value):
+                instance.__dict__["attr"] = value
+
+        class Module(types.ModuleType):
+            attr = Descriptor()
+
+        module = Module("test_module_subclass")
+        module.__dict__["attr"] = "from dict"
+
+        def load_module_attr():
+            return module.attr
+
+        for _ in range(_testinternalcapi.SPECIALIZATION_THRESHOLD):
+            self.assertEqual(load_module_attr(), "from descriptor")
+
+        self.assert_no_opcode(load_module_attr, "LOAD_ATTR_MODULE")
+
+    @cpython_only
+    @requires_specialization
     def test_specialized_iter_doesnt_skip_send_check(self):
         def gen_func(seq):
             yield from seq

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-27-00-00-00.gh-issue-156399.aB3xYz.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-27-00-00-00.gh-issue-156399.aB3xYz.rst
@@ -1,0 +1,4 @@
+Fix a regression where attribute access on a :class:`types.ModuleType`
+subclass could bypass a data descriptor defined on the subclass. The
+``LOAD_ATTR_MODULE`` specialization guarded on ``tp_getattro``, which
+subclasses inherit, and then read the module dictionary directly.

--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -9207,7 +9207,7 @@
                 uint32_t dict_version = read_u32(&this_instr[2].cache);
                 uint16_t index = read_u16(&this_instr[4].cache);
                 PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-                if (Py_TYPE(owner_o)->tp_getattro != PyModule_Type.tp_getattro) {
+                if (!PyModule_CheckExact(owner_o)) {
                     UPDATE_MISS_STATS(LOAD_ATTR);
                     assert(_PyOpcode_Deopt[opcode] == (LOAD_ATTR));
                     JUMP_TO_PREDICTED(LOAD_ATTR);

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2928,7 +2928,7 @@ dummy_func(
 
         op(_LOAD_ATTR_MODULE, (dict_version/2, index/1, owner -- attr, o)) {
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-            EXIT_IF(Py_TYPE(owner_o)->tp_getattro != PyModule_Type.tp_getattro);
+            EXIT_IF(!PyModule_CheckExact(owner_o));
             PyDictObject *dict = (PyDictObject *)((PyModuleObject *)owner_o)->md_dict;
             assert(dict != NULL);
             PyDictKeysObject *keys = FT_ATOMIC_LOAD_PTR_ACQUIRE(dict->ma_keys);

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -12324,7 +12324,7 @@
             uint32_t dict_version = (uint32_t)CURRENT_OPERAND0_32();
             uint16_t index = (uint16_t)CURRENT_OPERAND1_16();
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-            if (Py_TYPE(owner_o)->tp_getattro != PyModule_Type.tp_getattro) {
+            if (!PyModule_CheckExact(owner_o)) {
                 UOP_STAT_INC(uopcode, miss);
                 _tos_cache0 = owner;
                 SET_CURRENT_CACHED_VALUES(1);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -9206,7 +9206,7 @@
                 uint32_t dict_version = read_u32(&this_instr[2].cache);
                 uint16_t index = read_u16(&this_instr[4].cache);
                 PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-                if (Py_TYPE(owner_o)->tp_getattro != PyModule_Type.tp_getattro) {
+                if (!PyModule_CheckExact(owner_o)) {
                     UPDATE_MISS_STATS(LOAD_ATTR);
                     assert(_PyOpcode_Deopt[opcode] == (LOAD_ATTR));
                     JUMP_TO_PREDICTED(LOAD_ATTR);

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1010,7 +1010,7 @@ _Py_Specialize_LoadAttr(_PyStackRef owner_st, _Py_CODEUNIT *instr, PyObject *nam
         SPECIALIZATION_FAIL(LOAD_ATTR, SPEC_FAIL_OTHER);
         fail = true;
     }
-    else if (Py_TYPE(owner)->tp_getattro == PyModule_Type.tp_getattro) {
+    else if (PyModule_CheckExact(owner)) {
         fail = specialize_module_load_attr(owner, instr, name);
     }
     else if (PyType_Check(owner)) {


### PR DESCRIPTION
Attribute loads on a `types.ModuleType` subclass are specialized to `LOAD_ATTR_MODULE`, which reads the module dictionary directly. Both the specialization site and the runtime guard tested only `tp_getattro`:

```c
/* Python/specialize.c */
else if (Py_TYPE(owner)->tp_getattro == PyModule_Type.tp_getattro) {
    fail = specialize_module_load_attr(owner, instr, name);
}

/* Python/bytecodes.c */
EXIT_IF(Py_TYPE(owner_o)->tp_getattro != PyModule_Type.tp_getattro);
```

A subclass inherits `PyModule_Type.tp_getattro` unless it overrides `__getattr__`, so it satisfies both and takes the path. Neither check consults the type for a data descriptor, so once the instruction specializes the descriptor is bypassed and the dictionary value is returned instead. As noted in the issue, the guard was `PyModule_CheckExact` before 3.14, so subclasses never specialized.

This requires the exact module type in both places.

### Why both

The runtime guard matters independently of the specialization site: one instruction can specialize against an exact module and later execute against a subclass instance, for example when a loop walks a list holding both. Tightening only `specialize.c` would still let a subclass reaching an already-specialized instruction bypass its descriptor.

### Verification

Running the reproducer from the issue against a debug build of `main`:

```
['from descriptor', 'from dict', 'from dict', 'from dict']
```

and with this change:

```
['from descriptor', 'from descriptor', 'from descriptor', 'from descriptor']
```

`test_load_attr_module_subclass_with_data_descriptor` in `Lib/test/test_opcache.py` pins it, asserting both the descriptor result and that the code does not carry `LOAD_ATTR_MODULE`. It fails on unpatched `main` and passes with the change.

`test_opcache`, `test_module`, `test_descr` and `test_importlib` all pass. `test_import` reports 2 failures here (`FilePermissionTests.test_creation_mode`, `PycacheTests.test_unwritable_directory`), but those reproduce identically on an unpatched build of the same tree — they are container permission issues, not related to this change.

### Note on scope

This restores the pre-3.14 behaviour of declining to specialize for subclasses, so there is no regression against 3.13. It does give up specialization for module subclasses that have no data descriptor. Keeping that case fast would mean proving no data descriptor exists for the name *and* guarding against one being added later, which `_PyAttrCache` has no type-version field for — so it looked like a larger change than a correctness fix should carry. Happy to pursue that instead if you'd prefer it.

Fixes #156399


<!-- gh-issue-number: gh-156399 -->
* Issue: gh-156399
<!-- /gh-issue-number -->
