### PR TITLE
gh-156233: Fixing a couple of typos and a few code snippet errors in Python docs

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -3920,7 +3920,7 @@ subclassed handler which looks something like this::
 
 You'll need to be familiar with RFC 5424 to fully understand the above code, and it
 may be that you have slightly different needs (e.g. for how you pass structural data
-to the log). Nevertheless, the above should be adaptable to your speciric needs. With
+to the log). Nevertheless, the above should be adaptable to your specific needs. With
 the above handler, you'd pass structured data using something like this::
 
     sd = {

--- a/Doc/howto/mro.rst
+++ b/Doc/howto/mro.rst
@@ -189,7 +189,7 @@ prescription:
   the tail of any of the other lists, then add it to the linearization
   of C and remove it from the lists in the merge, otherwise look at the
   head of the next list and take it, if it is a good head.  Then repeat
-  the operation until all the class are removed or it is impossible to
+  the operation until all the classes are removed or it is impossible to
   find good heads.  In this case, it is impossible to construct the
   merge, Python 2.3 will refuse to create the class C and will raise an
   exception.*

--- a/Doc/library/logging.config.rst
+++ b/Doc/library/logging.config.rst
@@ -555,7 +555,7 @@ following configuration::
       'bar' : 'baz',
       'spam' : 99.9,
       'answer' : 42,
-      '.' {
+      '.' : {
         'foo': 'bar',
         'baz': 'bozz'
       }

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -834,7 +834,7 @@ can be overridden by the local file.
         def inner(x):
             1 / x
 
-         out()
+        out()
 
    calling ``pdb.pm()`` will allow to move between exceptions::
 


### PR DESCRIPTION
Hello Python team!

Just sending a PR to fix a couple of typos and a few code snippet errors in Python docs. No changes outside of a few .rst files used to generate content on docs.python.org are made to the Python project. These changes are not claimed to fix other unreported possible issues in the documentation, but rather just the items currently mentioned in #156233 .

---


On https://docs.python.org/3.16/howto/logging-cookbook.html (archived as is at https://web.archive.org/web/20260827054643/https://docs.python.org/3.16/howto/logging-cookbook.html )

- In the sentence
https://github.com/python/cpython/blob/fe3a26f43fad1d6eed20172d7f63ee2931ae2ce1/Doc/howto/logging-cookbook.rst?plain=1#L3923
  > Nevertheless, the above should be adaptable to your speciric needs.

  "speciric" should be "specific".

---

On https://docs.python.org/3.16/library/logging.config.html (archived as is at https://web.archive.org/web/20260827041728/https://docs.python.org/3.16/library/logging.config.html )

- In the example
  > You can also specify a special key '.' whose value is a mapping of attribute names to values. If found, the specified attributes will be set on the user-defined object before it is returned. Thus, with the following configuration:

 >```
 > {
 > '()' : 'my.package.customFormatterFactory',
 > 'bar' : 'baz',
 > 'spam' : 99.9,
 > 'answer' : 42,
 > '.' {
 >   'foo': 'bar',
 >   'baz': 'bozz'
 > }
 > }
 >```

 It seems the key "." is  missing a ":" before its value to avoid `':' expected after dictionary key (<string>, line 6)'` for the above.
https://github.com/python/cpython/blob/fe3a26f43fad1d6eed20172d7f63ee2931ae2ce1/Doc/library/logging.config.rst?plain=1#L558

---

On https://docs.python.org/3.16/library/pdb.html#pdbcommand-exceptions (archived as is at https://web.archive.org/web/20260827042203/https://docs.python.org/3.16/library/pdb.html#pdbcommand-exceptions )

- nit: In the example
  >```
  >def out():
  >    try:
  >        middle()
  >    except Exception as e:
  >        raise ValueError("reraise middle() error") from e
  >
  >def middle():
  >    try:
  >        return inner(0)
  >    except Exception as e:
  >        raise ValueError("Middle fail")
  >
  >def inner(x):
  >    1 / x
  >
  > out()
  >```

  There is an extra space on the beginning of the last line ` out()`, which prevents the snippet from running exactly as is if copy-pasted.
https://github.com/python/cpython/blob/fe3a26f43fad1d6eed20172d7f63ee2931ae2ce1/Doc/library/pdb.rst?plain=1#L837

---

In the latest version of https://docs.python.org/3/howto/mro.html#python-2-3-mro (archived as is at https://web.archive.org/web/20260822145356/https://docs.python.org/3/howto/mro.html#python-2-3-mro )

    In the sentence

        Then repeat the operation until all the class are removed or it is impossible to find good heads.

    it seems "all the class" should be "all the classes".

---

I am not trying in this PR to fix the `non-default type parameter 'TypeVarWithBound' follows default type parameter` for the `overly_generic` example on https://docs.python.org/3.16/reference/compound_stmts.html yet ( caused by https://github.com/python/cpython/blob/fe3a26f43fad1d6eed20172d7f63ee2931ae2ce1/Doc/reference/compound_stmts.rst?plain=1#L1852 ) which I discovered and reported in the same ticket because while a simple reordering fixes that to be runnable again in Python there may be other updates required for that example to work properly with type checkers like mypy , so I will handle that separately if that is ok.

---

Let me know if there are any additional backport PRs or other language repos for the docs I need to open manually to propagate these changes (if the automated backports don't end up running for this PR).

Thanks so much!


<!-- gh-issue-number: gh-156233 -->
* Issue: gh-156233
<!-- /gh-issue-number -->
