### PR TITLE
gh-156476: Ignore timeout in pure Python SimpleQueue.get() when block is false

### DIFF
--- a/Lib/queue.py
+++ b/Lib/queue.py
@@ -346,7 +346,9 @@ class _PySimpleQueue:
         available, else raise the Empty exception ('timeout' is ignored
         in that case).
         '''
-        if timeout is not None and timeout < 0:
+        if not block:
+            timeout = None
+        elif timeout is not None and timeout < 0:
             raise ValueError("'timeout' must be a non-negative number")
         if not self._count.acquire(block, timeout):
             raise Empty

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -956,6 +956,11 @@ class BaseSimpleQueueTest:
         with self.assertRaises(ValueError):
             q.get(timeout=-1)
 
+    def test_nonblocking_ignores_timeout(self):
+        q = self.q
+        with self.assertRaises(self.queue.Empty):
+            q.get(block=False, timeout=-1)
+
     def test_order(self):
         # Test a pair of concurrent put() and get()
         q = self.q

--- a/Misc/NEWS.d/next/Library/2026-08-28-00-59-00.gh-issue-156476.rQhxc7.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-28-00-59-00.gh-issue-156476.rQhxc7.rst
@@ -1,0 +1,3 @@
+The pure Python implementation of :meth:`queue.SimpleQueue.get` now ignores
+``timeout`` when ``block`` is false, matching the documented behavior and
+the C implementation. It previously raised :exc:`ValueError`.

--- a/Misc/NEWS.d/next/Library/2026-08-28-00-59-00.gh-issue-156476.rQhxc7.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-28-00-59-00.gh-issue-156476.rQhxc7.rst
@@ -1,3 +1,3 @@
 The pure Python implementation of :meth:`queue.SimpleQueue.get` now ignores
-``timeout`` when ``block`` is false, matching the documented behavior and
+*timeout* when *block* is false, matching the documented behavior and
 the C implementation. It previously raised :exc:`ValueError`.


### PR DESCRIPTION


<!-- gh-issue-number: gh-156476 -->
* Issue: gh-156476
<!-- /gh-issue-number -->
