### PR TITLE
gh-155813: Stop overwriting LIBFFI_CFLAGS and LIBFFI_LIBS on macOS

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-08-27-23-24-29.gh-issue-155813.LxRQu9.rst
+++ b/Misc/NEWS.d/next/Build/2026-08-27-23-24-29.gh-issue-155813.LxRQu9.rst
@@ -1,0 +1,3 @@
+On macOS, :option:`LIBFFI_CFLAGS` and :option:`LIBFFI_LIBS` are no longer
+ignored when the SDK provides ``libffi``, so :mod:`ctypes` can again be built
+against a different ``libffi``. Patch by Advit Arora.

--- a/configure
+++ b/configure
@@ -16220,8 +16220,8 @@ if test "x$ac_cv_lib_ffi_ffi_call" = xyes
 then :
 
                 have_libffi=yes
-        LIBFFI_CFLAGS="-I${SDKROOT}/usr/include/ffi -DUSING_APPLE_OS_LIBFFI=1"
-        LIBFFI_LIBS="-lffi"
+        LIBFFI_CFLAGS=${LIBFFI_CFLAGS-"-I${SDKROOT}/usr/include/ffi -DUSING_APPLE_OS_LIBFFI=1"}
+        LIBFFI_LIBS=${LIBFFI_LIBS-"-lffi"}
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -4375,8 +4375,8 @@ AS_VAR_IF([ac_sys_system], [Darwin], [
       AC_CHECK_LIB([ffi], [ffi_call], [
         dnl use ffi from SDK root
         have_libffi=yes
-        LIBFFI_CFLAGS="-I${SDKROOT}/usr/include/ffi -DUSING_APPLE_OS_LIBFFI=1"
-        LIBFFI_LIBS="-lffi"
+        LIBFFI_CFLAGS=${LIBFFI_CFLAGS-"-I${SDKROOT}/usr/include/ffi -DUSING_APPLE_OS_LIBFFI=1"}
+        LIBFFI_LIBS=${LIBFFI_LIBS-"-lffi"}
       ])
     ])
   ])


### PR DESCRIPTION
On macOS, `configure` sets `LIBFFI_CFLAGS` and `LIBFFI_LIBS` from the SDK before the pkg-config
check, so values passed on the command line are ignored. `Doc/using/configure.rst` documents both
as overrides. This uses the same preserve-if-set form as the pkg-config fallback and the libuuid
probe.

Configuring with `LIBFFI_CFLAGS=-I/nonexistent/include/ffi LIBFFI_LIBS="-L/nonexistent/lib -lffi"`,
the Makefile currently ends up with the SDK paths:

```
MODULE__CTYPES_CFLAGS=-fno-strict-overflow -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/ffi -DUSING_APPLE_OS_LIBFFI=1 -DUSING_MALLOC_CLOSURE_DOT_C=1
MODULE__CTYPES_LDFLAGS=-lffi -ldl
```

and with this change keeps the given values:

```
MODULE__CTYPES_CFLAGS=-fno-strict-overflow -I/nonexistent/include/ffi -DUSING_MALLOC_CLOSURE_DOT_C=1
MODULE__CTYPES_LDFLAGS=-L/nonexistent/lib -lffi -ldl
```

With no overrides the output is unchanged. `USING_APPLE_OS_LIBFFI` drops out when overriding
since it guards Apple-libffi code in `_ctypes`. iOS sets a different `ac_sys_system` and is
unaffected. The other documented `*_CFLAGS`/`*_LIBS` pairs already preserve user values.


<!-- gh-issue-number: gh-155813 -->
* Issue: gh-155813
<!-- /gh-issue-number -->
