### PR TITLE
gh-95555: Fix a stale comment about negating \P in a character class

### DIFF
--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1010,8 +1010,8 @@ class ReTests(unittest.TestCase):
             with self.subTest(char=c):
                 self.assertEqual(bool(ci.fullmatch(c)), expect)
         self.assertTrue(re.fullmatch(r'\p{Alphabetic=No}+', '123 '))
-        # These are engine categories, so (unlike \P of a multi-range
-        # property) they can be negated inside a character class.
+        # These are engine categories, so a negated one joins the set directly
+        # as a CATEGORY rather than being alternated in as a separate branch.
         self.assertTrue(re.fullmatch(r'[\P{Alphabetic}]+', '123 .'))
         self.assertTrue(re.fullmatch(r'[\p{XID_Start}_]+', 'foo_bar'))
 


### PR DESCRIPTION
The comment above the `[\P{Alphabetic}]` assertion in `test_property_escapes` still says that, unlike an engine category, `\P` of a multi-range property cannot be negated inside a character class. GH-152245 lifted that restriction, and the same test now asserts fifty lines below that `[\P{ASCII}]`, `[\P{ASCII}abc]` and `[^\P{ASCII}]` all match. The comment now states the distinction that does remain, which is how the member is compiled rather than whether it is allowed:

```pycon
>>> re._parser.parse(r'[\P{Alphabetic}x]')
[(IN, [(CATEGORY, CATEGORY_NOT_ALPHA), (LITERAL, 120)])]
>>> re._parser.parse(r'[\P{ASCII}x]')
[(BRANCH, (None, [[(LITERAL, 120)], [(IN, [(NEGATE, None), (RANGE, (0, 127))])]]))]
```

```
test_property_escapes (test.test_re.ReTests.test_property_escapes) ... ok
Total tests: run=1 (filtered)
Result: SUCCESS
```

Comment-only change in a test file, so there is no news entry.


<!-- gh-issue-number: gh-95555 -->
* Issue: gh-95555
<!-- /gh-issue-number -->
