### PR TITLE
[3.14] Fix typo in asyncio documentation (GH-148747)

### DIFF
--- a/Doc/library/asyncio-dev.rst
+++ b/Doc/library/asyncio-dev.rst
@@ -304,7 +304,7 @@ generator can occur in an unexpected order::
       try:
           yield 2
       finally:
-          await asyncio.sleep(0.1) # immitate some async work
+          await asyncio.sleep(0.1) # imitate some async work
           work_done = True
 
 


### PR DESCRIPTION
gh-156232: Backport a typo fix in asyncio to 3.14 branch (other typo fixes were in content not present in 3.14 which is why automated backport failed for the author of that PR)

(cherry picked from commit 9a1c70c639f2ac60ae3756bec20c2584303f748e , to fix https://github.com/python/cpython/pull/148747#issuecomment-4283655883 ,  leaving out content exclusive to later versions, 3.15 etc)