### PR TITLE
gh-156495: Compare normalized prefixes in site._venv()

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -1031,11 +1031,14 @@ def _venv(state):
                         )
                         break
 
-        if sys.prefix != site_prefix:
+        # site_prefix is already normalised by the abspath() above, but sys.prefix
+        # isn't. Normalise before comparing, or two spellings of the same directory
+        # look like a mismatch.
+        if os.path.normpath(sys.prefix) != site_prefix:
             _warn(
                 f'Unexpected value in sys.prefix, expected {site_prefix}, got {sys.prefix}',
                 RuntimeWarning)
-        if sys.exec_prefix != site_prefix:
+        if os.path.normpath(sys.exec_prefix) != site_prefix:
             _warn(
                 f'Unexpected value in sys.exec_prefix, expected {site_prefix}, got {sys.exec_prefix}',
                 RuntimeWarning)

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -303,6 +303,55 @@ class BasicTest(BaseTest):
                              pathlib.Path(expected), prefix)
 
     @requireVenvCreate
+    def test_prefixes_with_non_normalised_executable(self):
+        """
+        Test that a non-normalised executable path isn't counted as a mismatch.
+        """
+        # gh-156495: sys.prefix isn't normalised, but the prefix derived from
+        # sys.executable is, so a string comparison flagged two spellings of the
+        # same directory.
+        rmtree(self.env_dir)
+        self.run_with_capture(venv.create, self.env_dir)
+        # Run from a directory next to the env so argv[0] starts with '..',
+        # which normpath() can't collapse.
+        subdir = tempfile.mkdtemp(dir=os.path.dirname(self.env_dir))
+        self.addCleanup(rmtree, subdir)
+        relative_exe = os.path.join(
+            os.pardir, os.path.basename(self.env_dir), self.bindir, self.exe)
+        p = subprocess.run(
+            [relative_exe, '-c',
+             'import sys; print(sys.prefix); print(sys.exec_prefix)'],
+            cwd=subdir, capture_output=True, encoding='utf-8',
+            env={**os.environ, 'PYTHONHOME': ''})
+        self.assertEqual(p.returncode, 0, p.stderr)
+        self.assertNotIn('Unexpected value in sys.prefix', p.stderr)
+        self.assertNotIn('Unexpected value in sys.exec_prefix', p.stderr)
+        prefix, exec_prefix = p.stdout.splitlines()
+        for name, value in (('prefix', prefix), ('exec_prefix', exec_prefix)):
+            self.assertEqual(os.path.realpath(value),
+                             os.path.realpath(self.env_dir), name)
+
+    @requireVenvCreate
+    def test_prefixes_mismatch_is_still_reported(self):
+        """
+        Test that a genuine prefix mismatch is still reported.
+        """
+        rmtree(self.env_dir)
+        self.run_with_capture(venv.create, self.env_dir)
+        # Move pyvenv.cfg next to the interpreter instead of leaving it in the
+        # prefix, so that sys.prefix and the prefix derived from sys.executable
+        # differ for real and not only in spelling.
+        os.rename(os.path.join(self.env_dir, 'pyvenv.cfg'),
+                  os.path.join(self.env_dir, self.bindir, 'pyvenv.cfg'))
+        p = subprocess.run(
+            [self.envpy(), '-c', 'import sys; print(sys.prefix)'],
+            capture_output=True, encoding='utf-8',
+            env={**os.environ, 'PYTHONHOME': ''})
+        self.assertEqual(p.returncode, 0, p.stderr)
+        self.assertIn('Unexpected value in sys.prefix', p.stderr)
+        self.assertIn('Unexpected value in sys.exec_prefix', p.stderr)
+
+    @requireVenvCreate
     def test_sysconfig(self):
         """
         Test that the sysconfig functions work in a virtual environment.

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -23,8 +23,8 @@ from test.support import (captured_stdout, captured_stderr,
                           is_wasm32,
                           requires_venv_with_pip, TEST_HOME_DIR,
                           requires_resource, copy_python_src_ignore)
-from test.support.os_helper import (can_symlink, EnvironmentVarGuard, rmtree,
-                                    TESTFN, FakePath)
+from test.support.os_helper import (can_symlink, change_cwd, EnvironmentVarGuard,
+                                    rmtree, TESTFN, FakePath)
 import unittest
 import venv
 from unittest.mock import patch, Mock
@@ -318,11 +318,14 @@ class BasicTest(BaseTest):
         self.addCleanup(rmtree, subdir)
         relative_exe = os.path.join(
             os.pardir, os.path.basename(self.env_dir), self.bindir, self.exe)
-        p = subprocess.run(
-            [relative_exe, '-c',
-             'import sys; print(sys.prefix); print(sys.exec_prefix)'],
-            cwd=subdir, capture_output=True, encoding='utf-8',
-            env={**os.environ, 'PYTHONHOME': ''})
+        # Windows does not resolve a relative executable against subprocess's
+        # cwd argument, so change directory in this process instead.
+        with change_cwd(subdir):
+            p = subprocess.run(
+                [relative_exe, '-c',
+                 'import sys; print(sys.prefix); print(sys.exec_prefix)'],
+                capture_output=True, encoding='utf-8',
+                env={**os.environ, 'PYTHONHOME': ''})
         self.assertEqual(p.returncode, 0, p.stderr)
         self.assertNotIn('Unexpected value in sys.prefix', p.stderr)
         self.assertNotIn('Unexpected value in sys.exec_prefix', p.stderr)

--- a/Misc/NEWS.d/next/Library/2026-08-27-14-00-00.gh-issue-156495.Qk3vTz.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-27-14-00-00.gh-issue-156495.Qk3vTz.rst
@@ -1,0 +1,4 @@
+Fix a false-positive :exc:`RuntimeWarning` from :mod:`site` when a virtual
+environment interpreter is started through a non-normalised path such as
+``../.venv/bin/python``.  ``sys.prefix`` and the prefix derived from
+:data:`sys.executable` are now compared in normalised form.


### PR DESCRIPTION
Fixes #156495.

`site._venv()` compares `sys.prefix` against a `site_prefix` built with `os.path.abspath()`, using string equality. `abspath()` normalizes and `getpath` does not, so a venv interpreter started through a path such as `../venv/bin/python` reports two spurious `RuntimeWarning`s about prefixes that name the same directory.

This compares normalized forms instead. No observable value changes: `sys.prefix`, `sys.exec_prefix` and `sys.executable` are untouched, and the message still reports the original value. Only the condition for warning changes, and genuine mismatches still warn, including the one from #154160.

The check itself came from GH-126987 (gh-126985), by Filipe Laíns, which replaced the earlier `sys.prefix = sys.exec_prefix = site_prefix` assignment. The `abspath()` on the other side has been there since #60723 (bpo-16519), reported by Christian Heimes and fixed by Vinay Sajip, added so that invoking the interpreter through a relative path would work. Both do what they were meant to do. Only the string comparison between them is too strict.

Two tests are added, since there was no coverage of this warning in `test_site.py` or `test_venv.py`. The first fails without the change. The second pins down a genuine mismatch, so that a future change cannot silence the check altogether.

<details>
<summary>Verification</summary>

Bisected on clean venvs, invoking `../v/bin/python` from a sibling directory:

| version | warnings | `sys.prefix` | `sys.executable` |
|---|---|---|---|
| 3.11.15 | 0 | `/tmp/v` | `/tmp/sub/../v/bin/python` |
| 3.12.13 | 0 | `/tmp/v` | `/tmp/sub/../v/bin/python` |
| 3.13.15 | 0 | `/tmp/v` | `/tmp/sub/../v/bin/python` |
| 3.14.7 | 2 | `/tmp/sub/../v` | `/tmp/sub/../v/bin/python` |
| 3.15.0rc1 | 2 | `/tmp/sub/../v` | `/tmp/sub/../v/bin/python` |

`sys.executable` is identical throughout. Only `sys.prefix` and the check are new.

Every case, measured on this branch with and without the change:

| case | before | after |
|---|---|---|
| `../v/bin/python` from a sibling directory | 2 | 0 |
| the same with `env -i` (no `PATH` in the environment) | 2 | 0 |
| relative `PATH` entry (the #154160 symptom) | 2 | 2 |
| absolute invocation | 0 | 0 |
| `//tmp/v/bin/python` | 0 | 0 |
| `..` in the middle of the path | 0 | 0 |
| `pyvenv.cfg` next to the interpreter | 2 | 2 |

Test suite, before and after, on `test_venv test_site test_sys test_getpath test_embed test_sysconfig test_cmd_line test_cmd_line_script test_import test_frozen test_posixpath test_ntpath`: 12 of 12 modules pass either way, 874 tests before and 876 after, the difference being the two added here.

`os.path.normpath` is `_path_normpath`, a C builtin, at 549 ns per call. That is roughly 1 µs per interpreter start, and only inside a venv. I could not measure it above noise end to end.

</details>

<!-- gh-issue-number: gh-156495 -->
* Issue: gh-156495
<!-- /gh-issue-number -->
