### PR TITLE
gh-156466: fix cleanup on error in codegen_leave_annotations_scope

### DIFF
--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -775,10 +775,11 @@ codegen_rename_annotations_format_param(PyCodeObject *co)
 }
 
 static int
-codegen_leave_annotations_scope(compiler *c, location loc)
+codegen_finish_annotations_scope(compiler *c, location loc)
 {
     ADDOP_IN_SCOPE(c, loc, RETURN_VALUE);
     PyCodeObject *co = _PyCompile_OptimizeAndAssemble(c, 1);
+    _PyCompile_ExitScope(c);
     if (co == NULL) {
         return ERROR;
     }
@@ -788,7 +789,6 @@ codegen_leave_annotations_scope(compiler *c, location loc)
         return ERROR;
     }
 
-    _PyCompile_ExitScope(c);
     int ret = codegen_make_closure(c, loc, co, 0);
     Py_DECREF(co);
     RETURN_IF_ERROR(ret);
@@ -891,7 +891,7 @@ codegen_process_deferred_annotations(compiler *c, location loc)
     Py_DECREF(deferred_anno);
     Py_DECREF(conditional_annotation_indices);
 
-    RETURN_IF_ERROR(codegen_leave_annotations_scope(c, loc));
+    RETURN_IF_ERROR(codegen_finish_annotations_scope(c, loc));
     RETURN_IF_ERROR(codegen_nameop(
         c, loc,
         ste->ste_type == ClassBlock ? &_Py_ID(__annotate_func__) : &_Py_ID(__annotate__),
@@ -1197,7 +1197,7 @@ codegen_function_annotations(compiler *c, location loc,
             c, codegen_annotations_in_scope(c, loc, args, returns, &annotations_len)
         );
         ADDOP_I(c, loc, BUILD_MAP, annotations_len);
-        RETURN_IF_ERROR(codegen_leave_annotations_scope(c, loc));
+        RETURN_IF_ERROR(codegen_finish_annotations_scope(c, loc));
         return MAKE_FUNCTION_ANNOTATE;
     }
     else {


### PR DESCRIPTION

`codegen_leave_annotations_scope` could return on an error before the call to `_PyCompile_ExitScope`, and then the scope would not exit. Moved the `_PyCompile_ExitScope` up. 

Also renamed the function because otherwise a return value of `False` should mean "I did not exit the scope". Now the name is not about leaving the scope (we always leave the scope). 



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156466 -->
* Issue: gh-156466
<!-- /gh-issue-number -->
