### PR TITLE
gh-156505: Speed up difflib.HtmlDiff for lopsided replacements

### DIFF
--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -31,7 +31,7 @@ __all__ = ['get_close_matches', 'ndiff', 'restore', 'SequenceMatcher',
            'unified_diff', 'diff_bytes', 'HtmlDiff', 'Match']
 
 from heapq import nlargest as _nlargest
-from collections import namedtuple as _namedtuple
+from collections import deque as _deque, namedtuple as _namedtuple
 from types import GenericAlias
 lazy from _colorize import can_colorize, get_theme
 
@@ -1558,7 +1558,7 @@ def _mdiff(fromlines, tolines, context=None, linejunk=None,
         is defined) does not need to be of module scope.
         """
         line_iterator = _line_iterator()
-        fromlines,tolines=[],[]
+        fromlines, tolines = _deque(), _deque()
         while True:
             # Collecting lines of text until we have a from/to pair
             while (len(fromlines)==0 or len(tolines)==0):
@@ -1571,8 +1571,8 @@ def _mdiff(fromlines, tolines, context=None, linejunk=None,
                 if to_line is not None:
                     tolines.append((to_line,found_diff))
             # Once we have a pair, remove them from the collection and yield it
-            from_line, fromDiff = fromlines.pop(0)
-            to_line, to_diff = tolines.pop(0)
+            from_line, fromDiff = fromlines.popleft()
+            to_line, to_diff = tolines.popleft()
             yield (from_line,to_line,fromDiff or to_diff)
 
     # Handle case where user does not want context differencing, just yield

--- a/Lib/test/test_difflib.py
+++ b/Lib/test/test_difflib.py
@@ -118,6 +118,26 @@ class TestSFbugs(unittest.TestCase):
             [((1, '\x00-2\x01'), (1, '\x00+3\x01'), True)],
         )
 
+    def test_mdiff_lopsided_replace(self):
+        self.assertEqual(
+            list(difflib._mdiff(["a\n"] * 4, ["b\n"])),
+            [
+                ((1, '\x00-a\n\x01'), (1, '\x00+b\n\x01'), True),
+                ((2, '\x00-a\n\x01'), ('', '\n'), True),
+                ((3, '\x00-a\n\x01'), ('', '\n'), True),
+                ((4, '\x00-a\n\x01'), ('', '\n'), True),
+            ],
+        )
+        self.assertEqual(
+            list(difflib._mdiff(["a\n"], ["b\n"] * 4)),
+            [
+                ((1, '\x00-a\n\x01'), (1, '\x00+b\n\x01'), True),
+                (('', '\n'), (2, '\x00+b\n\x01'), True),
+                (('', '\n'), (3, '\x00+b\n\x01'), True),
+                (('', '\n'), (4, '\x00+b\n\x01'), True),
+            ],
+        )
+
 
 patch914575_from1 = """
    1. Beautiful is beTTer than ugly.


### PR DESCRIPTION
`difflib._mdiff()` used lists as FIFO queues for unmatched lines and removed
items with `pop(0)`. This repeatedly shifted the remaining items, causing
quadratic behavior for lopsided replacement blocks.

Use `collections.deque` and `popleft()` for constant-time FIFO removal. This
preserves the existing output while making the affected line-pairing step scale
approximately linearly.

Benchmarks on matched release builds from CPython main:

| Case | Before | After | Speedup |
|---|---:|---:|---:|
| `_mdiff()`, 64,000-to-1 | 264 ms | 61.9 ms | 4.26x |
| `HtmlDiff.make_table()`, 64,000-to-1 | 398 ms | 206 ms | 1.93x |
| `_mdiff()`, 128,000-to-1 | 999 ms | 126 ms | 7.94x |

The complete `test_difflib` suite passes. A focused regression test covers
lopsided replacements in both directions, and randomized differential testing
confirmed identical output for `_mdiff()` and `HtmlDiff` across context and
wrapping modes.

Fixes #156505 


<!-- gh-issue-number: gh-156505 -->
* Issue: gh-156505
<!-- /gh-issue-number -->
