### PR TITLE
gh-156321: Fix asyncio.shield() reporting a retrieved exception

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -909,8 +909,17 @@ def gather(*coros_or_futures, return_exceptions=False):
     return outer
 
 
-def _log_on_exception(fut):
+def _log_on_exception(fut, deferred=False):
     if fut.cancelled():
+        return
+
+    if not deferred:
+        # gh-156321: an exception retrieved by an awaiter must not be reported
+        fut._loop.call_soon(_log_on_exception, fut, True)
+        return
+
+    if not fut._log_traceback:
+        # The exception was retrieved, nothing to report.
         return
 
     exc = fut.exception()

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -2136,6 +2136,21 @@ class BaseTaskTests:
         test_utils.run_briefly(self.loop)
         mock_handler.assert_called_once()
 
+    def test_shield_cancel_outer_exception_retrieved(self):
+        # gh-156321: an exception retrieved by an awaiter must not be reported
+        mock_handler = mock.Mock()
+        self.loop.set_exception_handler(mock_handler)
+        inner = self.new_future(self.loop)
+        outer = asyncio.shield(inner)
+        test_utils.run_briefly(self.loop)
+        outer.cancel()
+        test_utils.run_briefly(self.loop)
+        inner.set_exception(Exception('foo'))
+        self.assertIsNotNone(inner.exception())
+        test_utils.run_briefly(self.loop)
+        test_utils.run_briefly(self.loop)
+        mock_handler.assert_not_called()
+
     def test_shield_cancel_outer_in_task(self):
         inner = self.new_future(self.loop)
 

--- a/Misc/NEWS.d/next/Library/2026-08-28-17-15-00.gh-issue-156321.mNOuMG.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-28-17-15-00.gh-issue-156321.mNOuMG.rst
@@ -1,0 +1,2 @@
+Fix :func:`asyncio.shield` reporting an exception that was already
+retrieved.


### PR DESCRIPTION
Fix asyncio.shield() reporting a retrieved exception

For more details see gh-156321