### PR TITLE
gh-156369: Update Windows builds to OpenSSL 3.5.8

### DIFF
--- a/Misc/NEWS.d/next/Windows/2026-08-28-10-51-35.gh-issue-156369.MPcRL5.rst
+++ b/Misc/NEWS.d/next/Windows/2026-08-28-10-51-35.gh-issue-156369.MPcRL5.rst
@@ -1,0 +1,1 @@
+Updated Windows builds to use OpenSSL 3.5.8.

--- a/Misc/externals.spdx.json
+++ b/Misc/externals.spdx.json
@@ -70,21 +70,21 @@
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "ca94e7c6c223d9caf77bb51aac5949186379608ea2a0cad3aa8bdf31856912e9"
+          "checksumValue": "36af13403a6f34251c875946d1d524c228cbf7b82fd54dd13d9019fbc37da87e"
         }
       ],
-      "downloadLocation": "https://github.com/python/cpython-source-deps/archive/refs/tags/openssl-3.5.7.tar.gz",
+      "downloadLocation": "https://github.com/python/cpython-source-deps/archive/refs/tags/openssl-3.5.8.tar.gz",
       "externalRefs": [
         {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:openssl:openssl:3.5.7:*:*:*:*:*:*:*",
+          "referenceLocator": "cpe:2.3:a:openssl:openssl:3.5.8:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
         }
       ],
       "licenseConcluded": "NOASSERTION",
       "name": "openssl",
       "primaryPackagePurpose": "SOURCE",
-      "versionInfo": "3.5.7"
+      "versionInfo": "3.5.8"
     },
     {
       "SPDXID": "SPDXRef-PACKAGE-sqlite",

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -54,7 +54,7 @@ echo.Fetching external libraries...
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.8
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.4.4
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-3.5.7
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-3.5.8
 set libraries=%libraries%                                       mpdecimal-4.0.0
 set libraries=%libraries%                                       sqlite-3.53.4.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-9.0.4.0
@@ -79,7 +79,7 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi-3.4.4
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-3.5.7
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-3.5.8
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-9.0.4.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 if NOT "%IncludeLLVM%"=="false"    set binaries=%binaries% llvm-21.1.4.0

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -105,8 +105,8 @@
     <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir>
     <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir>
     <mpdecimalDir Condition="$(mpdecimalDir) == ''">$(ExternalsDir)\mpdecimal-4.0.0\</mpdecimalDir>
-    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.5.7\</opensslDir>
-    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.5.7\$(ArchName)\</opensslOutDir>
+    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.5.8\</opensslDir>
+    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.5.8\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir Condition="$(nasmDir) == ''">$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.3.1\</zlibDir>


### PR DESCRIPTION


<!-- gh-issue-number: gh-156369 -->
* Issue: gh-156369
<!-- /gh-issue-number -->
