### PR TITLE
[3.13] gh-156369: Update Windows builds to use OpenSSL 3.0.22

### DIFF
--- a/Misc/NEWS.d/next/Windows/2026-08-28-10-55-22.gh-issue-156369.ETuGDj.rst
+++ b/Misc/NEWS.d/next/Windows/2026-08-28-10-55-22.gh-issue-156369.ETuGDj.rst
@@ -1,0 +1,1 @@
+Updated Windows builds to use OpenSSL 3.0.22.

--- a/Misc/externals.spdx.json
+++ b/Misc/externals.spdx.json
@@ -70,21 +70,21 @@
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "0349aef1ff9ded3eb23be12c2586e026be5cec3fd40df859e388671d7844fced"
+          "checksumValue": "0a7db2958a5ba7f3a7438835f1a583476a611aa160e04b445f9a25e2ffe865aa"
         }
       ],
-      "downloadLocation": "https://github.com/python/cpython-source-deps/archive/refs/tags/openssl-3.0.21.tar.gz",
+      "downloadLocation": "https://github.com/python/cpython-source-deps/archive/refs/tags/openssl-3.0.22.tar.gz",
       "externalRefs": [
         {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:openssl:openssl:3.0.21:*:*:*:*:*:*:*",
+          "referenceLocator": "cpe:2.3:a:openssl:openssl:3.0.22:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
         }
       ],
       "licenseConcluded": "NOASSERTION",
       "name": "openssl",
       "primaryPackagePurpose": "SOURCE",
-      "versionInfo": "3.0.21"
+      "versionInfo": "3.0.22"
     },
     {
       "SPDXID": "SPDXRef-PACKAGE-sqlite",

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -53,7 +53,7 @@ echo.Fetching external libraries...
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.8
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.4.4
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-3.0.21
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-3.0.22
 set libraries=%libraries%                                       mpdecimal-4.0.0
 set libraries=%libraries%                                       sqlite-3.50.4.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.15.0
@@ -77,7 +77,7 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi-3.4.4
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-3.0.21
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-3.0.22
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.15.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -76,8 +76,8 @@
     <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir>
     <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir>
     <mpdecimalDir Condition="$(mpdecimalDir) == ''">$(ExternalsDir)\mpdecimal-4.0.0\</mpdecimalDir>
-    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.0.21\</opensslDir>
-    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.0.21\$(ArchName)\</opensslOutDir>
+    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.0.22\</opensslDir>
+    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.0.22\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir Condition="$(nasmDir) == ''">$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.3.1\</zlibDir>


### PR DESCRIPTION


<!-- gh-issue-number: gh-156369 -->
* Issue: gh-156369
<!-- /gh-issue-number -->
