### PR TITLE
Do not recurse into `Literal` arguments during type evaluation

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -475,6 +475,9 @@ def _eval_type(t, globalns, localns, type_params, *, recursive_guard=frozenset()
                                     type_params=type_params, owner=owner,
                                     _recursive_guard=recursive_guard, format=format)
     if isinstance(t, (_GenericAlias, GenericAlias, Union)):
+        if isinstance(t, _LiteralGenericAlias):
+            # Unlike other generic aliases, Literal arguments aren't type expressions
+            return t
         if isinstance(t, GenericAlias):
             args = tuple(
                 _make_forward_ref(arg, parent_fwdref=parent_fwdref) if isinstance(arg, str) else arg


### PR DESCRIPTION
Unlike other generic aliases, `Literal` arguments aren't type expressions (e.g. `Literal[1, 'a'].__args__ == (1, 'a')`. As such, there is no need to recurse into all the arguments as they are guaranteed to be returned unchanged.

This is a small optimizaztion, that do not requires a news entry.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
