### PR TITLE
gh-156537: Optimize codec.decode by inlining the per-character write in CJK decoders

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-08-28-21-08-58.gh-issue-156537.aJhAM2.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-28-21-08-58.gh-issue-156537.aJhAM2.rst
@@ -1,0 +1,1 @@
+Optimize codecs.decode() calls

--- a/Misc/NEWS.d/next/Library/2026-08-28-21-08-58.gh-issue-156537.aJhAM2.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-28-21-08-58.gh-issue-156537.aJhAM2.rst
@@ -1,1 +1,0 @@
-Optimize codecs.decode() calls

--- a/Modules/cjkcodecs/cjkcodecs.h
+++ b/Modules/cjkcodecs/cjkcodecs.h
@@ -153,10 +153,13 @@ get_module_state(PyObject *mod)
 #define INCHAR1 (PyUnicode_READ(kind, data, *inpos))
 #define INCHAR2 (PyUnicode_READ(kind, data, *inpos + 1))
 
+/* Decoders emit one character at a time, so this must stay inline: the
+   out-of-line _PyUnicodeWriter_WriteChar() is a cross-module call per output
+   character.  OUTCHAR2 below is written inline for the same reason. */
 #define OUTCHAR(c)                                                         \
     do {                                                                   \
-        if (_PyUnicodeWriter_WriteChar(writer, (c)) < 0)                   \
-            return MBERR_EXCEPTION;                                         \
+        if (_PyUnicodeWriter_WriteCharInline(writer, (c)) < 0)             \
+            return MBERR_EXCEPTION;                                        \
     } while (0)
 
 #define OUTCHAR2(c1, c2)                                                   \

--- a/Modules/cjkcodecs/cjkcodecs.h
+++ b/Modules/cjkcodecs/cjkcodecs.h
@@ -153,9 +153,6 @@ get_module_state(PyObject *mod)
 #define INCHAR1 (PyUnicode_READ(kind, data, *inpos))
 #define INCHAR2 (PyUnicode_READ(kind, data, *inpos + 1))
 
-/* Decoders emit one character at a time, so this must stay inline: the
-   out-of-line _PyUnicodeWriter_WriteChar() is a cross-module call per output
-   character.  OUTCHAR2 below is written inline for the same reason. */
 #define OUTCHAR(c)                                                         \
     do {                                                                   \
         if (_PyUnicodeWriter_WriteCharInline(writer, (c)) < 0)             \


### PR DESCRIPTION
Every CJK decoder emits output through `OUTCHAR()`, which called the exported `_PyUnicodeWriter_WriteChar()`.  Since the codecs are shared extension modules, that's a cross boundary call to the exported function for each output character. Swapping to the `_PyUnicodeWriter_WriteCharInline()` removes the overhead of crossing the boundary speeding up decoding.

The single macro applies to all of the codec modules. 

| Benchmark | main | PR |
|---|---|---|
| decode 1.8MB shift_jis | 6.87 ms | 2.55 ms: 2.70x faster |
| decode 1.8MB euc_kr | 6.34 ms | 2.50 ms: 2.54x faster |
| decode 1.8MB euc_jp | 6.36 ms | 2.55 ms: 2.49x faster |
| decode 1.8MB big5 | 6.27 ms | 2.56 ms: 2.45x faster |
| decode 1kB euc_jp | 3.97 us | 1.82 us: 2.18x faster |
| decode 1.8MB euc_jp kana | 3.86 ms | 3.07 ms: 1.26x faster |

<details>
<summary>Benchmark script</summary>

```python
"""CJK decoder throughput (Modules/cjkcodecs)."""
import pyperf

ASCII = ('abc' * 30 + '\n')
KANA = ('あいう' * 10 + '\n')

def dec(d, e):
    d.decode(e)

if __name__ == "__main__":
    r = pyperf.Runner()
    for enc in ("euc_jp", "shift_jis", "big5", "euc_kr"):
        r.bench_func("decode 1.8MB %s" % enc, dec, (ASCII * 20000).encode(enc), enc)
    r.bench_func("decode 1.8MB euc_jp kana", dec, (KANA * 20000).encode("euc_jp"), "euc_jp")
    r.bench_func("decode 1kB euc_jp", dec, (ASCII * 11).encode("euc_jp"), "euc_jp")
```
</details>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156537 -->
* Issue: gh-156537
<!-- /gh-issue-number -->
