### PR TITLE
gh-156539: Validate duplicate ZIP members individually in testzip

### DIFF
--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -4335,6 +4335,30 @@ class OtherTests(unittest.TestCase):
             f.write('zipfile test data')
         self.assertRaises(ValueError, zipf.write, TESTFN)
 
+    def test_testzip_with_duplicate_names(self):
+        data = io.BytesIO()
+        with zipfile.ZipFile(data, mode="w") as zipf:
+            zipf.writestr("duplicate", b"corrupt")
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                zipf.writestr("duplicate", b"valid")
+
+        zipdata = bytearray(data.getvalue())
+        with zipfile.ZipFile(io.BytesIO(zipdata)) as zipf:
+            zinfo = zipf.infolist()[0]
+            file_header = struct.unpack_from(
+                zipfile.structFileHeader, zipdata, zinfo.header_offset
+            )
+            name_length, extra_length = file_header[-2:]
+        data_offset = (zinfo.header_offset + zipfile.sizeFileHeader
+                       + name_length + extra_length)
+        zipdata[data_offset] ^= 1
+
+        with zipfile.ZipFile(io.BytesIO(zipdata)) as zipf:
+            self.assertRaises(zipfile.BadZipFile, zipf.read,
+                              zipf.infolist()[0])
+            self.assertEqual("duplicate", zipf.testzip())
+
     def test_bad_constructor_mode(self):
         """Check that bad modes passed to ZipFile constructor are caught."""
         self.assertRaises(ValueError, zipfile.ZipFile, TESTFN, "q")

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -2145,7 +2145,7 @@ class ZipFile:
             try:
                 # Read by chunks, to avoid an OverflowError or a
                 # MemoryError with very large embedded files.
-                with self.open(zinfo.filename, "r") as f:
+                with self.open(zinfo, "r") as f:
                     while f.read(chunk_size):     # Check CRC-32
                         pass
             except BadZipFile:
@@ -2401,8 +2401,7 @@ class ZipFile:
             except KeyError:
                 pass
 
-            # Avoid missing entry if there is another entry having the same name,
-            # to prevent an error on `testzip()`.
+            # Keep the last remaining entry with this name in NameToInfo.
             # Reverse the order as NameToInfo normally stores the last added one.
             for zi in reversed(self.filelist):
                 if zi.filename == zinfo.filename:

--- a/Misc/NEWS.d/next/Library/2026-08-29-09-28-53.gh-issue-156539.mH4AGb.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-29-09-28-53.gh-issue-156539.mH4AGb.rst
@@ -1,0 +1,3 @@
+Fix :meth:`zipfile.ZipFile.testzip` to validate every member in a ZIP
+archive with duplicate names. It could previously miss corruption in an
+earlier member.


### PR DESCRIPTION
Fix `ZipFile.testzip()` to pass each `ZipInfo` object directly to `open()` instead of reopening the member by filename.

When an archive contains duplicate filenames, filename-based lookup resolves to the last matching entry. As a result, `testzip()` can iterate over an earlier `ZipInfo` but actually reopen and validate a later duplicate, allowing corruption in the earlier member to go undetected.

Passing the `ZipInfo` directly preserves the identity of the member being iterated and ensures that every entry in `filelist` is validated individually.

This also avoids an unnecessary filename-to-`ZipInfo` lookup through `NameToInfo` and makes the implementation better match the existing `ZipFile.open()` API, which already accepts `ZipInfo` objects specifically to disambiguate duplicate members.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156539 -->
* Issue: gh-156539
<!-- /gh-issue-number -->
