### PR TITLE
gh-156466: Fix additional compiler scope cleanup errors

### DIFF
--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -1634,7 +1634,7 @@ codegen_class_body(compiler *c, stmt_ty s, int firstlineno)
         ADDOP_N_IN_SCOPE(c, loc, STORE_DEREF, &_Py_ID(__classdict__), cellvars);
     }
     if (SYMTABLE_ENTRY(c)->ste_has_conditional_annotations) {
-        ADDOP_I(c, loc, BUILD_SET, 0);
+        ADDOP_I_IN_SCOPE(c, loc, BUILD_SET, 0);
         ADDOP_N_IN_SCOPE(c, loc, STORE_DEREF, &_Py_ID(__conditional_annotations__), cellvars);
     }
     /* compile the body proper */

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -1735,7 +1735,9 @@ _PyCompile_CodeGen(PyObject *ast, PyObject *filename, PyCompilerFlags *pflags,
 finally:
     Py_XDECREF(consts_list);
     Py_XDECREF(metadata);
-    _PyCompile_ExitScope(c);
+    if (c->u != NULL) {
+        _PyCompile_ExitScope(c);
+    }
     compiler_free(c);
     _PyArena_Free(arena);
     return res;


### PR DESCRIPTION
Two small cleanup bugs:

* `codegen_class_body` was missing an IN_SCOPE
* `_PyCompile_CodeGen` could exit a scope that was never entered in the path where `metadata` failed allocation

<!-- gh-issue-number: gh-156466 -->
* Issue: gh-156466
<!-- /gh-issue-number -->
