### PR TITLE
gh-156548: Performance - Presize sets built from sized iterables

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-29-04-42-02.gh-issue-156548.ywUwcn.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-29-04-42-02.gh-issue-156548.ywUwcn.rst
@@ -1,0 +1,1 @@
+Optimize set(), frozenset(), and set.update().

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -563,17 +563,11 @@ set_table_resize(PySetObject *so, Py_ssize_t minused)
 }
 
 /*
-Do one big resize at the start, rather than incrementally resizing as we insert
-new keys.  Expect that there will be no (or few) overlapping keys.  An `n` too
-large for the arithmetic below is ignored, leaving growth incremental.
+Resize at the start of an operation where the final maximum set size is known
 */
 static int
 set_presize(PySetObject *so, Py_ssize_t n)
 {
-    assert(n >= 0);
-    if (n == 0 || n >= PY_SSIZE_T_MAX/8 - so->fill) {
-        return 0;
-    }
     if ((so->fill + n)*5 >= so->mask*3) {
         return set_table_resize(so, (so->used + n)*2);
     }
@@ -1236,7 +1230,11 @@ set_update_iterable_lock_held(PySetObject *so, PyObject *other)
 
     Py_ssize_t n = PyObject_LengthHint(other, 0);
     if (n < 0) {
-        PyErr_Clear();  /* advisory only; just grow on demand instead */
+        PyErr_Clear();  /* grow on demand instead */
+    }
+    else if (n == 0 || n >= PY_SSIZE_T_MAX/8 - so->fill) {
+        /* Either a length hint was not found or the returned value for `n`
+           could lead to an overflow */
     }
     else if (set_presize(so, n) < 0) {
         Py_DECREF(it);

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -562,6 +562,24 @@ set_table_resize(PySetObject *so, Py_ssize_t minused)
     return 0;
 }
 
+/*
+Do one big resize at the start, rather than incrementally resizing as we insert
+new keys.  Expect that there will be no (or few) overlapping keys.  An `n` too
+large for the arithmetic below is ignored, leaving growth incremental.
+*/
+static int
+set_presize(PySetObject *so, Py_ssize_t n)
+{
+    assert(n >= 0);
+    if (n == 0 || n >= PY_SSIZE_T_MAX/8 - so->fill) {
+        return 0;
+    }
+    if ((so->fill + n)*5 >= so->mask*3) {
+        return set_table_resize(so, (so->used + n)*2);
+    }
+    return 0;
+}
+
 static int
 set_contains_entry(PySetObject *so, PyObject *key, Py_hash_t hash)
 {
@@ -842,13 +860,8 @@ set_merge_lock_held(PySetObject *so, PyObject *otherset)
     if (other == so || other->used == 0)
         /* a.update(a) or a.update(set()); nothing to do */
         return 0;
-    /* Do one big resize at the start, rather than
-     * incrementally resizing as we insert new keys.  Expect
-     * that there will be no (or few) overlapping keys.
-     */
-    if ((so->fill + other->used)*5 >= so->mask*3) {
-        if (set_table_resize(so, (so->used + other->used)*2) != 0)
-            return -1;
+    if (set_presize(so, other->used) < 0) {
+        return -1;
     }
     so_entry = so->table;
     other_entry = other->table;
@@ -1195,15 +1208,8 @@ set_update_dict_lock_held(PySetObject *so, PyObject *other)
     }
 #endif
 
-    /* Do one big resize at the start, rather than
-    * incrementally resizing as we insert new keys.  Expect
-    * that there will be no (or few) overlapping keys.
-    */
-    Py_ssize_t dictsize = PyDict_GET_SIZE(other);
-    if ((so->fill + dictsize)*5 >= so->mask*3) {
-        if (set_table_resize(so, (so->used + dictsize)*2) != 0) {
-            return -1;
-        }
+    if (set_presize(so, PyDict_GET_SIZE(other)) < 0) {
+        return -1;
     }
 
     Py_ssize_t pos = 0;
@@ -1225,6 +1231,15 @@ set_update_iterable_lock_held(PySetObject *so, PyObject *other)
 
     PyObject *it = PyObject_GetIter(other);
     if (it == NULL) {
+        return -1;
+    }
+
+    Py_ssize_t n = PyObject_LengthHint(other, 0);
+    if (n < 0) {
+        PyErr_Clear();  /* advisory only; just grow on demand instead */
+    }
+    else if (set_presize(so, n) < 0) {
+        Py_DECREF(it);
         return -1;
     }
 


### PR DESCRIPTION
`set()` and `set.update()` already presize their underlying containers when they can infer the expected container size from another `set` or `dict`, but they fall back to incremental growth for all other iterables. 

Since we can also retrieve the size of lists and tuples, we can extend the same logic to sized iterables to reduce container resizing overhead. Iterables that have no clear size (i.e. generators) will remain unaffected. 

For this PR, I first refactored the two existing explicit presize calls into a helper function to be shared for the sized iterables as well. 

  | Benchmark | main | PR |
  |---|---|---|
  | set(list[str]) 10k | 158 us | 119 us: 1.32x faster |
  | set(list[str]) 1M | 88.2 ms | 68.7 ms: 1.28x faster |
  | set(tuple[str]) 1M | 85.6 ms | 66.9 ms: 1.28x faster |
  | set(list[int]) 10k | 117 us | 95.3 us: 1.23x faster |
  | set(list[int]) 1M | 24.9 ms | 20.6 ms: 1.21x faster |
  | set(tuple[int]) 1M | 23.8 ms | 19.9 ms: 1.20x faster |
  | set.update(list) 1M | 24.2 ms | 20.5 ms: 1.18x faster |
  | frozenset(list) 1M | 26.6 ms | 22.6 ms: 1.18x faster |
  | set(genexpr) 1M [no hint] | 59.4 ms | 60.3 ms: 1.02x slower |

**Note:** In the no hint case, theres about a ~8ns fixed overhead to call `PyObject_LengthHint` and discard the output.

<details>
<summary>Benchmark script</summary>

```python
"""set/frozenset built from a sized iterable (Objects/setobject.c)."""
import pyperf

def mkset(s): 
  set(s)

def mkfrozen(s): 
  frozenset(s)

def upd(s): 
  d = set(); d.update(s)

def gen(n): 
  set(x for x in range(n))

if __name__ == "__main__":
    r = pyperf.Runner()
    ints = list(range(1000000)); strs = [str(i) for i in ints]
    r.bench_func("set(list[int]) 1M", mkset, ints)
    r.bench_func("set(list[str]) 1M", mkset, strs)
    r.bench_func("frozenset(list) 1M", mkfrozen, ints)
    r.bench_func("set.update(list) 1M", upd, ints)
    r.bench_func("set(list) 10k", mkset, list(range(10000)))
    r.bench_func("set(genexpr) 1M [no hint]", gen, 1000000)
```
</details>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156548 -->
* Issue: gh-156548
<!-- /gh-issue-number -->
