### PR TITLE
gh-156145: Don't rely on errno for float `pow` and `is_integer`

### DIFF
--- a/Include/internal/pycore_pymath.h
+++ b/Include/internal/pycore_pymath.h
@@ -9,10 +9,9 @@ extern "C" {
 #endif
 
 
-/* _Py_ADJUST_ERANGE1(x)
- * _Py_ADJUST_ERANGE2(x, y)
- * Set errno to 0 before calling a libm function, and invoke one of these
- * macros after, passing the function result(s) (_Py_ADJUST_ERANGE2 is useful
+/* _Py_ADJUST_ERANGE2(x, y)
+ * Set errno to 0 before calling a libm function, and invoke this
+ * macro after, passing the function result(s) (_Py_ADJUST_ERANGE2 is useful
  * for functions returning complex results).  This makes two kinds of
  * adjustments to errno:  (A) If it looks like the platform libm set
  * errno=ERANGE due to underflow, clear errno. (B) If it looks like the
@@ -30,18 +29,6 @@ extern "C" {
  *        if the returned result is a NaN, or if a C89 box returns HUGE_VAL
  *        in non-overflow cases.
  */
-static inline void _Py_ADJUST_ERANGE1(double x)
-{
-    if (errno == 0) {
-        if (x == INFINITY || x == -INFINITY) {
-            errno = ERANGE;
-        }
-    }
-    else if (errno == ERANGE && x == 0.0) {
-        errno = 0;
-    }
-}
-
 static inline void _Py_ADJUST_ERANGE2(double x, double y)
 {
     if (x == INFINITY || x == -INFINITY ||

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -785,18 +785,13 @@ float_pow(PyObject *v, PyObject *w, PyObject *z)
      * positive and not equal to 1.0.  We finally allow
      * the platform pow to step in and do the rest.
      */
-    errno = 0;
     ix = pow(iv, iw);
-    _Py_ADJUST_ERANGE1(ix);
     if (negate_result)
         ix = -ix;
 
-    if (errno != 0) {
-        /* We don't expect any errno value other than ERANGE, but
-         * the range of libm bugs appears unbounded.
-         */
-        PyErr_SetFromErrno(errno == ERANGE ? PyExc_OverflowError :
-                             PyExc_ValueError);
+    if (isinf(ix)) {
+        PyErr_SetString(PyExc_OverflowError,
+                        "float exponentiation result out of range");
         return NULL;
     }
     return PyFloat_FromDouble(ix);
@@ -836,20 +831,12 @@ float_is_integer_impl(PyObject *self)
 /*[clinic end generated code: output=7112acf95a4d31ea input=311810d3f777e10d]*/
 {
     double x = PyFloat_AsDouble(self);
-    PyObject *o;
 
     if (x == -1.0 && PyErr_Occurred())
         return NULL;
     if (!isfinite(x))
         Py_RETURN_FALSE;
-    errno = 0;
-    o = (floor(x) == x) ? Py_True : Py_False;
-    if (errno != 0) {
-        PyErr_SetFromErrno(errno == ERANGE ? PyExc_OverflowError :
-                             PyExc_ValueError);
-        return NULL;
-    }
-    return Py_NewRef(o);
+    return PyBool_FromLong(floor(x) == x);
 }
 
 /*[clinic input]


### PR DESCRIPTION
This PR only addresses the `Objects/floatobject.c` portion of the linked issue.

Buy one get one free: I believe this PR allows closing #91290 

<!-- gh-issue-number: gh-156145 -->
* Issue: gh-156145
<!-- /gh-issue-number -->
