### PR TITLE
gh-156555: Fix crash in sqlite3.Row() with uninitialised Cursor

### DIFF
--- a/Lib/test/test_sqlite3/test_factory.py
+++ b/Lib/test/test_sqlite3/test_factory.py
@@ -280,6 +280,12 @@ class RowFactoryTests(MemoryDatabaseMixin, unittest.TestCase):
         self.assertRaises(TypeError, self.con.cursor, FakeCursor)
         self.assertRaises(TypeError, sqlite.Row, FakeCursor(), ())
 
+    def test_uninitialised_cursor(self):
+        cur = sqlite.Cursor.__new__(sqlite.Cursor)
+        with self.assertRaisesRegex(sqlite.ProgrammingError,
+                                    "Base Cursor.__init__ not called"):
+            sqlite.Row(cur, ())
+
 
 class TextFactoryTests(MemoryDatabaseMixin, unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2026-08-29-18-52-43.gh-issue-156555.nNV61R.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-29-18-52-43.gh-issue-156555.nNV61R.rst
@@ -1,0 +1,3 @@
+Fix a crash in :class:`sqlite3.Row` when it is given a
+:class:`sqlite3.Cursor` whose ``__init__()`` was not called; it now raises
+:exc:`sqlite3.ProgrammingError` instead.

--- a/Modules/_sqlite/row.c
+++ b/Modules/_sqlite/row.c
@@ -88,6 +88,13 @@ pysqlite_row_new_impl(PyTypeObject *type, pysqlite_Cursor *cursor,
 
     assert(type != NULL && type->tp_alloc != NULL);
 
+    if (!cursor->initialized) {
+        pysqlite_state *state = pysqlite_get_state_by_type(type);
+        PyErr_SetString(state->ProgrammingError,
+                        "Base Cursor.__init__ not called.");
+        return NULL;
+    }
+
     self = (pysqlite_Row *) type->tp_alloc(type, 0);
     if (self == NULL)
         return NULL;


### PR DESCRIPTION


<!-- gh-issue-number: gh-156555 -->
* Issue: gh-156555
<!-- /gh-issue-number -->
