### PR TITLE
[3.14] gh-155974: Add a test for the window attributes after a failed write

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -428,6 +428,26 @@ class TestCurses(unittest.TestCase):
                 self.assertRaises(ValueError, stdscr.insstr, arg)
                 self.assertRaises(ValueError, stdscr.insnstr, arg, 1)
 
+    def test_output_string_attr_restored(self):
+        # A write with an attr restores the window rendition afterwards,
+        # whether it succeeded or failed.
+        win = curses.newwin(2, 10, 0, 0)
+        def current_attrs():
+            # Write a cell with the window's current rendition and read it
+            # back, so that the rendition itself is checked.
+            win.addstr(1, 0, ' ')
+            return win.inch(1, 0) & curses.A_ATTRIBUTES
+        for func, args in [(win.addstr, ('x',)), (win.addnstr, ('x', 1)),
+                           (win.insstr, ('x',)), (win.insnstr, ('x', 1))]:
+            with self.subTest(func.__qualname__):
+                win.attrset(curses.A_UNDERLINE)
+                # y=100 is outside the window, so the write fails.
+                self.assertRaises(curses.error, func, 100, 0, *args,
+                                  curses.A_BOLD)
+                self.assertEqual(current_attrs(), curses.A_UNDERLINE)
+                func(0, 0, *args, curses.A_BOLD)
+                self.assertEqual(current_attrs(), curses.A_UNDERLINE)
+
     def test_add_string_behavior(self):
         # addstr() advances the cursor past the written text; addnstr()
         # writes at most n characters.


### PR DESCRIPTION
A write with an *attr* restores the window rendition afterwards, whether it succeeded or failed. This branch does the right thing already -- the regression fixed by #155975 was introduced in 3.15 by 30dde1eeb3f, which is not here -- so this only adds the test as a guard.

The test reads the rendition by writing a cell with it and reading that cell back with `inch()`, since `window.getattrs()` is 3.16 only.

<!-- gh-issue-number: gh-155974 -->
* Issue: gh-155974
<!-- /gh-issue-number -->
