### PR TITLE
gh-151365: Revert temporary Git downgrade

### DIFF
--- a/.github/workflows/reusable-check-html-ids.yml
+++ b/.github/workflows/reusable-check-html-ids.yml
@@ -20,13 +20,6 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: 'Downgrade Git'
-        # Temporarily downgrade to 2.43 until 2.55 is in the runner image,
-        # to avoid "fatal: shallow file has changed since we read it" bug.
-        # See https://github.com/python/cpython/issues/151365.
-        run: |
-          sudo apt-get install -y --allow-downgrades 'git=1:2.43.*' 'git-man=1:2.43.*'
-          git --version
       - name: 'Find merge base'
         id: merge-base
         run: |

--- a/.github/workflows/reusable-context.yml
+++ b/.github/workflows/reusable-context.yml
@@ -90,15 +90,6 @@ jobs:
             || ''
           }}
 
-    - name: 'Downgrade Git'
-      # Temporarily downgrade to 2.43 until 2.55 is in the runner image,
-      # to avoid "fatal: shallow file has changed since we read it" bug.
-      # See https://github.com/python/cpython/issues/151365.
-      if: github.event_name == 'pull_request'
-      run: |
-        sudo apt-get install -y --allow-downgrades 'git=1:2.43.*' 'git-man=1:2.43.*'
-        git --version
-
     # Adapted from https://github.com/actions/checkout/issues/520#issuecomment-1167205721
     - name: Fetch commits to get branch diff
       if: github.event_name == 'pull_request'

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -47,14 +47,6 @@ jobs:
             && github.event.pull_request.head.sha
             || ''
           }}
-    - name: 'Downgrade Git'
-      # Temporarily downgrade to 2.43 until 2.55 is in the runner image,
-      # to avoid "fatal: shallow file has changed since we read it" bug.
-      # See https://github.com/python/cpython/issues/151365.
-      if: github.event_name == 'pull_request'
-      run: |
-        sudo apt-get install -y --allow-downgrades 'git=1:2.43.*' 'git-man=1:2.43.*'
-        git --version
     # Adapted from https://github.com/actions/checkout/issues/520#issuecomment-1167205721
     - name: 'Fetch commits to get branch diff'
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
This reverts commit 6d2b551399342fc6621195abfde7d79bcb1d7a4b.

The [`Ubuntu 24.04`](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) and [`Ubuntu 26.04`](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2604-Readme.md) runner images now default to Git 2.55.0, so the revert is no longer necessary. 
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-151365 -->
* Issue: gh-151365
<!-- /gh-issue-number -->
