### PR TITLE
Fix a dangling pointer and reference leak in `local_timezone_from_timestamp`

### DIFF
--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -6762,7 +6762,7 @@ local_timezone_from_timestamp(time_t timestamp)
     PyObject *nameo = NULL;
     const char *zone = NULL;
 #ifndef HAVE_STRUCT_TM_TM_ZONE
-    char buf[100];
+    char buf[100];  // for zone, which is used after the block below
 #endif
 
     if (_PyTime_localtime(timestamp, &local_time_tm) != 0)
@@ -6774,10 +6774,9 @@ local_timezone_from_timestamp(time_t timestamp)
     {
         PyObject *local_time, *utc_time;
         struct tm utc_time_tm;
-        if (strftime(buf, sizeof(buf), "%Z", &local_time_tm) == 0) {
-            buf[0] = '\0';
+        if (strftime(buf, sizeof(buf), "%Z", &local_time_tm) != 0) {
+            zone = buf;
         }
-        zone = buf;
         local_time = new_datetime(local_time_tm.tm_year + 1900,
                                   local_time_tm.tm_mon + 1,
                                   local_time_tm.tm_mday,

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -6761,6 +6761,9 @@ local_timezone_from_timestamp(time_t timestamp)
     struct tm local_time_tm;
     PyObject *nameo = NULL;
     const char *zone = NULL;
+#ifndef HAVE_STRUCT_TM_TM_ZONE
+    char buf[100];
+#endif
 
     if (_PyTime_localtime(timestamp, &local_time_tm) != 0)
         return NULL;
@@ -6771,8 +6774,9 @@ local_timezone_from_timestamp(time_t timestamp)
     {
         PyObject *local_time, *utc_time;
         struct tm utc_time_tm;
-        char buf[100];
-        strftime(buf, sizeof(buf), "%Z", &local_time_tm);
+        if (strftime(buf, sizeof(buf), "%Z", &local_time_tm) == 0) {
+            buf[0] = '\0';
+        }
         zone = buf;
         local_time = new_datetime(local_time_tm.tm_year + 1900,
                                   local_time_tm.tm_mon + 1,
@@ -6783,8 +6787,10 @@ local_timezone_from_timestamp(time_t timestamp)
         if (local_time == NULL) {
             return NULL;
         }
-        if (_PyTime_gmtime(timestamp, &utc_time_tm) != 0)
+        if (_PyTime_gmtime(timestamp, &utc_time_tm) != 0) {
+            Py_DECREF(local_time);
             return NULL;
+        }
         utc_time = new_datetime(utc_time_tm.tm_year + 1900,
                                 utc_time_tm.tm_mon + 1,
                                 utc_time_tm.tm_mday,


### PR DESCRIPTION
A few little fixes. The `zone` pointer outlives the block holding `buf`, `strftime()`'s result is unchecked, and `local_time` leaks when `_PyTime_gmtime()` failed. I don't think any are news-worthy, these are unlikely to cause an issue in practice.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
