### PR TITLE
[3.14] gh-151365: Revert temporary Git downgrade (GH-156584)

### DIFF
--- a/.github/workflows/reusable-context.yml
+++ b/.github/workflows/reusable-context.yml
@@ -94,15 +94,6 @@ jobs:
             || ''
           }}
 
-    - name: 'Downgrade Git'
-      # Temporarily downgrade to 2.43 until 2.55 is in the runner image,
-      # to avoid "fatal: shallow file has changed since we read it" bug.
-      # See https://github.com/python/cpython/issues/151365.
-      if: github.event_name == 'pull_request'
-      run: |
-        sudo apt-get install -y --allow-downgrades 'git=1:2.43.*' 'git-man=1:2.43.*'
-        git --version
-
     # Adapted from https://github.com/actions/checkout/issues/520#issuecomment-1167205721
     - name: Fetch commits to get branch diff
       if: github.event_name == 'pull_request'

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -47,14 +47,6 @@ jobs:
             && github.event.pull_request.head.sha
             || ''
           }}
-    - name: 'Downgrade Git'
-      # Temporarily downgrade to 2.43 until 2.55 is in the runner image,
-      # to avoid "fatal: shallow file has changed since we read it" bug.
-      # See https://github.com/python/cpython/issues/151365.
-      if: github.event_name == 'pull_request'
-      run: |
-        sudo apt-get install -y --allow-downgrades 'git=1:2.43.*' 'git-man=1:2.43.*'
-        git --version
     # Adapted from https://github.com/actions/checkout/issues/520#issuecomment-1167205721
     - name: 'Fetch commits to get branch diff'
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
Revert "gh-151365: Temporarily downgrade Git to prevent fatal error (GH-155495)"

This reverts commit 6d2b551399342fc6621195abfde7d79bcb1d7a4b. (cherry picked from commit 3e9efe550971a02a1580f2202399c1249d4be548)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
