### PR TITLE
[3.14] gh-69370: Fix "python -m inspect --details" for unencodable paths (GH-155246)

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -3361,6 +3361,10 @@ def _main():
     import argparse
     import importlib
 
+    # The printed text can contain characters unencodable in the encoding
+    # of stdout, e.g. undecodable bytes of a file name.
+    sys.stdout.reconfigure(errors='backslashreplace')
+
     parser = argparse.ArgumentParser(color=True)
     parser.add_argument(
         'object',

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -40,7 +40,7 @@ from test.support import cpython_only, import_helper
 from test.support import MISSING_C_DOCSTRINGS, ALWAYS_EQ
 from test.support import run_no_yield_async_fn, EqualToForwardRef
 from test.support.import_helper import DirsOnSysPath, ready_to_import
-from test.support.os_helper import TESTFN, temp_cwd
+from test.support.os_helper import TESTFN, TESTFN_UNDECODABLE, temp_cwd
 from test.support.script_helper import assert_python_ok, assert_python_failure, kill_python
 from test.support import has_subprocess_support
 from test import support
@@ -6461,6 +6461,25 @@ class TestMain(unittest.TestCase):
                                             'sys')
         lines = err.decode().splitlines()
         self.assertEqual(lines, ["Can't get info for builtin modules."])
+
+    @unittest.skipUnless(TESTFN_UNDECODABLE,
+                         'requires undecodable file names')
+    def test_details_undecodable_path(self):
+        # gh-69370: the path of the module is not encodable in the encoding
+        # of stdout.
+        with temp_cwd() as test_dir:
+            subdir = os.path.join(os.fsencode(test_dir), TESTFN_UNDECODABLE)
+            try:
+                os.mkdir(subdir)
+            except OSError:
+                self.skipTest('undecodable paths are not supported')
+            with open(os.path.join(subdir, b'undecodable_mod.py'), 'w') as f:
+                f.write('"""Module docstring."""\n')
+            rc, out, err = assert_python_ok('-X', 'utf8=0', '-m', 'inspect',
+                                            '--details', 'undecodable_mod',
+                                            PYTHONPATH=os.fsdecode(subdir))
+        self.assertIn(b'Target: undecodable_mod', out)
+        self.assertEqual(err, b'')
 
     def test_details(self):
         module = importlib.import_module('unittest')

--- a/Misc/NEWS.d/next/Library/2026-08-05-17-30-00.gh-issue-69370.inspCLI.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-05-17-30-00.gh-issue-69370.inspCLI.rst
@@ -1,0 +1,4 @@
+:program:`python -m inspect --details` no longer fails with
+:exc:`UnicodeEncodeError` if the path of the module contains characters
+unencodable in the encoding of :data:`sys.stdout`.  Such characters are now
+escaped with backslashes.


### PR DESCRIPTION
It failed with UnicodeEncodeError if the path of the module contains characters unencodable in the encoding of sys.stdout, e.g. undecodable bytes of a file name.  Such characters are now escaped with backslashes, unless stdout uses an error handler which can handle them.

(cherry picked from commit abf7a184bd94da4d1a6b54503a27ede1957b48b7)

`test_details_undecodable_path()` is added before `test_details()`, which is named `test_details_option_with_package()` in the main branch.


<!-- gh-issue-number: gh-69370 -->
* Issue: gh-69370
<!-- /gh-issue-number -->
