### PR TITLE
gh-156512: Guard duplicate connection lost calls in asyncio selector transports

### DIFF
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -916,8 +916,9 @@ class _SelectorTransport(transports._FlowControlMixin,
             if self._protocol_connected:
                 self._protocol.connection_lost(exc)
         finally:
-            self._sock.close()
-            self._sock = None
+            if self._sock is not None:
+                self._sock.close()
+                self._sock = None
             self._protocol = None
             self._loop = None
             server = self._server
@@ -1128,7 +1129,9 @@ class _SelectorSocketTransport(_SelectorTransport):
                 if self._empty_waiter is not None:
                     self._empty_waiter.set_result(None)
                 if self._closing:
-                    self._call_connection_lost(None)
+                    if not self._conn_lost:
+                        self._conn_lost += 1
+                        self._call_connection_lost(None)
                 elif self._eof:
                     self._sock.shutdown(socket.SHUT_WR)
 
@@ -1174,7 +1177,9 @@ class _SelectorSocketTransport(_SelectorTransport):
                 if self._empty_waiter is not None:
                     self._empty_waiter.set_result(None)
                 if self._closing:
-                    self._call_connection_lost(None)
+                    if not self._conn_lost:
+                        self._conn_lost += 1
+                        self._call_connection_lost(None)
                 elif self._eof:
                     self._sock.shutdown(socket.SHUT_WR)
 
@@ -1345,4 +1350,6 @@ class _SelectorDatagramTransport(_SelectorTransport, transports.DatagramTranspor
         if not self._buffer:
             self._loop._remove_writer(self._sock_fd)
             if self._closing:
-                self._call_connection_lost(None)
+                if not self._conn_lost:
+                    self._conn_lost += 1
+                    self._call_connection_lost(None)

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -1195,6 +1195,28 @@ class SelectorSocketTransportTests(test_utils.TestCase):
         self.assertEqual(transport.get_write_buffer_size(), 0)
         self.assertTrue(self.protocol.connection_lost.called)
 
+    def test_resume_writing_closes_transport(self):
+        # gh-156512: When protocol.resume_writing() closes the transport,
+        # connection_lost must be called exactly once and not raise AttributeError.
+        data = memoryview(b'data')
+        self.sock.send.return_value = 4
+        self.sock.send.fileno.return_value = 7
+
+        def _resume_writing():
+            transport.close()
+
+        self.protocol.resume_writing.side_effect = _resume_writing
+
+        transport = self.socket_transport()
+        transport._high_water = 1
+        transport._buffer_size = 4
+        transport._buffer.append(data)
+        transport._protocol_paused = True
+
+        transport._write_ready()
+
+        self.assertEqual(self.protocol.connection_lost.call_count, 1)
+
 class SelectorSocketTransportBufferedProtocolTests(test_utils.TestCase):
 
     def setUp(self):

--- a/Misc/NEWS.d/next/Library/2026-08-30-08-18-00.gh-issue-156512.a9b8c7.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-30-08-18-00.gh-issue-156512.a9b8c7.rst
@@ -1,0 +1,1 @@
+Fix duplicate connection lost invocations and unhandled AttributeError in :mod:`asyncio` selector transports when :meth:`~asyncio.BaseProtocol.resume_writing` closes or aborts the transport.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
<!-- Describe your changes in detail -->
When a protocol's `resume_writing()` callback closes or aborts the transport upon exhausting its output stream, `transport.close()` schedules `_call_connection_lost` asynchronously on the event loop. However, the synchronous drain loop in `_write_sendmsg` / `_write_send` immediately proceeded to also call `_call_connection_lost(None)` synchronously. This resulted in duplicate teardown and an unhandled `AttributeError` when the scheduled callback later executed against torn-down transport attributes (`_sock` and `_protocol` as `None`).

This PR:
1. Guards the synchronous `_call_connection_lost(None)` calls in `_write_sendmsg`, `_write_send`, and `_sendto_ready` with `if not self._conn_lost:` and increments `_conn_lost`.
2. Adds a defensive `if self._sock is not None:` check in `_call_connection_lost`.
3. Adds a unit test in `Lib/test/test_asyncio/test_selector_events.py` verifying that closing a transport from `resume_writing()` invokes `connection_lost()` exactly once.

<!-- Issue number(s) below -->
Fixes #156512

<!-- Categorize the PR by setting a good title and adding one or more labels:
`library` / `asyncio` -->

<!-- gh-issue-number: gh-156512 -->
* Issue: gh-156512
<!-- /gh-issue-number -->
