### PR TITLE
gh-156577: Allow metavar in argparse store_true and store_false actions

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1163,15 +1163,17 @@ class _StoreTrueAction(_StoreConstAction):
                  default=False,
                  required=False,
                  help=None,
+                 metavar=None,
                  deprecated=False):
         super(_StoreTrueAction, self).__init__(
             option_strings=option_strings,
             dest=dest,
             const=True,
-            deprecated=deprecated,
+            default=default,
             required=required,
             help=help,
-            default=default)
+            metavar=metavar,
+            deprecated=deprecated)
 
 
 class _StoreFalseAction(_StoreConstAction):
@@ -1182,6 +1184,7 @@ class _StoreFalseAction(_StoreConstAction):
                  default=True,
                  required=False,
                  help=None,
+                 metavar=None,
                  deprecated=False):
         super(_StoreFalseAction, self).__init__(
             option_strings=option_strings,
@@ -1190,6 +1193,7 @@ class _StoreFalseAction(_StoreConstAction):
             default=default,
             required=required,
             help=help,
+            metavar=metavar,
             deprecated=deprecated)
 
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -909,6 +909,11 @@ class TestOptionalsActionStoreFalse(ParserTestCase):
         ('-z', NS(z=False)),
     ]
 
+    def test_metavar(self):
+        parser = argparse.ArgumentParser()
+        action = parser.add_argument('-z', action='store_false', metavar='FLAG')
+        self.assertEqual(action.metavar, 'FLAG')
+
 
 class TestOptionalsActionStoreTrue(ParserTestCase):
     """Tests the store_true action for an Optional"""
@@ -919,6 +924,11 @@ class TestOptionalsActionStoreTrue(ParserTestCase):
         ('', NS(apple=False)),
         ('--apple', NS(apple=True)),
     ]
+
+    def test_metavar(self):
+        parser = argparse.ArgumentParser()
+        action = parser.add_argument('--apple', action='store_true', metavar='FLAG')
+        self.assertEqual(action.metavar, 'FLAG')
 
 class TestBooleanOptionalAction(ParserTestCase):
     """Tests BooleanOptionalAction"""

--- a/Misc/NEWS.d/next/Library/2026-08-30-08-45-00.gh-issue-156577.1a2b3c.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-30-08-45-00.gh-issue-156577.1a2b3c.rst
@@ -1,0 +1,1 @@
+Allow passing ``metavar`` to :mod:`argparse` actions ``'store_true'`` and ``'store_false'`` for consistency with ``'store_const'``.


### PR DESCRIPTION
<!-- gh-issue-number: gh-156577 -->
* Issue: gh-156577
<!-- /gh-issue-number -->

# Description
`_StoreTrueAction` and `_StoreFalseAction` subclass `_StoreConstAction`, which accepts `metavar=None`. However, neither `_StoreTrueAction` nor `_StoreFalseAction` accepted `metavar` in their `__init__`, raising a `TypeError` when `metavar` was passed to `parser.add_argument(..., action='store_true', metavar='...')`.

This PR adds `metavar=None` to `_StoreTrueAction.__init__` and `_StoreFalseAction.__init__` and forwards it to `super().__init__` for consistency across `_StoreConstAction` subclasses.

Added unit tests in `test_argparse.py` and NEWS entry.