### PR TITLE
gh-156544: Avoid race in UserDict.__getitem__ via try/except KeyError

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -1186,8 +1186,10 @@ class UserDict(_collections_abc.MutableMapping):
         return len(self.data)
 
     def __getitem__(self, key):
-        if key in self.data:
+        try:
             return self.data[key]
+        except KeyError:
+            pass
         if hasattr(self.__class__, "__missing__"):
             return self.__class__.__missing__(self, key)
         raise KeyError(key)

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -77,9 +77,14 @@ class TestUserObjects(unittest.TestCase):
         class A(UserDict):
             def __missing__(self, key):
                 return 456
-        self.assertEqual(A()[123], 456)
+        a = A()
+        self.assertEqual(a[123], 456)
+        a[123] = "hello"
+        self.assertEqual(a[123], "hello")
+        del a[123]
+        self.assertEqual(a[123], 456)
         # get() ignores __missing__ on dict
-        self.assertIs(A().get(123), None)
+        self.assertIs(a.get(123), None)
 
 
 ################################################################################

--- a/Misc/NEWS.d/next/Library/2026-08-30-08-46-00.gh-issue-156544.x9y8z7.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-30-08-46-00.gh-issue-156544.x9y8z7.rst
@@ -1,0 +1,1 @@
+Avoid race condition in :meth:`collections.UserDict.__getitem__` under free-threading by using a single ``try``/``except KeyError`` lookup on ``self.data`` rather than a containment check followed by indexing.


### PR DESCRIPTION
<!-- gh-issue-number: gh-156544 -->
* Issue: gh-156544
<!-- /gh-issue-number -->

# Description
Previously, `UserDict.__getitem__` checked `if key in self.data:` before accessing `self.data[key]`. In free-threaded Python builds or when threads interleave between containment check and subscript access, if another thread deletes `key` via `__delitem__`, `self.data[key]` raised an uncaught `KeyError`, preventing `__missing__` from being called.

This PR changes `UserDict.__getitem__` to use EAFP (`try: return self.data[key] except KeyError:`), eliminating the race condition and reducing the operation from 2 dictionary lookups to 1.

Added test coverage in `test_collections.py` and NEWS entry.