### PR TITLE
gh-150922: Fix test_cmd libedit assertion in test_bang_completion_without_do_shell

### DIFF
--- a/Lib/test/test_cmd.py
+++ b/Lib/test/test_cmd.py
@@ -316,7 +316,10 @@ class CmdTestReadline(unittest.TestCase):
         for input in [b"! h\t\n", b"!h\t\n"]:
             with self.subTest(input=input):
                 output = run_pty(script, input)
-                self.assertIn(b'hello', output)
+                # libedit redraws only the untyped suffix after a
+                # cursor-forward escape, unlike GNU readline which retypes
+                # the whole completed word, so check the common suffix.
+                self.assertIn(b'ello', output)
                 self.assertIn(b'tab completion success', output)
 
 def load_tests(loader, tests, pattern):


### PR DESCRIPTION
Fixes #150922

`test_bang_completion_without_do_shell` asserted that the raw PTY
transcript contains the literal bytes `b'hello'` after tab-completing
`!h<TAB>`. That only holds for GNU readline, which retypes the whole
completed word. libedit instead redraws via a cursor-forward escape
sequence and only re-emits the untyped suffix (e.g. `\x1b[9Cello`),
so the assertion fails on libedit-linked builds (default on macOS/BSD,
and used on some Linux distros) even though completion works
correctly.

This switches the assertion to check for `b'ello'`, the suffix common
to both backends' output, so the test no longer depends on
backend-specific echo/redraw formatting. The existing
`tab completion success` assertion right below it still verifies the
functional outcome of the completion.

Test-only change; no behavior change in `Lib/cmd.py`, so no
Misc/NEWS.d entry per the devguide's test-change exemption.

<!-- gh-issue-number: gh-150922 -->
* Issue: gh-150922
<!-- /gh-issue-number -->
