### PR TITLE
Enable linting of lazy import tests

### DIFF
--- a/Lib/test/.ruff.toml
+++ b/Lib/test/.ruff.toml
@@ -14,10 +14,8 @@ extend-exclude = [
     # New grammar constructions may not yet be recognized by Ruff,
     # and tests re-use the same names as only the grammar is being checked.
     "test_grammar.py",
-    # Lazy import syntax (PEP 810) is not yet supported by Ruff
-    "test_lazy_import/__init__.py",
-    "test_lazy_import/data/*.py",
-    "test_lazy_import/data/**/*.py",
+    # Intentional bad lazy import syntax
+    "test_lazy_import/data/badsyntax/*.py",
     # Unary plus literal pattern is not yet supported by Ruff (GH-145239)
     "test_patma.py",
 ]
@@ -32,4 +30,5 @@ select = [
 "*/**/__main__.py" = ["F401"]  # Unused import
 "test_import/*.py" = ["F401"]  # Unused import
 "test_importlib/*.py" = ["F401"]  # Unused import
+"test_lazy_import/**/*.py" = ["F401"]  # Unused import
 "typinganndata/partialexecution/*.py" = ["F401"]  # Unused import


### PR DESCRIPTION
Ruff 0.15.6 added support for lazy import parsing.