### PR TITLE
gh-156635: Fix the exceptions in the xml.dom documentation

### DIFF
--- a/Doc/library/xml.dom.minidom.rst
+++ b/Doc/library/xml.dom.minidom.rst
@@ -264,6 +264,11 @@ rules apply:
 * :attr:`~xml.dom.Document.strictErrorChecking` and
   :attr:`~xml.dom.Attr.specified` are always ``False``.
 
+* :meth:`~xml.dom.Element.removeAttribute` and
+  :meth:`~xml.dom.Element.removeAttributeNS` raise
+  :exc:`~xml.dom.NotFoundErr` if there is no matching attribute,
+  while the DOM specifies that this has no effect.
+
 The following interfaces have no implementation in :mod:`!xml.dom.minidom`:
 
 * :class:`DOMTimeStamp`

--- a/Doc/library/xml.dom.rst
+++ b/Doc/library/xml.dom.rst
@@ -461,7 +461,7 @@ for each node type are:
 .. method:: Node.insertBefore(newChild, refChild)
 
    Insert a new child node before an existing child.  It must be the case that
-   *refChild* is a child of this node; if not, :exc:`ValueError` is raised.
+   *refChild* is a child of this node; if not, :exc:`NotFoundErr` is raised.
    *newChild* is returned. If *refChild* is ``None``, it inserts *newChild* at the
    end of the children's list.
 
@@ -469,7 +469,7 @@ for each node type are:
 .. method:: Node.removeChild(oldChild)
 
    Remove a child node.  *oldChild* must be a child of this node; if not,
-   :exc:`ValueError` is raised.  *oldChild* is returned on success.  If *oldChild*
+   :exc:`NotFoundErr` is raised.  *oldChild* is returned on success.  If *oldChild*
    will not be used further, its :meth:`~xml.dom.minidom.Node.unlink` method
    should be called.
 
@@ -477,7 +477,7 @@ for each node type are:
 .. method:: Node.replaceChild(newChild, oldChild)
 
    Replace an existing node with a new node. It must be the case that  *oldChild*
-   is a child of this node; if not, :exc:`ValueError` is raised.
+   is a child of this node; if not, :exc:`NotFoundErr` is raised.
 
 
 .. method:: Node.normalize()
@@ -826,8 +826,7 @@ of that class.
 
 .. method:: Element.removeAttribute(name)
 
-   Remove an attribute by name.  If there is no matching attribute, a
-   :exc:`NotFoundErr` is raised.
+   Remove an attribute by name.
 
 
 .. method:: Element.removeAttributeNode(oldAttr)
@@ -838,8 +837,7 @@ of that class.
 
 .. method:: Element.removeAttributeNS(namespaceURI, localName)
 
-   Remove an attribute by name.  Note that it uses a localName, not a qname.  No
-   exception is raised if there is no matching attribute.
+   Remove an attribute by name.  Note that it uses a localName, not a qname.
 
 
 .. method:: Element.setAttribute(name, value)


### PR DESCRIPTION
`Node.insertBefore()`, `Node.removeChild()` and `Node.replaceChild()` were documented as raising `ValueError` for a node which is not a child of this node.  They raise `NotFoundErr`, which is a `DOMException` and not a `ValueError`.

`Element.removeAttribute()` was documented as raising `NotFoundErr` if there is no matching attribute, and `Element.removeAttributeNS()` as raising nothing, although both raise `NotFoundErr`.  The DOM specifies that removing an absent attribute has no effect, so neither is documented in `xml.dom` any more, and this is documented as a deviation in the `xml.dom.minidom` documentation.


<!-- gh-issue-number: gh-156635 -->
* Issue: gh-156635
<!-- /gh-issue-number -->
