### PR TITLE
[3.13] gh-156635: Fix the exceptions in the xml.dom documentation (GH-156636)

### DIFF
--- a/Doc/library/xml.dom.minidom.rst
+++ b/Doc/library/xml.dom.minidom.rst
@@ -268,6 +268,11 @@ rules apply:
 * :attr:`~xml.dom.Document.strictErrorChecking` and
   :attr:`~xml.dom.Attr.specified` are always ``False``.
 
+* :meth:`~xml.dom.Element.removeAttribute` and
+  :meth:`~xml.dom.Element.removeAttributeNS` raise
+  :exc:`~xml.dom.NotFoundErr` if there is no matching attribute,
+  while the DOM specifies that this has no effect.
+
 The following interfaces have no implementation in :mod:`xml.dom.minidom`:
 
 * :class:`DOMTimeStamp`

--- a/Doc/library/xml.dom.rst
+++ b/Doc/library/xml.dom.rst
@@ -464,7 +464,7 @@ for each node type are:
 .. method:: Node.insertBefore(newChild, refChild)
 
    Insert a new child node before an existing child.  It must be the case that
-   *refChild* is a child of this node; if not, :exc:`ValueError` is raised.
+   *refChild* is a child of this node; if not, :exc:`NotFoundErr` is raised.
    *newChild* is returned. If *refChild* is ``None``, it inserts *newChild* at the
    end of the children's list.
 
@@ -472,7 +472,7 @@ for each node type are:
 .. method:: Node.removeChild(oldChild)
 
    Remove a child node.  *oldChild* must be a child of this node; if not,
-   :exc:`ValueError` is raised.  *oldChild* is returned on success.  If *oldChild*
+   :exc:`NotFoundErr` is raised.  *oldChild* is returned on success.  If *oldChild*
    will not be used further, its :meth:`~xml.dom.minidom.Node.unlink` method
    should be called.
 
@@ -480,7 +480,7 @@ for each node type are:
 .. method:: Node.replaceChild(newChild, oldChild)
 
    Replace an existing node with a new node. It must be the case that  *oldChild*
-   is a child of this node; if not, :exc:`ValueError` is raised.
+   is a child of this node; if not, :exc:`NotFoundErr` is raised.
 
 
 .. method:: Node.normalize()
@@ -829,8 +829,7 @@ of that class.
 
 .. method:: Element.removeAttribute(name)
 
-   Remove an attribute by name.  If there is no matching attribute, a
-   :exc:`NotFoundErr` is raised.
+   Remove an attribute by name.
 
 
 .. method:: Element.removeAttributeNode(oldAttr)
@@ -841,8 +840,7 @@ of that class.
 
 .. method:: Element.removeAttributeNS(namespaceURI, localName)
 
-   Remove an attribute by name.  Note that it uses a localName, not a qname.  No
-   exception is raised if there is no matching attribute.
+   Remove an attribute by name.  Note that it uses a localName, not a qname.
 
 
 .. method:: Element.setAttribute(name, value)


### PR DESCRIPTION
(cherry picked from commit 74b944afe32049191674c747e060d8d67a2a1b17)

Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>

Backported manually, because the 3.13 documentation does not use `:mod:`!xml.dom.minidom`` in the conflicting line.


<!-- gh-issue-number: gh-156635 -->
* Issue: gh-156635
<!-- /gh-issue-number -->
