### PR TITLE
gh-156463: Install the manual page under the interpreter's LDVERSION

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2518,13 +2518,13 @@ altmaninstall:
 		fi; \
 	done
 	$(INSTALL_DATA) $(srcdir)/Misc/python.man \
-		$(DESTDIR)$(MANDIR)/man1/python$(VERSION).1
+		$(DESTDIR)$(MANDIR)/man1/python$(LDVERSION).1
 
 # Install the unversioned manual page
 .PHONY: maninstall
 maninstall:	altmaninstall
 	-rm -f $(DESTDIR)$(MANDIR)/man1/python3.1
-	(cd $(DESTDIR)$(MANDIR)/man1; $(LN) -s python$(VERSION).1 python3.1)
+	(cd $(DESTDIR)$(MANDIR)/man1; $(LN) -s python$(LDVERSION).1 python3.1)
 
 # Install the library
 XMLLIBSUBDIRS=  xml xml/dom xml/etree xml/parsers xml/sax

--- a/Misc/NEWS.d/next/Build/2026-08-30-11-56-02.gh-issue-156463.3MU9Hk.rst
+++ b/Misc/NEWS.d/next/Build/2026-08-30-11-56-02.gh-issue-156463.3MU9Hk.rst
@@ -1,0 +1,5 @@
+Install the manual page under the name of the interpreter it documents, so
+that non-default builds get one too. The page is now installed as
+``python$(LDVERSION).1``, which yields ``python3.16t.1`` for a free-threaded
+build and ``python3.16d.1`` for a debug build, instead of overwriting the
+default ``python3.16.1``. Builds with an empty ``ABIFLAGS`` are unaffected.


### PR DESCRIPTION
`altmaninstall` installs the manual page as `python$(VERSION).1`, but the
interpreter it documents is named after `$(LDVERSION)`. A build with a
non-empty `ABIFLAGS` — free-threaded (`t`) or debug (`d`) — therefore gets no
manual page under its own name, and when installed alongside a default build it
overwrites that build's page.

This installs it as `python$(LDVERSION).1`.

The issue suggests changing the `altmaninstall` line only. That alone would
leave a dangling link: `maninstall` points the unversioned `python3.1` at
`python$(VERSION).1`, which is no longer installed once the versioned page is
named after `LDVERSION`. Both lines are updated.

Builds with an empty `ABIFLAGS` are unaffected, since `LDVERSION` expands to
`VERSION`.

Verified on a debug build (`ABIFLAGS=d`) with `make maninstall DESTDIR=...`:

```
/usr/bin/install -c -m 644 ./Misc/python.man .../man1/python3.16d.1
(cd .../man1; ln -s python3.16d.1 python3.1)
```

The page is installed under the interpreter's own name, and the unversioned
link resolves.

The issue explicitly asks for a broader view before jumping to fixes, so this
is offered as a concrete proposal rather than as a settled decision.


<!-- gh-issue-number: gh-156463 -->
* Issue: gh-156463
<!-- /gh-issue-number -->
