### PR TITLE
gh-154894: Reject duplicate unicode path extra fields in zipfile

### DIFF
--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -4156,6 +4156,23 @@ class OtherTests(unittest.TestCase):
         with self.assertRaises(zipfile.BadZipfile):
             zipfile.ZipFile(TESTFN, "r").close()
 
+    def test_read_zipfile_duplicate_unicode_path_extra_field(self):
+        filename = "이름.txt"
+        filename_crc = struct.pack('<L', zipfile.crc32(filename.encode("utf-8")))
+
+        def unicode_path(name):
+            data = b'\x01' + filename_crc + name
+            return b'\x75\x70' + len(data).to_bytes(2, 'little') + data
+
+        with zipfile.ZipFile(TESTFN, mode='w') as zf:
+            zip_info = zipfile.ZipInfo(filename)
+            zip_info.extra = (unicode_path("first.txt".encode("utf-8"))
+                              + unicode_path("last.txt".encode("utf-8")))
+            zf.writestr(zip_info, b'Hello World!')
+
+        with self.assertRaisesRegex(zipfile.BadZipFile, "Duplicate unicode path"):
+            zipfile.ZipFile(TESTFN, "r").close()
+
     def test_read_after_write_unicode_filenames(self):
         with zipfile.ZipFile(TESTFN2, 'w') as zipfp:
             zipfp.writestr('приклад', b'sample')

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -588,6 +588,7 @@ class ZipInfo:
         # Try to decode the extra field.
         extra = self.extra
         unpack = struct.unpack
+        seen_unicode_path = False
         while len(extra) >= 4:
             tp, ln = unpack('<HH', extra[:4])
             if ln+4 > len(extra):
@@ -611,6 +612,12 @@ class ZipInfo:
                     raise BadZipFile(f"Corrupt zip64 extra field. "
                                      f"{field} not found.") from None
             elif tp == 0x7075:
+                # Parsers disagree on which one wins, so a member carrying more
+                # than one is ambiguous rather than merely redundant.
+                if seen_unicode_path:
+                    raise BadZipFile(
+                        "Duplicate unicode path extra field (0x7075)")
+                seen_unicode_path = True
                 data = extra[4:ln+4]
                 # Unicode Path Extra Field
                 try:

--- a/Misc/NEWS.d/next/Library/2026-08-30-11-58-04.gh-issue-154894.XFOjGQ.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-30-11-58-04.gh-issue-154894.XFOjGQ.rst
@@ -1,0 +1,4 @@
+:mod:`zipfile` now rejects an archive member that carries more than one
+Unicode Path extra field (``0x7075``) instead of silently using the last one.
+ZIP parsers disagree on which of the duplicates wins, so such a member is
+ambiguous rather than merely redundant.


### PR DESCRIPTION
A member may carry the Unicode Path extra field (`0x7075`) more than once.
`zipfile` silently takes the last one, and other ZIP parsers make different
choices, so the decoded filename is ambiguous rather than merely redundant —
which is the differential described in the issue.

This raises `BadZipFile` when a second `0x7075` field is seen for the same
member. The reproducer from the issue now fails to open instead of returning
`['last.txt']`.

`test_zipfile`, `test_zipimport` and `test_importlib` pass.

Please note this is a behaviour change: archives that previously opened will
now be rejected. The issue is filed as "consider rejecting" and I did not find
a maintainer decision on it, so please treat this as a proposal. I am happy to
close it, or to emit a warning and keep the current last-one-wins behaviour
instead, if either is preferred.


<!-- gh-issue-number: gh-154894 -->
* Issue: gh-154894
<!-- /gh-issue-number -->
