### PR TITLE
gh-54092: Implement writexml() for DocumentFragment in xml.dom.minidom

### DIFF
--- a/Doc/library/xml.dom.minidom.rst
+++ b/Doc/library/xml.dom.minidom.rst
@@ -154,6 +154,9 @@ module documentation.  This section lists the differences between the API and
    .. versionchanged:: 3.9
       The *standalone* parameter was added.
 
+   .. versionchanged:: next
+      It now works for :class:`!DocumentFragment` nodes.
+
 .. method:: Node.toxml(encoding=None, standalone=None)
 
    Return a string or byte string containing the XML represented by
@@ -175,6 +178,9 @@ module documentation.  This section lists the differences between the API and
    .. versionchanged:: 3.9
       The *standalone* parameter was added.
 
+   .. versionchanged:: next
+      It now works for :class:`!DocumentFragment` nodes.
+
 .. method:: Node.toprettyxml(indent="\t", newl="\n", encoding=None, \
                              standalone=None)
 
@@ -193,6 +199,9 @@ module documentation.  This section lists the differences between the API and
 
    .. versionchanged:: 3.9
       The *standalone* parameter was added.
+
+   .. versionchanged:: next
+      It now works for :class:`!DocumentFragment` nodes.
 
 .. _dom-example:
 

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -648,6 +648,12 @@ xml
   rather than defaulted from the DTD.
   (Contributed by Jason Orendorff and Serhiy Storchaka in :gh:`44871`.)
 
+* The :meth:`~xml.dom.minidom.Node.writexml`,
+  :meth:`~xml.dom.minidom.Node.toxml` and
+  :meth:`~xml.dom.minidom.Node.toprettyxml` methods
+  now work for :class:`!DocumentFragment` nodes in :mod:`xml.dom.minidom`.
+  (Contributed by Serhiy Storchaka in :gh:`54092`.)
+
 zipfile
 -------
 

--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -561,6 +561,22 @@ class MinidomTest(unittest.TestCase):
         dom.unlink()
         self.assertEqual(str, domstr)
 
+    def testWriteXMLDocumentFragment(self):
+        dom = parseString('<doc><a b="c"/>text<!--comment--></doc>')
+        frag = dom.createDocumentFragment()
+        for node in list(dom.documentElement.childNodes):
+            frag.appendChild(node)
+        self.assertEqual(frag.toxml(), '<a b="c"/>text<!--comment-->')
+        self.assertEqual(frag.toprettyxml(),
+                         '<a b="c"/>\ntext\n<!--comment-->\n')
+        # the fragment itself does not add a level of indentation
+        writer = io.StringIO()
+        frag.writexml(writer, "  ", "  ", "\n")
+        self.assertEqual(writer.getvalue(),
+                         '  <a b="c"/>\n  text\n  <!--comment-->\n')
+        self.assertEqual(dom.createDocumentFragment().toxml(), '')
+        dom.unlink()
+
     def test_toxml_quote_text(self):
         dom = Document()
         elem = dom.appendChild(dom.createElement('elem'))

--- a/Lib/xml/dom/minidom.py
+++ b/Lib/xml/dom/minidom.py
@@ -379,6 +379,10 @@ class DocumentFragment(Node):
     def __init__(self):
         self.childNodes = NodeList()
 
+    def writexml(self, writer, indent="", addindent="", newl=""):
+        for node in self.childNodes:
+            node.writexml(writer, indent, addindent, newl)
+
 
 class Attr(Node):
     __slots__=('_name', '_value', 'namespaceURI',

--- a/Misc/NEWS.d/next/Library/2026-08-30-13-37-47.gh-issue-54092.Tq8Wm3.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-30-13-37-47.gh-issue-54092.Tq8Wm3.rst
@@ -1,0 +1,6 @@
+Implement :meth:`~xml.dom.minidom.Node.writexml` for document fragments
+in :mod:`xml.dom.minidom`,
+so that :meth:`~xml.dom.minidom.Node.toxml` and
+:meth:`~xml.dom.minidom.Node.toprettyxml` now work for them.
+They write the children of the fragment,
+without adding a level of indentation.


### PR DESCRIPTION
`DocumentFragment` was the only serializable node type without a `writexml()` method, so `toxml()` and `toprettyxml()` failed with `AttributeError` for document fragments.  It was documented as implemented since GH-12677.

The fragment writes its children at the current indentation, without adding a level of indentation for itself, as it has no tag.


<!-- gh-issue-number: gh-54092 -->
* Issue: gh-54092
<!-- /gh-issue-number -->
