### PR TITLE
gh-57952: Clarify that xml.dom documents DOM interfaces

### DIFF
--- a/Doc/library/xml.dom.rst
+++ b/Doc/library/xml.dom.rst
@@ -153,6 +153,11 @@ Objects in the DOM
 
 The definitive documentation for the DOM is the DOM specification from the W3C.
 
+The names documented in this section are DOM interfaces.
+With the exception of :class:`Node` and the exception classes,
+they are not provided by the :mod:`!xml.dom` module itself,
+but by concrete DOM implementations, such as :mod:`xml.dom.minidom`.
+
 Note that DOM attributes may also be manipulated as nodes instead of as simple
 strings.  It is fairly rare that you must do this, however, so this usage is not
 yet documented.


### PR DESCRIPTION
The names documented in the "Objects in the DOM" section are interfaces from the DOM specification, not classes provided by the `xml.dom` module.  Only `Node` and the exception classes exist there; the concrete classes come from an implementation such as `xml.dom.minidom`.

<!-- gh-issue-number: gh-57952 -->
* Issue: gh-57952
<!-- /gh-issue-number -->
