### PR TITLE
gh-135385: Do not reserve inline values for attributes stored in slots

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-08-30-16-30-00.gh-issue-135385.Wn7Rd4.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-08-30-16-30-00.gh-issue-135385.Wn7Rd4.rst
@@ -1,0 +1,3 @@
+Reduce the memory consumption of instances of classes which define
+``__slots__`` and also have a ``__dict__``.  Space for the attributes stored
+in slots is no longer reserved in the inline values of every instance.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -7286,6 +7286,11 @@ _PyDict_NewKeysForClass(PyHeapTypeObject *cls)
                 PyObject *key = PyTuple_GET_ITEM(attrs, i);
                 Py_hash_t hash;
                 if (PyUnicode_CheckExact(key) && (hash = unicode_get_hash(key)) != -1) {
+                    /* An attribute stored in a slot never uses the dict. */
+                    PyObject *descr = _PyType_Lookup((PyTypeObject *)cls, key);
+                    if (descr != NULL && Py_IS_TYPE(descr, &PyMemberDescr_Type)) {
+                        continue;
+                    }
                     if (insert_split_key(keys, key, hash) == DKIX_EMPTY) {
                         break;
                     }


### PR DESCRIPTION
`__static_attributes__` contains every name assigned as `self.X` in the class body, and `_PyDict_NewKeysForClass()` inserted all of them into the shared keys of the class.  An attribute stored in a slot is never stored in the instance dict, so the inline values reserved for it on every instance were never used.

For the example in the issue:

```
only __slots__              64_449_113 bytes
only __dict__              104_452_257 bytes
__dict__ and __slots__     104_452_697 bytes   (120_452_257 before)
```

An `xml.dom.minidom` element node, where all 11 names in `__static_attributes__` are slots, goes from 328 to 232 bytes.

The lookup is done once per attribute name at class creation, and I see no difference in benchmarks, including creating 100000 classes.

<!-- gh-issue-number: gh-135385 -->
* Issue: gh-135385
<!-- /gh-issue-number -->
