### PR TITLE
gh-123299: What's New: Link to compression and compression.zstd

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -648,7 +648,7 @@ Improved error messages
 :pep:`784`: Zstandard support in the standard library
 -----------------------------------------------------
 
-The new :mod:`!compression` package contains modules :mod:`!compression.lzma`,
+The new :mod:`compression` package contains modules :mod:`!compression.lzma`,
 :mod:`!compression.bz2`, :mod:`!compression.gzip` and :mod:`!compression.zlib`
 which re-export the :mod:`lzma`, :mod:`bz2`, :mod:`gzip` and :mod:`zlib`
 modules respectively. The new import names under :mod:`!compression` are the
@@ -657,7 +657,7 @@ the existing modules names have not been deprecated. Any deprecation or removal
 of the existing compression modules will occur no sooner than five years after
 the release of 3.14.
 
-The new :mod:`!compression.zstd` module provides compression and decompression
+The new :mod:`compression.zstd` module provides compression and decompression
 APIs for the Zstandard format via bindings to `Meta's zstd library
 <https://facebook.github.io/zstd/>`__. Zstandard is a widely adopted, highly
 efficient, and fast compression format. In addition to the APIs introduced in


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

We link to `compression.zstd` in the release highlights:

https://docs.python.org/3/whatsnew/3.14.html#summary-release-highlights

But its own section links to the `lzma`, `bz2`, `gzip` and `zlib` modules, but not the new `compression` and `compression.zstd`:

https://docs.python.org/3/whatsnew/3.14.html#whatsnew314-zstandard

Let's link them.

<!-- gh-issue-number: gh-123299 -->
* Issue: gh-123299
<!-- /gh-issue-number -->
