### PR TITLE
gh-63882: Implement empty tests in test_minidom

### DIFF
--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -482,7 +482,15 @@ class MinidomTest(unittest.TestCase):
         self.assertEqual(child2.getAttributeNS("http://www.python.org", "missing"),
                          '')
 
-    def testGetAttributeNode(self): pass
+    def testGetAttributeNode(self):
+        dom = parseString("<doc a='1'/>")
+        elem = dom.documentElement
+        attr = elem.getAttributeNode("a")
+        self.assertEqual(attr.name, "a")
+        self.assertEqual(attr.value, "1")
+        self.assertIs(attr.ownerElement, elem)
+        self.assertIsNone(elem.getAttributeNode("b"))
+        dom.unlink()
 
     def testGetElementsByTagNameNS(self):
         d="""<foo xmlns:minidom='http://pyxml.sf.net/minidom'>
@@ -671,9 +679,34 @@ class MinidomTest(unittest.TestCase):
         self.assertEqual(str(el), repr(el))
         self.assertEqual('<DOM Text node "\'foo\'">', str(el))
 
-    def testWriteText(self): pass
+    def testWriteText(self):
+        dom = parseString("<doc><a>text</a><b>&lt;&amp;&gt;</b></doc>")
+        elem = dom.documentElement
+        writer = io.StringIO()
+        elem.writexml(writer)
+        self.assertEqual(writer.getvalue(),
+                "<doc><a>text</a><b>&lt;&amp;&gt;</b></doc>")
+        writer = io.StringIO()
+        elem.writexml(writer, indent="  ", addindent="  ", newl="\n")
+        self.assertEqual(writer.getvalue(),
+                "  <doc>\n"
+                "    <a>text</a>\n"
+                "    <b>&lt;&amp;&gt;</b>\n"
+                "  </doc>\n")
+        dom.unlink()
 
-    def testDocumentElement(self): pass
+    def testDocumentElement(self):
+        dom = parseString("<!-- comment --><doc/><?pi data?>")
+        elem = dom.documentElement
+        self.assertEqual(elem.tagName, "doc")
+        self.assertIs(elem, dom.childNodes[1])
+        dom.unlink()
+
+        dom = Document()
+        self.assertIsNone(dom.documentElement)
+        elem = dom.appendChild(dom.createElement("doc"))
+        self.assertIs(dom.documentElement, elem)
+        dom.unlink()
 
     def testTooManyDocumentElements(self):
         doc = parseString("<doc/>")
@@ -683,25 +716,126 @@ class MinidomTest(unittest.TestCase):
         elem.unlink()
         doc.unlink()
 
-    def testCreateElementNS(self): pass
+    def testCreateElementNS(self):
+        dom = Document()
+        elem = dom.createElementNS("http://xml.python.org/ns", "p:elem")
+        self.assertEqual(elem.nodeType, Node.ELEMENT_NODE)
+        self.assertEqual(elem.tagName, "p:elem")
+        self.assertEqual(elem.nodeName, "p:elem")
+        self.assertEqual(elem.namespaceURI, "http://xml.python.org/ns")
+        self.assertEqual(elem.prefix, "p")
+        self.assertEqual(elem.localName, "elem")
+        self.assertIs(elem.ownerDocument, dom)
+        self.assertIsNone(elem.parentNode)
 
-    def testCreateAttributeNS(self): pass
+        elem = dom.createElementNS("http://xml.python.org/ns", "elem")
+        self.assertEqual(elem.tagName, "elem")
+        self.assertIsNone(elem.prefix)
+        self.assertEqual(elem.localName, "elem")
+        dom.unlink()
 
-    def testParse(self): pass
+    def testCreateAttributeNS(self):
+        dom = Document()
+        attr = dom.createAttributeNS("http://xml.python.org/ns", "p:attr")
+        self.assertEqual(attr.nodeType, Node.ATTRIBUTE_NODE)
+        self.assertEqual(attr.name, "p:attr")
+        self.assertEqual(attr.nodeName, "p:attr")
+        self.assertEqual(attr.namespaceURI, "http://xml.python.org/ns")
+        self.assertEqual(attr.prefix, "p")
+        self.assertEqual(attr.localName, "attr")
+        self.assertEqual(attr.value, "")
+        self.assertIs(attr.ownerDocument, dom)
+        self.assertIsNone(attr.ownerElement)
 
-    def testParseString(self): pass
+        elem = dom.appendChild(dom.createElement("doc"))
+        elem.setAttributeNode(attr)
+        self.assertIs(attr.ownerElement, elem)
+        self.assertIs(elem.getAttributeNodeNS("http://xml.python.org/ns",
+                                              "attr"), attr)
+        dom.unlink()
 
-    def testComment(self): pass
+    def testParse(self):
+        # parsing from a file object is tested in testParseFromBinaryFile
+        # and testParseFromTextFile
+        dom = parse(tstfile)
+        self.assertEqual(dom.nodeType, Node.DOCUMENT_NODE)
+        self.assertEqual(dom.documentElement.tagName, "HTML")
+        dom.unlink()
 
-    def testAttrListItem(self): pass
+        self.assertRaises(ExpatError, parseString, "<doc>")
 
-    def testAttrListItems(self): pass
+    def testParseString(self):
+        dom = parseString("<doc>text</doc>")
+        self.assertEqual(dom.nodeType, Node.DOCUMENT_NODE)
+        self.assertEqual(dom.documentElement.tagName, "doc")
+        self.assertEqual(dom.documentElement.firstChild.data, "text")
+        dom.unlink()
 
-    def testAttrListItemNS(self): pass
+        dom = parseString(b"<?xml version='1.0' encoding='utf-8'?>"
+                          b"<doc>\xc3\xa9</doc>")
+        self.assertEqual(dom.documentElement.firstChild.data, "\xe9")
+        dom.unlink()
 
-    def testAttrListKeys(self): pass
+    def testComment(self):
+        dom = Document()
+        comment = dom.createComment("comment")
+        self.assertEqual(comment.nodeType, Node.COMMENT_NODE)
+        self.assertEqual(comment.nodeName, "#comment")
+        self.assertEqual(comment.data, "comment")
+        self.assertEqual(comment.nodeValue, "comment")
+        self.assertIsNone(comment.attributes)
+        dom.appendChild(comment)
+        self.assertEqual(dom.toxml(),
+                         '<?xml version="1.0" ?><!--comment-->')
+        dom.unlink()
 
-    def testAttrListKeysNS(self): pass
+        dom = parseString("<doc><!--comment--></doc>")
+        comment = dom.documentElement.firstChild
+        self.assertEqual(comment.nodeType, Node.COMMENT_NODE)
+        self.assertEqual(comment.data, "comment")
+        dom.unlink()
+
+    def testAttrListItem(self):
+        dom = parseString("<doc a='1' b='2'/>")
+        attrs = dom.documentElement.attributes
+        self.assertEqual(attrs.item(0).name, "a")
+        self.assertEqual(attrs.item(1).name, "b")
+        self.assertIsNone(attrs.item(2))
+        dom.unlink()
+
+    def testAttrListItems(self):
+        dom = parseString("<doc a='1' b='2'/>")
+        attrs = dom.documentElement.attributes
+        self.assertEqual(attrs.items(), [("a", "1"), ("b", "2")])
+        dom.unlink()
+
+    def testAttrListItemNS(self):
+        dom = parseString("<doc xmlns:p='http://xml.python.org/ns' "
+                          "p:a='1' b='2'/>")
+        attrs = dom.documentElement.attributes
+        self.assertEqual(attrs.itemsNS(), [
+            ((xml.dom.XMLNS_NAMESPACE, "p"), "http://xml.python.org/ns"),
+            (("http://xml.python.org/ns", "a"), "1"),
+            ((None, "b"), "2"),
+        ])
+        dom.unlink()
+
+    def testAttrListKeys(self):
+        dom = parseString("<doc a='1' b='2'/>")
+        attrs = dom.documentElement.attributes
+        self.assertEqual(list(attrs.keys()), ["a", "b"])
+        dom.unlink()
+
+    def testAttrListKeysNS(self):
+        dom = parseString("<doc xmlns:p='http://xml.python.org/ns' "
+                          "p:a='1' b='2'/>")
+        attrs = dom.documentElement.attributes
+        self.assertEqual(list(attrs.keysNS()), [
+            (xml.dom.XMLNS_NAMESPACE, "p"),
+            ("http://xml.python.org/ns", "a"),
+            (None, "b"),
+        ])
+        dom.unlink()
 
     def testRemoveNamedItem(self):
         doc = parseString("<doc a=''/>")
@@ -722,29 +856,162 @@ class MinidomTest(unittest.TestCase):
         self.assertRaises(xml.dom.NotFoundErr, attrs.removeNamedItemNS,
                           "http://xml.python.org/", "b")
 
-    def testAttrListValues(self): pass
+    def testAttrListValues(self):
+        dom = parseString("<doc a='1' b='2'/>")
+        attrs = dom.documentElement.attributes
+        self.assertEqual([attr.name for attr in attrs.values()], ["a", "b"])
+        self.assertEqual([attr.value for attr in attrs.values()], ["1", "2"])
+        dom.unlink()
 
-    def testAttrListLength(self): pass
+    def testAttrListLength(self):
+        dom = parseString("<doc a='1' b='2'/>")
+        attrs = dom.documentElement.attributes
+        self.assertEqual(attrs.length, 2)
+        self.assertEqual(len(attrs), 2)
+        dom.unlink()
 
-    def testAttrList__getitem__(self): pass
+        dom = parseString("<doc/>")
+        self.assertEqual(dom.documentElement.attributes.length, 0)
+        dom.unlink()
 
-    def testAttrList__setitem__(self): pass
+    def testAttrList__getitem__(self):
+        dom = parseString("<doc xmlns:p='http://xml.python.org/ns' "
+                          "p:a='1' b='2'/>")
+        attrs = dom.documentElement.attributes
+        self.assertEqual(attrs["b"].value, "2")
+        self.assertEqual(attrs[("http://xml.python.org/ns", "a")].value, "1")
+        self.assertRaises(KeyError, attrs.__getitem__, "missing")
+        self.assertRaises(KeyError, attrs.__getitem__, (None, "missing"))
+        dom.unlink()
 
-    def testSetAttrValueandNodeValue(self): pass
+    def testAttrList__setitem__(self):
+        dom = parseString("<doc a='1'/>")
+        elem = dom.documentElement
+        attrs = elem.attributes
+        attrs["a"] = "2"
+        self.assertEqual(elem.getAttribute("a"), "2")
+        attrs["b"] = "3"
+        self.assertEqual(elem.getAttribute("b"), "3")
+        self.assertEqual(attrs.length, 2)
 
-    def testParseElement(self): pass
+        attr = dom.createAttribute("c")
+        attr.value = "4"
+        attrs["c"] = attr
+        self.assertIs(elem.getAttributeNode("c"), attr)
+        self.assertEqual(elem.getAttribute("c"), "4")
+        dom.unlink()
 
-    def testParseAttributes(self): pass
+    def testSetAttrValueandNodeValue(self):
+        dom = parseString("<doc a='1'/>")
+        attr = dom.documentElement.getAttributeNode("a")
+        self.assertEqual(attr.value, "1")
+        self.assertEqual(attr.nodeValue, "1")
+        attr.value = "2"
+        self.assertEqual(attr.nodeValue, "2")
+        attr.nodeValue = "3"
+        self.assertEqual(attr.value, "3")
+        self.assertEqual(dom.documentElement.getAttribute("a"), "3")
+        dom.unlink()
 
-    def testParseElementNamespaces(self): pass
+    def testParseElement(self):
+        dom = parseString("<doc><child/><child/></doc>")
+        elem = dom.documentElement
+        self.assertEqual(elem.nodeType, Node.ELEMENT_NODE)
+        self.assertEqual(elem.tagName, "doc")
+        self.assertIsNone(elem.namespaceURI)
+        self.assertIs(elem.parentNode, dom)
+        self.assertIs(elem.ownerDocument, dom)
+        self.assertEqual([child.tagName for child in elem.childNodes],
+                         ["child", "child"])
+        dom.unlink()
 
-    def testParseAttributeNamespaces(self): pass
+    def testParseAttributes(self):
+        dom = parseString("<doc a='1' b='&amp;'/>")
+        elem = dom.documentElement
+        self.assertEqual(elem.getAttribute("a"), "1")
+        self.assertEqual(elem.getAttribute("b"), "&")
+        self.assertEqual(elem.getAttribute("missing"), "")
+        self.assertTrue(elem.hasAttribute("a"))
+        self.assertFalse(elem.hasAttribute("missing"))
+        attr = elem.getAttributeNode("a")
+        self.assertTrue(attr.specified)
+        self.assertIsNone(attr.namespaceURI)
+        dom.unlink()
 
-    def testParseProcessingInstructions(self): pass
+    def testParseElementNamespaces(self):
+        dom = parseString("<p:doc xmlns:p='http://xml.python.org/ns'"
+                          " xmlns='http://xml.python.org/default'>"
+                          "<child/></p:doc>")
+        elem = dom.documentElement
+        self.assertEqual(elem.tagName, "p:doc")
+        self.assertEqual(elem.namespaceURI, "http://xml.python.org/ns")
+        self.assertEqual(elem.prefix, "p")
+        self.assertEqual(elem.localName, "doc")
+        child = elem.getElementsByTagName("child")[0]
+        self.assertEqual(child.namespaceURI, "http://xml.python.org/default")
+        self.assertIsNone(child.prefix)
+        self.assertEqual(child.localName, "child")
+        dom.unlink()
 
-    def testChildNodes(self): pass
+    def testParseAttributeNamespaces(self):
+        dom = parseString("<doc xmlns:p='http://xml.python.org/ns'"
+                          " p:a='1' b='2'/>")
+        elem = dom.documentElement
+        self.assertEqual(elem.getAttributeNS("http://xml.python.org/ns", "a"),
+                         "1")
+        self.assertEqual(elem.getAttributeNS(None, "b"), "2")
+        attr = elem.getAttributeNodeNS("http://xml.python.org/ns", "a")
+        self.assertEqual(attr.name, "p:a")
+        self.assertEqual(attr.prefix, "p")
+        self.assertEqual(attr.localName, "a")
+        declaration = elem.getAttributeNode("xmlns:p")
+        self.assertEqual(declaration.namespaceURI, xml.dom.XMLNS_NAMESPACE)
+        self.assertEqual(declaration.value, "http://xml.python.org/ns")
+        dom.unlink()
 
-    def testFirstChild(self): pass
+    def testParseProcessingInstructions(self):
+        # the content of a processing instruction is tested
+        # in testProcessingInstruction
+        dom = parseString("<?before data?><doc/><?after?>")
+        pi = dom.childNodes[0]
+        self.assertEqual(pi.nodeType, Node.PROCESSING_INSTRUCTION_NODE)
+        self.assertEqual(pi.target, "before")
+        self.assertEqual(pi.data, "data")
+        self.assertIs(pi.parentNode, dom)
+        pi = dom.childNodes[2]
+        self.assertEqual(pi.target, "after")
+        self.assertEqual(pi.data, "")
+        dom.unlink()
+
+    def testChildNodes(self):
+        dom = parseString("<doc>text<child/><!--comment--></doc>")
+        children = dom.documentElement.childNodes
+        self.assertEqual(len(children), 3)
+        self.assertEqual([child.nodeType for child in children],
+                         [Node.TEXT_NODE, Node.ELEMENT_NODE, Node.COMMENT_NODE])
+        for child in children:
+            self.assertIs(child.parentNode, dom.documentElement)
+        dom.unlink()
+
+        dom = parseString("<doc/>")
+        self.assertEqual(len(dom.documentElement.childNodes), 0)
+        dom.unlink()
+
+    def testFirstChild(self):
+        dom = parseString("<doc><a/><b/></doc>")
+        elem = dom.documentElement
+        self.assertEqual(elem.firstChild.tagName, "a")
+        self.assertEqual(elem.lastChild.tagName, "b")
+        self.assertIs(elem.firstChild, elem.childNodes[0])
+        self.assertIs(elem.lastChild, elem.childNodes[-1])
+        self.assertIsNone(elem.firstChild.previousSibling)
+        self.assertIs(elem.firstChild.nextSibling, elem.lastChild)
+        dom.unlink()
+
+        dom = parseString("<doc/>")
+        self.assertIsNone(dom.documentElement.firstChild)
+        self.assertIsNone(dom.documentElement.lastChild)
+        dom.unlink()
 
     def testHasChildNodes(self):
         dom = parseString("<doc><foo/></doc>")


### PR DESCRIPTION
The 25 tests defined as `def testX(self): pass` now test `NamedNodeMap` methods, the factory methods for namespaced nodes, parsing of elements, attributes, namespaces and processing instructions, and the traversal attributes.

`testParse` and `testParseProcessingInstructions` are limited to what is not already covered by `testParseFromBinaryFile`, `testParseFromTextFile` and `testProcessingInstruction`.

This makes PR #128948, which comments these tests out, unnecessary.

<!-- gh-issue-number: gh-63882 -->
* Issue: gh-63882
<!-- /gh-issue-number -->
