### PR TITLE
gh-156676: Fix test for non-CPython implementations

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -2544,6 +2544,7 @@ class SubinterpImportTests(unittest.TestCase):
         excsnap = _interpreters.run_string(interpid, script)
         self.assertIsNot(excsnap, None)
 
+    @cpython_only
     @requires_subinterpreters
     def test_pyinit_function_raises_exception(self):
         # gh-144601: PyInit functions that raised exceptions would cause a


### PR DESCRIPTION
gh-156676

Mark `test_pyinit_function_raises_exception` as CPython-specific.

This test uses the CPython-specific `_testsinglephase` module, so
the test should be skipped on non-CPython implementations.

Tests:
- `python3 -m test test_import`