### PR TITLE
gh-92041: Avoid a second sys.modules scan in inspect.getmodule

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -938,6 +938,8 @@ def getmodule(object, _filename=None):
         return sys.modules.get(modulesbyfile[_filename])
     # Try the cache again with the absolute file name
     try:
+        if _filename is None:
+            _filename = getfile(object)
         file = getabsfile(object, _filename)
     except (TypeError, FileNotFoundError):
         return None

--- a/Lib/test/test_zipimport_support.py
+++ b/Lib/test/test_zipimport_support.py
@@ -3,6 +3,7 @@
 # The tests are centralised in this fashion to make it easy to drop them
 # if a platform doesn't support zipimport
 import test.support
+import importlib
 import os
 import os.path
 import sys
@@ -95,6 +96,35 @@ class ZipSupportTests(unittest.TestCase):
                 self.assertEqual(inspect.getsource(zip_pkg.foo), test_src)
             finally:
                 del sys.modules["zip_pkg"]
+
+    def test_inspect_fresh_namespace_uses_module_loader(self):
+        # gh-92041: a frame exec'd in a plain namespace resolves to the
+        # zipimported module owning its filename, so getsource() can use
+        # the module's loader.
+        test_src = textwrap.dedent("""\
+            import inspect
+
+            def capture():
+                return inspect.currentframe()
+
+            frame = capture()
+        """)
+        with os_helper.temp_dir() as d:
+            script_name = make_script(d, "zipped_mod", test_src)
+            zip_name, _ = make_zip_script(d, "test_zip", script_name)
+            os.remove(script_name)
+            sys.path.insert(0, zip_name)
+            module = importlib.import_module("zipped_mod")
+            try:
+                namespace = {}
+                exec(compile(test_src, module.__file__, "exec"), namespace)
+                frame = namespace["frame"]
+                self.assertIs(inspect.getmodule(frame), module)
+                self.assertEqual(inspect.getsource(frame),
+                                 "def capture():\n"
+                                 "    return inspect.currentframe()\n")
+            finally:
+                del sys.modules["zipped_mod"]
 
     def test_doctest_issue4197(self):
         # To avoid having to keep two copies of the doctest module's

--- a/Misc/NEWS.d/next/Library/2026-08-30-12-00-00.gh-issue-92041.nRcsQe.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-30-12-00-00.gh-issue-92041.nRcsQe.rst
@@ -1,0 +1,2 @@
+Speed up :func:`inspect.getmodule` for objects resolved by filename, such
+as frames, tracebacks and code objects.


### PR DESCRIPTION
When `inspect.getmodule()` computes its filename cache key, `getabsfile()` consults `getsourcefile()`, which recurses into `getmodule()` — scanning `sys.modules` a second time on every cache miss. Cache hits also pay `getsourcefile()`'s linecache probe and `os.path.exists()` call. This PR passes the filename explicitly, so the key is computed without the recursion.

## Benchmark

10,000 synthetic modules in `sys.modules`

| Workload | main | PR | Speedup |
|---|---:|---:|---:|
| Cached filename hit | 4.13 µs | 0.85 µs | 4.9x |
| Unregistered frame (repeated miss) | 3.19 ms | 1.55 ms | 2.1x |
| Bare code object (repeated miss) | 3.06 ms | 1.53 ms | 2.0x |
| Miss after a registry mutation | 3.14 ms | 1.67 ms | 1.9x |
| Function fast path | 0.168 µs | 0.168 µs | no change |

<details>
<summary>Benchmark script</summary>

```python
import inspect
import sys
import timeit
import types

for i in range(10_000):
    m = types.ModuleType(f"fake_{i}")
    m.__file__ = f"/tmp/fake/mod_{i}.py"
    sys.modules[m.__name__] = m

real_file = sys.modules["fake_1"].__file__
code_hit = compile("pass", real_file, "exec")
code_miss = compile("pass", "<generated>", "exec")
ns = {"sys": sys, "out": {}}
exec(compile("out['frame'] = sys._getframe()", "<generated>", "exec"), ns)
frame = ns["out"]["frame"]

def a_function():
    pass

inspect.getmodule(code_hit)  # warm the cache

for label, fn in [
    ("cached filename hit", lambda: inspect.getmodule(code_hit)),
    ("unregistered frame (miss)", lambda: inspect.getmodule(frame)),
    ("bare code object (miss)", lambda: inspect.getmodule(code_miss)),
    ("function fast path", lambda: inspect.getmodule(a_function)),
]:
    number, elapsed = timeit.Timer(fn).autorange()
    print(f"{label:28s} {elapsed / number * 1e6:10.3f} us")
```

</details>


<!-- gh-issue-number: gh-92041 -->
* Issue: gh-92041
<!-- /gh-issue-number -->
