### PR TITLE
gh-156667: Add DOM Level 3 names to minidom

### DIFF
--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -59,6 +59,59 @@ class MinidomTest(unittest.TestCase):
         t = node.wholeText
         self.assertEqual(t, s, "looking for %r, found %r" % (s, t))
 
+    def testDOMLevel3GetFeature(self):
+        impl = getDOMImplementation()
+        doc = impl.createDocument(None, "doc", None)
+        node = doc.documentElement
+
+        self.assertIs(impl.getFeature("Core", "2.0"), impl)
+        self.assertIs(node.getFeature("Core", "2.0"), node)
+        self.assertIsNone(impl.getFeature("Core", "3.0"))
+        self.assertIsNone(node.getFeature("Core", "3.0"))
+
+        # The names from the working draft are kept for compatibility.
+        self.assertIs(impl.getInterface("Core"), impl)
+        self.assertIs(node.getInterface("Core"), node)
+
+    def testDOMLevel3AttributeNames(self):
+        doc = Document()
+        pairs = (
+            ("actualEncoding", "inputEncoding", "us-ascii", "utf-8"),
+            ("encoding", "xmlEncoding", "utf-8", "utf-16"),
+            ("standalone", "xmlStandalone", False, True),
+            ("version", "xmlVersion", "1.0", "1.1"),
+        )
+        for old_name, new_name, old_value, new_value in pairs:
+            with self.subTest(node="Document", name=new_name):
+                setattr(doc, old_name, old_value)
+                self.assertEqual(getattr(doc, new_name), old_value)
+                setattr(doc, new_name, new_value)
+                self.assertEqual(getattr(doc, old_name), new_value)
+
+        entity = xml.dom.minidom.Entity("entity", None, None, None)
+        pairs = (
+            ("actualEncoding", "inputEncoding", "us-ascii", "utf-8"),
+            ("encoding", "xmlEncoding", "utf-8", "utf-16"),
+            ("version", "xmlVersion", "1.0", "1.1"),
+        )
+        for old_name, new_name, old_value, new_value in pairs:
+            with self.subTest(node="Entity", name=new_name):
+                setattr(entity, old_name, old_value)
+                self.assertEqual(getattr(entity, new_name), old_value)
+                setattr(entity, new_name, new_value)
+                self.assertEqual(getattr(entity, old_name), new_value)
+
+        doc = parseString(
+            "<!DOCTYPE doc ["
+            "<!ELEMENT doc (child)>"
+            "<!ELEMENT child EMPTY>"
+            "]><doc> <child/></doc>"
+        )
+        text = doc.documentElement.firstChild
+        self.assertTrue(text.isElementContentWhitespace)
+        self.assertEqual(text.isElementContentWhitespace,
+                         text.isWhitespaceInElementContent)
+
     def testDocumentAsyncAttr(self):
         doc = Document()
         self.assertFalse(doc.async_)
@@ -1555,12 +1608,14 @@ class MinidomTest(unittest.TestCase):
         # DTD-based namespace is right.  The names can vary by loader
         # since each supports a different level of DTD information.
         t = elem.schemaType
+        self.assertIs(elem.schemaTypeInfo, t)
         self.confirm(t.name is None
                 and t.namespace == xml.dom.EMPTY_NAMESPACE)
         names = "id notid text enum ref refs ent ents nm nms".split()
         for name in names:
             a = elem.getAttributeNode(name)
             t = a.schemaType
+            self.assertEqual(a.schemaTypeInfo, t)
             self.confirm(hasattr(t, "name")
                     and t.namespace == xml.dom.EMPTY_NAMESPACE)
 

--- a/Lib/xml/dom/minidom.py
+++ b/Lib/xml/dom/minidom.py
@@ -227,16 +227,19 @@ class Node(xml.dom.Node):
         # Overridden in Element and Attr where localName can be Non-Null
         return None
 
-    # Node interfaces from Level 3 (WD 9 April 2002)
+    # Node interfaces from DOM Level 3
 
     def isSameNode(self, other):
         return self is other
 
-    def getInterface(self, feature):
-        if self.isSupported(feature, None):
+    def getFeature(self, feature, version):
+        if self.isSupported(feature, version):
             return self
         else:
             return None
+
+    def getInterface(self, feature):
+        return self.getFeature(feature, None)
 
     # The "user data" functions use a dictionary that is only present
     # if some user data has been set, so be careful not to assume it
@@ -504,9 +507,12 @@ class Attr(Node):
         else:
             return info.getAttributeType(self.nodeName)
 
+    _get_schemaTypeInfo = _get_schemaType
+
 defproperty(Attr, "isId",       doc="True if this attribute is an ID.")
 defproperty(Attr, "localName",  doc="Namespace-local name of this attribute.")
 defproperty(Attr, "schemaType", doc="Schema type for this attribute.")
+defproperty(Attr, "schemaTypeInfo", doc="Schema type for this attribute.")
 
 
 class NamedNodeMap(object):
@@ -712,7 +718,7 @@ class Element(Node):
                'nextSibling', 'previousSibling')
     nodeType = Node.ELEMENT_NODE
     nodeValue = None
-    schemaType = _no_type
+    schemaType = schemaTypeInfo = _no_type
 
     _magic_id_nodes = 0
 
@@ -1220,7 +1226,12 @@ class Text(CharacterData):
         else:
             return info.isElementContent()
 
+    _get_isElementContentWhitespace = _get_isWhitespaceInElementContent
+
 defproperty(Text, "isWhitespaceInElementContent",
+            doc="True iff this text node contains only whitespace"
+                " and is in element content.")
+defproperty(Text, "isElementContentWhitespace",
             doc="True iff this text node contains only whitespace"
                 " and is in element content.")
 defproperty(Text, "wholeText",
@@ -1429,11 +1440,35 @@ class Entity(Identified, Node):
     def _get_actualEncoding(self):
         return self.actualEncoding
 
+    def _get_inputEncoding(self):
+        return self.actualEncoding
+
+    def _set_inputEncoding(self, value):
+        self.actualEncoding = value
+
+    inputEncoding = property(_get_inputEncoding, _set_inputEncoding)
+
     def _get_encoding(self):
         return self.encoding
 
+    def _get_xmlEncoding(self):
+        return self.encoding
+
+    def _set_xmlEncoding(self, value):
+        self.encoding = value
+
+    xmlEncoding = property(_get_xmlEncoding, _set_xmlEncoding)
+
     def _get_version(self):
         return self.version
+
+    def _get_xmlVersion(self):
+        return self.version
+
+    def _set_xmlVersion(self, value):
+        self.version = value
+
+    xmlVersion = property(_get_xmlVersion, _set_xmlVersion)
 
     def appendChild(self, newChild):
         raise xml.dom.HierarchyRequestErr(
@@ -1567,13 +1602,16 @@ class DOMImplementation(DOMImplementationLS):
         doctype.systemId = systemId
         return doctype
 
-    # DOM Level 3 (WD 9 April 2002)
+    # DOM Level 3
 
-    def getInterface(self, feature):
-        if self.hasFeature(feature, None):
+    def getFeature(self, feature, version):
+        if self.hasFeature(feature, version):
             return self
         else:
             return None
+
+    def getInterface(self, feature):
+        return self.getFeature(feature, None)
 
     # internal
     def _create_document(self):
@@ -1644,7 +1682,7 @@ class Document(Node, DocumentLS):
     previousSibling = nextSibling = None
 
 
-    # Document attributes from Level 3 (WD 9 April 2002)
+    # Document attributes from DOM Level 3
 
     actualEncoding = None
     encoding = None
@@ -1675,6 +1713,14 @@ class Document(Node, DocumentLS):
     def _get_actualEncoding(self):
         return self.actualEncoding
 
+    def _get_inputEncoding(self):
+        return self.actualEncoding
+
+    def _set_inputEncoding(self, value):
+        self.actualEncoding = value
+
+    inputEncoding = property(_get_inputEncoding, _set_inputEncoding)
+
     def _get_doctype(self):
         return self.doctype
 
@@ -1684,17 +1730,41 @@ class Document(Node, DocumentLS):
     def _get_encoding(self):
         return self.encoding
 
+    def _get_xmlEncoding(self):
+        return self.encoding
+
+    def _set_xmlEncoding(self, value):
+        self.encoding = value
+
+    xmlEncoding = property(_get_xmlEncoding, _set_xmlEncoding)
+
     def _get_errorHandler(self):
         return self.errorHandler
 
     def _get_standalone(self):
         return self.standalone
 
+    def _get_xmlStandalone(self):
+        return self.standalone
+
+    def _set_xmlStandalone(self, value):
+        self.standalone = value
+
+    xmlStandalone = property(_get_xmlStandalone, _set_xmlStandalone)
+
     def _get_strictErrorChecking(self):
         return self.strictErrorChecking
 
     def _get_version(self):
         return self.version
+
+    def _get_xmlVersion(self):
+        return self.version
+
+    def _set_xmlVersion(self, value):
+        self.version = value
+
+    xmlVersion = property(_get_xmlVersion, _set_xmlVersion)
 
     def _check_new_child(self, newChild, oldChild=None):
         Node._check_new_child(self, newChild, oldChild)

--- a/Misc/NEWS.d/next/Library/2026-08-31-16-10-00.gh-issue-156667.kQ4mLs.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-31-16-10-00.gh-issue-156667.kQ4mLs.rst
@@ -1,0 +1,2 @@
+Add the DOM Level 3 Recommendation names for methods and attributes in
+:mod:`xml.dom.minidom`. Keep the names from earlier working drafts as aliases.


### PR DESCRIPTION
## Summary

- add the DOM Level 3 Recommendation names for the affected `minidom` methods and attributes
- keep the names from the earlier working drafts working as compatibility aliases
- add regression tests for the new names and a Library NEWS entry

`getFeature(feature, version)` follows the final DOM Level 3 signature, while the existing one-argument `getInterface(feature)` behavior is preserved. The new attribute names share their values with the existing names.

Closes #156667

## Tests

- `PCbuild\amd64\python_d.exe -m test -u cpu test_minidom test_pulldom test_xml_dom_minicompat test_xml_dom_xmlbuilder test_xml test_sax`
- `PCbuild\amd64\python_d.exe Tools\patchcheck\patchcheck.py`
- `PCbuild\build.bat -p x64 -c Debug` (0 warnings, 0 errors)

This contribution was prepared with assistance from OpenAI Codex. I reviewed, adjusted, and tested the resulting changes.

<!-- gh-issue-number: gh-156667 -->
* Issue: gh-156667
<!-- /gh-issue-number -->
