### PR TITLE
gh-156699: Preserve single-file mailboxes when replacement fails

### DIFF
--- a/Lib/mailbox.py
+++ b/Lib/mailbox.py
@@ -764,11 +764,7 @@ class _singlefileMailbox(Mailbox):
             os.chown(new_file.name, info.st_uid, info.st_gid)
         except (AttributeError, OSError):
             pass
-        try:
-            os.rename(new_file.name, self._path)
-        except FileExistsError:
-            os.remove(self._path)
-            os.rename(new_file.name, self._path)
+        os.replace(new_file.name, self._path)
         self._file = open(self._path, 'rb+')
         self._toc = new_toc
         self._pending = False

--- a/Lib/test/test_mailbox.py
+++ b/Lib/test/test_mailbox.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import sys
 import time
@@ -14,6 +15,7 @@ from test.support import refleak_helper
 from test.support import requires_root_user
 from test.support import socket_helper
 import unittest
+from unittest import mock
 import textwrap
 import mailbox
 import glob
@@ -1283,6 +1285,26 @@ class _TestMboxMMDF(_TestSingleFile):
 class TestMbox(_TestMboxMMDF, unittest.TestCase):
 
     _factory = lambda self, path, factory=None: mailbox.mbox(path, factory)
+
+    def test_flush_replacement_failure(self):
+        box = self._box
+        box.add(self._template % 0)
+        key = box.add(self._template % 1)
+        box.flush()
+        box.remove(key)
+
+        error = OSError(errno.EIO, 'injected replacement failure')
+        with mock.patch.object(mailbox.os, 'replace', side_effect=error):
+            with self.assertRaises(OSError) as cm:
+                box.flush()
+        self.assertEqual(cm.exception.errno, errno.EIO)
+        self.assertTrue(os.path.exists(self._path))
+
+        self._box = mailbox.mbox(self._path)
+        self.assertEqual(
+            [message.get_payload() for message in self._box.values()],
+            ['0\n', '1\n'],
+        )
 
     @unittest.skipUnless(hasattr(os, 'umask'), 'test needs os.umask()')
     def test_file_perms(self):

--- a/Misc/NEWS.d/next/Library/2026-08-30-23-29-06.gh-issue-156699.YecuE8.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-30-23-29-06.gh-issue-156699.YecuE8.rst
@@ -1,0 +1,2 @@
+Preserve :class:`mailbox.mbox`, :class:`mailbox.MMDF`, and
+:class:`mailbox.Babyl` files when replacing a rewritten mailbox fails.


### PR DESCRIPTION
Use os.replace() so a failed single-file mailbox replacement does not first remove the existing pathname.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156699 -->
* Issue: gh-156699
<!-- /gh-issue-number -->
