### PR TITLE
gh-116750: Document 3.14 changes around sys.monitoring.clear_tool_id

### DIFF
--- a/Doc/library/sys.monitoring.rst
+++ b/Doc/library/sys.monitoring.rst
@@ -54,10 +54,17 @@ Registering and using tools
 
    Unregister all events and callback functions associated with *tool_id*.
 
+   .. versionadded:: 3.14
+
 .. function:: free_tool_id(tool_id: int, /) -> None
 
    Should be called once a tool no longer requires *tool_id*.
    Will call :func:`clear_tool_id` before releasing *tool_id*.
+
+   .. versionchanged:: 3.14
+      Now calls :func:`clear_tool_id` before releasing *tool_id*.
+      Previously, it would not disable global or local events associated
+      with *tool_id*, nor unregister any callback functions.
 
 .. function:: get_tool(tool_id: int, /) -> str | None
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1906,6 +1906,12 @@ sys.monitoring
   These replace and deprecate the :monitoring-event:`!BRANCH` event.
   (Contributed by Mark Shannon in :gh:`122548`.)
 
+* Add :func:`sys.monitoring.clear_tool_id` to unregister all events and
+  callback functions associated with a tool identifier.
+  :func:`sys.monitoring.free_tool_id` now calls it before releasing the
+  tool identifier, instead of leaving its events and callbacks registered.
+  (Contributed by Tian Gao in :gh:`116750`.)
+
 
 sysconfig
 ---------


### PR DESCRIPTION
clear_tool_id() was added in 3.14 but lacked a versionadded note. Also free_tool_id()'s behavior changed (now calling clear_tool_id() before releasing the tool_id, rather than leaving events/callbacks registered) which was also not a documented change. Also add a What's New in 3.14 entry covering both.

(Using gh-116750 as issue number, which is the issue for the original change but is already closed, hope that is OK.)