### PR TITLE
gh-156707: Remove the junction created in test_realpath_volume_guid_path()

### DIFF
--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -1585,11 +1585,15 @@ class TestNtpath(NtpathTestCase):
                 except (OSError, subprocess.CalledProcessError):
                     raise unittest.SkipTest('creating the test junction failed')
 
-                for path in 'testjunc', 'testjunc/spam', 'testjunc/spam/eggs':
-                    with self.subTest(path=path):
-                        realpath = ntpath.realpath(path)
-                        self.assertStartsWith(realpath, '\\\\?\\Volume{')
-                        self.assertTrue(ntpath.isabs(realpath), realpath)
+                try:
+                    for path in 'testjunc', 'testjunc/spam', 'testjunc/spam/eggs':
+                        with self.subTest(path=path):
+                            realpath = ntpath.realpath(path)
+                            self.assertStartsWith(realpath, '\\\\?\\Volume{')
+                            self.assertTrue(ntpath.isabs(realpath), realpath)
+                finally:
+                    # Remove the junction, not the volume it points to.
+                    os_helper.rmdir('testjunc')
 
     def test_isfile_invalid_paths(self):
         isfile = ntpath.isfile


### PR DESCRIPTION
The test created a junction to a volume without a mount point and left it to the temporary directory cleanup, which descended into the junction and tried to remove files on that volume.

`os.rmdir()` removes the junction itself, not the directory it points to.

<!-- gh-issue-number: gh-156707 -->
* Issue: gh-156707
<!-- /gh-issue-number -->
