### PR TITLE
gh-156707: Do not follow junctions in os_helper.rmtree() on Windows

### DIFF
--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -434,7 +434,10 @@ if sys.platform.startswith("win"):
                           file=sys.__stderr__)
                     mode = 0
                 if stat.S_ISDIR(mode):
-                    _waitfor(_rmtree_inner, fullname, waitall=True)
+                    # Do not follow junctions, which os.lstat() reports
+                    # as directories.
+                    if not os.path.isjunction(fullname):
+                        _waitfor(_rmtree_inner, fullname, waitall=True)
                     _force_run(fullname, os.rmdir, fullname)
                 else:
                     _force_run(fullname, os.unlink, fullname)


### PR DESCRIPTION
`os.lstat()` reports a junction as a directory, so `os_helper.rmtree()` descended into junctions and could remove files outside of the removed tree.

`os.walk()` and `shutil.rmtree()` already skip junctions, so this only makes `os_helper.rmtree()` agree with them.

<!-- gh-issue-number: gh-156707 -->
* Issue: gh-156707
<!-- /gh-issue-number -->
