### PR TITLE
gh-99064: Ignore the encoding declaration when parsing decoded text

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1068,6 +1068,34 @@ class ElementTreeTest(unittest.TestCase):
         self.assertRaises(ValueError, ET.XML, xml('undefined').encode('ascii'))
         self.assertRaises(LookupError, ET.XML, xml('xxx').encode('ascii'))
 
+    def test_parse_text_source(self):
+        # gh-99064: The encoding declared in the document does not apply
+        # to a source which is already decoded.
+        def check(encoding, body):
+            xml = ("<?xml version='1.0' encoding='%s'?><xml>%s</xml>" %
+                   (encoding, body))
+            with self.subTest(encoding=encoding):
+                self.assertEqual(ET.parse(io.StringIO(xml)).getroot().text,
+                                 body)
+                # the same with an explicitly created parser
+                self.assertEqual(
+                    ET.parse(io.StringIO(xml), ET.XMLParser()).getroot().text,
+                    body)
+        check("ascii", 'a')
+        check("iso-8859-1", '\xbd')
+        check("iso-8859-15", '\u20ac')
+        check("cp437", '\u221a')
+        check("utf-8", '\u4e2d')
+        # not ASCII compatible, unsupported for a bytes source
+        check("utf-16", '\u4e2d')
+        check("utf-32", '\u4e2d')
+
+    def test_parse_text_source_multiple_chunks(self):
+        # the encoding is overridden before the first chunk is parsed
+        body = '\xe4' * 100_000
+        xml = "<?xml version='1.0' encoding='ISO-8859-1'?><xml>%s</xml>" % body
+        self.assertEqual(ET.parse(io.StringIO(xml)).getroot().text, body)
+
     @support.subTests('sample,exception', [
         (b'<x> \xa1</x>', UnicodeDecodeError),  # crashed
         (b'<x> \xa1</x', UnicodeDecodeError),  # crashed

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1072,8 +1072,8 @@ class ElementTreeTest(unittest.TestCase):
         # gh-99064: The encoding declared in the document does not apply
         # to a source which is already decoded.
         def check(encoding, body):
-            xml = ("<?xml version='1.0' encoding='%s'?><xml>%s</xml>" %
-                   (encoding, body))
+            xml = (f"<?xml version='1.0' encoding='{encoding}'?>" 
+                   f"<xml>{body}</xml>")
             with self.subTest(encoding=encoding):
                 self.assertEqual(ET.parse(io.StringIO(xml)).getroot().text,
                                  body)

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1072,7 +1072,7 @@ class ElementTreeTest(unittest.TestCase):
         # gh-99064: The encoding declared in the document does not apply
         # to a source which is already decoded.
         def check(encoding, body):
-            xml = (f"<?xml version='1.0' encoding='{encoding}'?>" 
+            xml = (f"<?xml version='1.0' encoding='{encoding}'?>"
                    f"<xml>{body}</xml>")
             with self.subTest(encoding=encoding):
                 self.assertEqual(ET.parse(io.StringIO(xml)).getroot().text,

--- a/Misc/NEWS.d/next/Library/2026-08-31-20-30-00.gh-issue-99064.Rt4mZ9.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-31-20-30-00.gh-issue-99064.Rt4mZ9.rst
@@ -1,0 +1,5 @@
+Fix :func:`xml.etree.ElementTree.parse` with a text file or other source
+of :class:`str` data in the C implementation.
+The encoding declared in the document was applied to the already decoded
+text, which produced mojibake.  It is now ignored, as when parsing with
+:meth:`!XMLParser.feed` or :func:`~xml.etree.ElementTree.fromstring`.

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -4084,6 +4084,7 @@ _elementtree_XMLParser__parse_whole_impl(XMLParserObject *self,
 
     /* read from open file object */
     elementtreestate *st = self->state;
+    int first = 1;
     for (;;) {
 
         buffer = PyObject_CallFunction(reader, "i", 64*1024);
@@ -4099,6 +4100,11 @@ _elementtree_XMLParser__parse_whole_impl(XMLParserObject *self,
             if (PyUnicode_GET_LENGTH(buffer) == 0) {
                 Py_DECREF(buffer);
                 break;
+            }
+            if (first) {
+                /* The text is already decoded, the encoding declared in the
+                   document does not apply to it.  Return code ignored. */
+                (void)EXPAT(st, SetEncoding)(self->parser, "utf-8");
             }
             temp = PyUnicode_AsEncodedString(buffer, "utf-8", "surrogatepass");
             Py_DECREF(buffer);
@@ -4123,6 +4129,7 @@ _elementtree_XMLParser__parse_whole_impl(XMLParserObject *self,
         res = expat_parse(
             st, self, PyBytes_AS_STRING(buffer), (int)PyBytes_GET_SIZE(buffer),
             0);
+        first = 0;
 
         Py_DECREF(buffer);
 


### PR DESCRIPTION
`ElementTree.parse()` mis-decodes a text file in the C implementation: `_parse_whole()` encodes the read string as UTF-8, but leaves expat to honor the encoding declared in the document.

```python
>>> doc = '<?xml version="1.0" encoding="ISO-8859-1"?><r a="äöü"/>'
>>> ET.parse(io.StringIO(doc)).getroot().get('a')                  # before
'Ã¤Ã¶Ã¼'
>>> ET.parse(io.StringIO(doc), ET.XMLParser()).getroot().get('a')
'äöü'
>>> ET.fromstring(doc).get('a')
'äöü'
```

`XMLParser.feed()` overrides the encoding for `str` data (bpo-16986), but `_parse_whole()` was never changed, so `parse()` without an explicit parser has been the odd one out. It now overrides it too, and a text source declaring a non-ASCII-compatible encoding (UTF-16, UTF-32) is no longer a `ParseError`.


<!-- gh-issue-number: gh-99064 -->
* Issue: gh-99064
<!-- /gh-issue-number -->
