### PR TITLE
gh-156668: Fix Document.async_ setter

### DIFF
--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -62,7 +62,11 @@ class MinidomTest(unittest.TestCase):
     def testDocumentAsyncAttr(self):
         doc = Document()
         self.assertFalse(doc.async_)
-        self.assertFalse(Document.async_)
+        doc.async_ = False
+        self.assertFalse(doc.async_)
+        with self.assertRaises(xml.dom.NotSupportedErr):
+            doc.async_ = True
+        self.assertFalse(doc.async_)
 
     def testParseFromBinaryFile(self):
         with open(tstfile, 'rb') as file:

--- a/Lib/xml/dom/xmlbuilder.py
+++ b/Lib/xml/dom/xmlbuilder.py
@@ -336,8 +336,6 @@ del NodeFilter
 class DocumentLS:
     """Mixin to create documents that conform to the load/save spec."""
 
-    async_ = False
-
     def _get_async(self):
         return False
 
@@ -345,6 +343,8 @@ class DocumentLS:
         if flag:
             raise xml.dom.NotSupportedErr(
                 "asynchronous document loading is not supported")
+
+    async_ = property(_get_async, _set_async)
 
     def abort(self):
         # What does it mean to "clear" a document?  Does the

--- a/Misc/NEWS.d/next/Library/2026-08-31-12-51-00.gh-issue-156668.asyncLS.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-31-12-51-00.gh-issue-156668.asyncLS.rst
@@ -1,0 +1,2 @@
+Fix ``Document.async_`` in :mod:`xml.dom.minidom` so setting it to true
+raises :exc:`xml.dom.NotSupportedErr`.


### PR DESCRIPTION
## Summary

`DocumentLS` already provides `_get_async()` and `_set_async()`, but `async_` was left as a plain class attribute, so assigning `True` did not call the setter.

This change exposes the existing getter and setter through a property so that:

* `doc.async_` remains `False`.
* `doc.async_ = False` remains valid.
* `doc.async_ = True` raises `xml.dom.NotSupportedErr`.

The test suite verifies this observable behavior.

This change intentionally does not attempt to resolve the broader architectural question around the obsolete DOM Level 3 Load and Save API discussed in #156668.

## Testing

The focused `Document.async_` behavioral test was run successfully in a substitute environment.

The complete CPython test suite could not be run against a locally built CPython main interpreter because the local checkout does not have a usable built CPython executable, and the available Python 3.12 interpreter cannot execute the current main branch.

## Issue

Fixes the concrete `Document.async_` bug described in #156668.


<!-- gh-issue-number: gh-156668 -->
* Issue: gh-156668
<!-- /gh-issue-number -->
