### PR TITLE
gh-156745: Inline CJK replacement writer call

### DIFF
--- a/Misc/NEWS.d/next/Library/2026-09-01-03-09-14.gh-issue-156745.sLPFxu.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-01-03-09-14.gh-issue-156745.sLPFxu.rst
@@ -1,1 +1,0 @@
-Optimize cjk codec decode() with 'replace' error handling

--- a/Misc/NEWS.d/next/Library/2026-09-01-03-09-14.gh-issue-156745.sLPFxu.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-01-03-09-14.gh-issue-156745.sLPFxu.rst
@@ -1,0 +1,1 @@
+Optimize cjk codec decode() with 'replace' error handling

--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -429,8 +429,8 @@ multibytecodec_decerror(const MultibyteCodec *codec,
     }
 
     if (errors == ERROR_REPLACE) {
-        if (_PyUnicodeWriter_WriteChar(&buf->writer,
-                                       Py_UNICODE_REPLACEMENT_CHARACTER) < 0)
+        if (_PyUnicodeWriter_WriteCharInline(
+                &buf->writer, Py_UNICODE_REPLACEMENT_CHARACTER) < 0)
             goto errorexit;
     }
     if (errors == ERROR_IGNORE || errors == ERROR_REPLACE) {


### PR DESCRIPTION
Call `_PyUnicodeWriter_WriteCharInline()` instead of the python lib version of the method. 
Removes the overhead of the boundary call between the `.so` and the exported function. 

```python
# decode dense invalid bytes with errors='replace'
bad = b"\x81\x40" + b"\xff"*4000
bad.decode('shift_jis', 'replace')
```
| Benchmark | base | patched | delta |
|---|---|---|---|
| `replace`, all-invalid (shift_jis) | 34.06 µs | 27.08 µs | **−20.5%** |
| `replace`, all-invalid (gbk) | 36.55 µs | 28.20 µs | **−22.8%** |
| `replace`, mixed valid/invalid | 18.95 µs | 16.85 µs | **−11.1%** |
| valid input, no errors *(control)* | 18.50 µs | 18.39 µs | −0.6% (noise) |
| `ignore`, all-invalid *(control)* | 24.17 µs | 24.16 µs | 0.0% (noise) |

<!-- gh-issue-number: gh-156745 -->
* Issue: gh-156745
<!-- /gh-issue-number -->
