### PR TITLE
gh-156748 : Performance - Use takeref append in _csv

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-09-01-03-05-22.gh-issue-156748.B0Z47w.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-09-01-03-05-22.gh-issue-156748.B0Z47w.rst
@@ -1,0 +1,1 @@
+Optimize refcount churn in _csv.

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -14,6 +14,7 @@ module instead.
 #endif
 
 #include "Python.h"
+#include "pycore_list.h"         // _PyList_AppendTakeRef()
 #include "pycore_pyatomic_ft_wrappers.h"
 
 #include <stddef.h>               // offsetof()
@@ -710,11 +711,9 @@ parse_save_field(ReaderObj *self)
         }
         self->field_len = 0;
     }
-    if (PyList_Append(self->fields, field) < 0) {
-        Py_DECREF(field);
+    if (_PyList_AppendTakeRef((PyListObject *)self->fields, field) < 0) {
         return -1;
     }
-    Py_DECREF(field);
     return 0;
 }
 


### PR DESCRIPTION
Reduce refcount churn by consuming the reference instead in lieu of calling append and decreffing.

| Benchmark | base | patched | delta |
|---|---|---|---|
| 50 fields × 200 rows | 537.7 µs | 508.3 µs | **−5.5%** |
| quoted + embedded separators/newlines | 468.9 µs | 435.8 µs | **−7.1%** |
| all-empty fields (50 × 200) | 173.6 µs | 150.0 µs | **−13.6%** |
| 2 fields × 200 rows | 24.0 µs | 23.3 µs | −2.9% (noise 3.3%) |
| 5 × 500-char fields *(control)* | 2517.7 µs | 2508.2 µs | −0.4% (noise 21%) |

```python
# 50 fields x 200 rows
data = "\n".join(",".join(f"f{j}" for j in range(50)) for _ in range(200))
list(csv.reader(io.StringIO(data)))
```

<!-- gh-issue-number: gh-156748 -->
* Issue: gh-156748
<!-- /gh-issue-number -->
