### PR TITLE
gh-126929: Retry extension loading with long Windows paths

### DIFF
--- a/Misc/NEWS.d/next/Windows/2026-09-01-10-05-00.gh-issue-126929.long-path-dll.rst
+++ b/Misc/NEWS.d/next/Windows/2026-09-01-10-05-00.gh-issue-126929.long-path-dll.rst
@@ -1,0 +1,1 @@
+Fix loading extension modules from long Windows paths by retrying with an extended-length path after the initial load fails and the target is confirmed to be a regular file.

--- a/Python/dynload_win.c
+++ b/Python/dynload_win.c
@@ -307,6 +307,36 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
         hDLL = LoadLibraryExW(wpathname, NULL,
                               LOAD_LIBRARY_SEARCH_DEFAULT_DIRS |
                               LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
+        if (hDLL == NULL) {
+            DWORD attributes = GetFileAttributesW(wpathname);
+            if (attributes != INVALID_FILE_ATTRIBUTES &&
+                !(attributes & FILE_ATTRIBUTE_DIRECTORY)) {
+                size_t path_length = wcslen(wpathname);
+                int is_unc = wpathname[0] == L'\\' && wpathname[1] == L'\\';
+                size_t prefix_length = is_unc ? 8 : 4;
+                wchar_t *extended_path = PyMem_RawMalloc(
+                    (path_length + prefix_length + 1) * sizeof(wchar_t));
+                if (extended_path != NULL) {
+                    if (is_unc) {
+                        wcscpy_s(extended_path, path_length + prefix_length + 1,
+                                 L"\\\\?\\UNC\\");
+                        wcscat_s(extended_path, path_length + prefix_length + 1,
+                                 wpathname + 2);
+                    }
+                    else {
+                        wcscpy_s(extended_path, path_length + prefix_length + 1,
+                                 L"\\\\?\\");
+                        wcscat_s(extended_path, path_length + prefix_length + 1,
+                                 wpathname);
+                    }
+                    hDLL = LoadLibraryExW(
+                        extended_path, NULL,
+                        LOAD_LIBRARY_SEARCH_DEFAULT_DIRS |
+                        LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
+                    PyMem_RawFree(extended_path);
+                }
+            }
+        }
         Py_END_ALLOW_THREADS
         PyMem_Free(wpathname);
 


### PR DESCRIPTION
Fixes #126929.

On Windows, retry extension-module loading with a long-path-compatible DLL path when the initial load fails because the path exceeds legacy limits.

The change also adds the required Windows NEWS entry.

Validation performed:
- `git diff --check`
- tracked-secret scan on both changed files
- commit contains DCO sign-off and an SSH signature

Windows-specific runtime validation was not available locally.

<!-- gh-issue-number: gh-126929 -->
* Issue: gh-126929
<!-- /gh-issue-number -->
