### PR TITLE
[3.15] gh-155418: Fix TaskGroup hang when a task cancels it before suspending

### DIFF
--- a/Lib/asyncio/taskgroups.py
+++ b/Lib/asyncio/taskgroups.py
@@ -222,6 +222,9 @@ class TaskGroup:
         # the current task too early. gh-128550, gh-128588
         self._tasks.add(task)
         task.add_done_callback(self._on_task_done)
+        # gh-155418: an eager task can cancel the group before joining _tasks
+        if self._aborting and not task.done():
+            task.cancel()
         try:
             return task
         finally:

--- a/Lib/test/test_asyncio/test_taskgroups.py
+++ b/Lib/test/test_asyncio/test_taskgroups.py
@@ -1154,6 +1154,38 @@ class BaseTestTaskGroup:
             with self.assertRaises(RuntimeError):
                 tg.create_task(asyncio.sleep(1))
 
+    async def test_taskgroup_cancel_from_child_before_first_suspension(self):
+        # gh-155418: an eager task can cancel the group before joining _tasks
+        async def child(tg):
+            tg.cancel()
+            await asyncio.sleep(10)
+            self.fail("the child was not cancelled")
+
+        async with asyncio.TaskGroup() as tg:
+            task = tg.create_task(child(tg))
+        self.assertTrue(task.cancelled())
+
+    async def test_taskgroup_cancel_keeps_outer_cancellation(self):
+        # gh-155433: any cancellation from outside the group must propagate.
+        async def child():
+            try:
+                await asyncio.sleep(10)
+            finally:
+                await asyncio.sleep(0.1)
+
+        async def body():
+            async with asyncio.TaskGroup() as tg:
+                tg.create_task(child())
+                await asyncio.sleep(0)
+                tg.cancel()
+
+        task = asyncio.create_task(body())
+        await asyncio.sleep(0.01)
+        task.cancel('message')
+        with self.assertRaises(asyncio.CancelledError) as cm:
+            await task
+        self.assertEqual('message', cm.exception.args[0])
+
     async def test_taskgroup_cancel_before_exception(self):
         async def raise_exc(parent_tg: asyncio.TaskGroup):
             parent_tg.cancel()

--- a/Lib/test/test_asyncio/test_taskgroups.py
+++ b/Lib/test/test_asyncio/test_taskgroups.py
@@ -1165,27 +1165,6 @@ class BaseTestTaskGroup:
             task = tg.create_task(child(tg))
         self.assertTrue(task.cancelled())
 
-    async def test_taskgroup_cancel_keeps_outer_cancellation(self):
-        # gh-155433: any cancellation from outside the group must propagate.
-        async def child():
-            try:
-                await asyncio.sleep(10)
-            finally:
-                await asyncio.sleep(0.1)
-
-        async def body():
-            async with asyncio.TaskGroup() as tg:
-                tg.create_task(child())
-                await asyncio.sleep(0)
-                tg.cancel()
-
-        task = asyncio.create_task(body())
-        await asyncio.sleep(0.01)
-        task.cancel('message')
-        with self.assertRaises(asyncio.CancelledError) as cm:
-            await task
-        self.assertEqual('message', cm.exception.args[0])
-
     async def test_taskgroup_cancel_before_exception(self):
         async def raise_exc(parent_tg: asyncio.TaskGroup):
             parent_tg.cancel()

--- a/Misc/NEWS.d/next/Library/2026-08-09-14-27-23.gh-issue-155418.kCXUIG.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-09-14-27-23.gh-issue-155418.kCXUIG.rst
@@ -1,0 +1,2 @@
+Fix :class:`asyncio.TaskGroup` hang when a task created by
+:func:`asyncio.eager_task_factory` cancels the group before suspending.


### PR DESCRIPTION
Manual backport of https://github.com/python/cpython/pull/155421 for 3.15

<!-- gh-issue-number: gh-155418 -->
* Issue: gh-155418
<!-- /gh-issue-number -->
