### PR TITLE
[3.14] gh-119452: test_large_content_length_truncated: Don't use the full LOOPBACK_TIMEOUT on Windows

### DIFF
--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -1134,7 +1134,16 @@ class CGIHTTPServerTestCase(BaseTestCase):
             self.assertEqual(res.read(), b'%d %d' % (size, size) + self.linesep)
 
     def test_large_content_length_truncated(self):
-        with support.swap_attr(self.request_handler, 'timeout', support.LOOPBACK_TIMEOUT):
+        timeout = support.LOOPBACK_TIMEOUT
+        if not hasattr(os, 'fork'):
+            # On Windows, request() waits for the entire timeout; the default
+            # LOOPBACK_TIMEOUT (10s) is too long for 40 repetitions.
+            # Use a fraction of that (for slow machines), or .001 (in case
+            # LOOPBACK_TIMEOUT is cunfigured to be smaller).
+            timeout = max(timeout / 100, 0.001)
+            # (On Unix, request() returns early so a large LOOPBACK_TIMEOUT
+            # isn't an issue.)
+        with support.swap_attr(self.request_handler, 'timeout', timeout):
             for w in range(18, 65):
                 size = 1 << w
                 headers = {'Content-Length' : str(size)}

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -1139,7 +1139,7 @@ class CGIHTTPServerTestCase(BaseTestCase):
             # On Windows, request() waits for the entire timeout; the default
             # LOOPBACK_TIMEOUT (10s) is too long for 40 repetitions.
             # Use a fraction of that (for slow machines), or .001 (in case
-            # LOOPBACK_TIMEOUT is cunfigured to be smaller).
+            # LOOPBACK_TIMEOUT is configured to be smaller).
             timeout = max(timeout / 100, 0.001)
             # (On Unix, request() returns early so a large LOOPBACK_TIMEOUT
             # isn't an issue.)


### PR DESCRIPTION
This is a follow-up to GH-155951 (commit 39921ebf7007a7fe3181bbebcf64d4433ec5de7a),
addressing Windows Refleaks buildbot timeouts.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119452 -->
* Issue: gh-119452
<!-- /gh-issue-number -->
