### PR TITLE
gh-156764: Fix safety configure option defaults

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-09-01-17-44-34.gh-issue-156764.SF2573.rst
+++ b/Misc/NEWS.d/next/Build/2026-09-01-17-44-34.gh-issue-156764.SF2573.rst
@@ -1,0 +1,2 @@
+Fix the default handling of the ``safety`` configure option and the
+``--disable-*`` handling of the ``safety`` and ``slower-safety`` options.

--- a/configure
+++ b/configure
@@ -10161,15 +10161,14 @@ printf %s "checking for --enable-safety... " >&6; }
 # Check whether --enable-safety was given.
 if test ${enable_safety+y}
 then :
-  enableval=$enable_safety; if test "x$disable_safety" = xyes
-then :
-  enable_safety=no
+  enableval=$enable_safety; case $enableval in #(
+  yes|no) :
+    enable_safety=$enableval ;; #(
+  *) :
+    as_fn_error $? "invalid --enable-safety option: expected \"yes\" or \"no\"" "$LINENO" 5 ;;
+esac
 else case e in #(
   e) enable_safety=yes ;;
-esac
-fi
-else case e in #(
-  e) enable_safety=no ;;
 esac
 fi
 
@@ -10437,13 +10436,12 @@ printf %s "checking for --enable-slower-safety... " >&6; }
 # Check whether --enable-slower-safety was given.
 if test ${enable_slower_safety+y}
 then :
-  enableval=$enable_slower_safety; if test "x$disable_slower_safety" = xyes
-then :
-  enable_slower_safety=no
-else case e in #(
-  e) enable_slower_safety=yes ;;
+  enableval=$enable_slower_safety; case $enableval in #(
+  yes|no) :
+    enable_slower_safety=$enableval ;; #(
+  *) :
+    as_fn_error $? "invalid --enable-slower-safety option: expected \"yes\" or \"no\"" "$LINENO" 5 ;;
 esac
-fi
 else case e in #(
   e) enable_slower_safety=no ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -2595,7 +2595,10 @@ AS_VAR_IF([with_strict_overflow], [yes],
 AC_MSG_CHECKING([for --enable-safety])
 AC_ARG_ENABLE([safety],
   [AS_HELP_STRING([--enable-safety], [enable usage of the security compiler options with no performance overhead])],
-  [AS_VAR_IF([disable_safety], [yes], [enable_safety=no], [enable_safety=yes])], [enable_safety=no])
+  [AS_CASE([$enableval],
+    [yes|no], [enable_safety=$enableval],
+    [AC_MSG_ERROR([invalid --enable-safety option: expected "yes" or "no"])])],
+  [enable_safety=yes])
 AC_MSG_RESULT([$enable_safety])
 
 if test "$enable_safety" = "yes"
@@ -2611,7 +2614,10 @@ fi
 AC_MSG_CHECKING([for --enable-slower-safety])
 AC_ARG_ENABLE([slower-safety],
   [AS_HELP_STRING([--enable-slower-safety], [enable usage of the security compiler options with performance overhead])],
-  [AS_VAR_IF([disable_slower_safety], [yes], [enable_slower_safety=no], [enable_slower_safety=yes])], [enable_slower_safety=no])
+  [AS_CASE([$enableval],
+    [yes|no], [enable_slower_safety=$enableval],
+    [AC_MSG_ERROR([invalid --enable-slower-safety option: expected "yes" or "no"])])],
+  [enable_slower_safety=no])
 AC_MSG_RESULT([$enable_slower_safety])
 
 if test "$enable_slower_safety" = "yes"


### PR DESCRIPTION
Preserve the default enabled safety configuration while correctly handling enable, disable, and invalid values for both safety options.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156764 -->
* Issue: gh-156764
<!-- /gh-issue-number -->
