### PR TITLE
gh-64862: Use iter() with stop_exception in the stdlib

### DIFF
--- a/Lib/_weakrefset.py
+++ b/Lib/_weakrefset.py
@@ -52,14 +52,11 @@ class WeakSet:
         return self.__class__(self)
 
     def pop(self):
-        while True:
-            try:
-                itemref = self.data.pop()
-            except KeyError:
-                raise KeyError('pop from empty WeakSet') from None
+        for itemref in iter(self.data.pop, stop_exception=KeyError):
             item = itemref()
             if item is not None:
                 return item
+        raise KeyError('pop from empty WeakSet')
 
     def remove(self, item):
         self.data.remove(ref(item))

--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -243,11 +243,8 @@ class ThreadPoolExecutor(_base.Executor):
             self._broken = ('A thread initializer failed, the thread pool '
                             'is not usable anymore')
             # Drain work queue and mark pending futures failed
-            while True:
-                try:
-                    work_item = self._work_queue.get_nowait()
-                except queue.Empty:
-                    break
+            for work_item in iter(self._work_queue.get_nowait,
+                                  stop_exception=queue.Empty):
                 if work_item is not None:
                     work_item.future.set_exception(self.BROKEN(self._broken))
 
@@ -257,11 +254,8 @@ class ThreadPoolExecutor(_base.Executor):
             if cancel_futures:
                 # Drain all work items from the queue, and then cancel their
                 # associated futures.
-                while True:
-                    try:
-                        work_item = self._work_queue.get_nowait()
-                    except queue.Empty:
-                        break
+                for work_item in iter(self._work_queue.get_nowait,
+                                      stop_exception=queue.Empty):
                     if work_item is not None:
                         work_item.future.cancel()
 

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -93,13 +93,9 @@ class _WeakValueDictionary:
         self.data = {}
 
     def _commit_removals(self):
-        pop = self._pending_removals.pop
         d = self.data
-        while True:
-            try:
-                key = pop()
-            except IndexError:
-                return
+        for key in iter(self._pending_removals.pop,
+                        stop_exception=IndexError):
             _weakref._remove_dead_weakref(d, key)
 
     def get(self, key, default=None):

--- a/Lib/multiprocessing/heap.py
+++ b/Lib/multiprocessing/heap.py
@@ -257,11 +257,8 @@ class Heap(object):
 
     def _free_pending_blocks(self):
         # Free all the blocks in the pending list - called with the lock held.
-        while True:
-            try:
-                block = self._pending_free_blocks.pop()
-            except IndexError:
-                break
+        for block in iter(self._pending_free_blocks.pop,
+                          stop_exception=IndexError):
             self._add_free_block(block)
             self._remove_allocated_block(block)
 

--- a/Lib/multiprocessing/resource_tracker.py
+++ b/Lib/multiprocessing/resource_tracker.py
@@ -310,11 +310,8 @@ class ResourceTracker(object):
             else:
                 self._launch()
 
-        while True:
-            try:
-                reentrant_msg = self._reentrant_messages.popleft()
-            except IndexError:
-                break
+        for reentrant_msg in iter(self._reentrant_messages.popleft,
+                                  stop_exception=IndexError):
             self._write(reentrant_msg)
         if msg is not None:
             self._write(msg)

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1336,9 +1336,8 @@ class XMLPullParser:
         Events are consumed from the internal event queue as they are
         retrieved from the iterator.
         """
-        events = self._events_queue
-        while events:
-            event = events.popleft()
+        for event in iter(self._events_queue.popleft,
+                          stop_exception=IndexError):
             if isinstance(event, Exception):
                 raise event
             else:


### PR DESCRIPTION
Replace hand-written loops which drain a container or a queue with `iter(callable, stop_exception=...)`, added in GH-156298.

All of them except `XMLPullParser.read_events()` already caught the exception raised by the exhausted container; `read_events()` tested the queue for emptiness before popping from it, which is also one step less atomic.

Loops which drain a small container are left as they are: raising and catching the exception costs about 100 ns, which only pays off above ~35 items (measured on a PGO build; the per-item cost of the exception form is ~19% lower, because it does not test the container in every iteration).

<!-- gh-issue-number: gh-64862 -->
* Issue: gh-64862
<!-- /gh-issue-number -->
