### PR TITLE
gh-156777: Optimize import overhead in the logging package

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -23,7 +23,6 @@ Copyright (C) 2001-2022 Vinay Sajip. All Rights Reserved.
 To use, simply 'import logging' and log away!
 """
 
-# io, os, traceback and warnings must stay eager to support finalization
 import sys, os, time, io, re, traceback, warnings, weakref, collections.abc
 
 lazy import pickle

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -23,7 +23,10 @@ Copyright (C) 2001-2022 Vinay Sajip. All Rights Reserved.
 To use, simply 'import logging' and log away!
 """
 
+# io, os, traceback and warnings must stay eager to support finalization
 import sys, os, time, io, re, traceback, warnings, weakref, collections.abc
+
+lazy import pickle
 
 from types import GenericAlias
 from string import Template
@@ -1841,7 +1844,6 @@ class Logger(Filterer):
 
     def __reduce__(self):
         if getLogger(self.name) is not self:
-            import pickle
             raise pickle.PicklingError('logger cannot be pickled')
         return getLogger, (self.name,)
 
@@ -2365,9 +2367,7 @@ def captureWarnings(capture):
 
 def __getattr__(name):
     if name in ("__version__", "__date__"):
-        from warnings import _deprecated
-
-        _deprecated(name, remove=(3, 20))
+        warnings._deprecated(name, remove=(3, 20))
         return {  # Do not change
             "__version__": "0.5.1.2",
             "__date__": "07 February 2010",

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -25,11 +25,11 @@ To use, simply 'import logging' and log away!
 
 import sys, os, time, io, re, traceback, warnings, weakref, collections.abc
 
-lazy import pickle
-
 from types import GenericAlias
 from string import Template
 from string import Formatter as StrFormatter
+
+lazy import pickle
 
 
 __all__ = ['BASIC_FORMAT', 'BufferingFormatter', 'CRITICAL', 'DEBUG', 'ERROR',

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -24,25 +24,24 @@ Copyright (C) 2001-2022 Vinay Sajip. All Rights Reserved.
 To use, simply 'import logging.config' and log away!
 """
 
-lazy import configparser
 import errno
 import functools
 import io
-lazy import json
 import logging
-lazy import logging.handlers
 import os
-lazy import queue
 import re
+import threading
+import traceback
+lazy import configparser
+lazy import json
+lazy import queue
 lazy import select
 lazy import socket
 lazy import struct
-import threading
-import traceback
-
 lazy from bisect import bisect_left
+lazy from logging import handlers as logging_handlers
 lazy from multiprocessing.queues import Queue as MPQueue
-lazy from socketserver import ThreadingTCPServer, StreamRequestHandler
+lazy from socketserver import StreamRequestHandler, ThreadingTCPServer
 
 
 DEFAULT_LOGGING_CONFIG_PORT = 9030
@@ -169,7 +168,7 @@ def _install_handlers(cp, formatters):
             h.setLevel(level)
         if len(fmt):
             h.setFormatter(formatters[fmt])
-        if issubclass(klass, logging.handlers.MemoryHandler):
+        if issubclass(klass, logging_handlers.MemoryHandler):
             target = section.get("target", "")
             if len(target): #the target handler may not be loaded yet, so keep for later...
                 fixups.append((h, target))
@@ -761,7 +760,7 @@ class DictConfigurator(BaseConfigurator):
             q = queue.Queue()  # unbounded
 
         rhl = kwargs.pop('respect_handler_level', False)
-        lklass = kwargs.pop('listener', logging.handlers.QueueListener)
+        lklass = kwargs.pop('listener', logging_handlers.QueueListener)
         handlers = kwargs.pop('handlers', [])
 
         listener = lklass(q, *handlers, respect_handler_level=rhl)
@@ -792,7 +791,7 @@ class DictConfigurator(BaseConfigurator):
                 klass = cname
             else:
                 klass = self.resolve(cname)
-            if issubclass(klass, logging.handlers.MemoryHandler):
+            if issubclass(klass, logging_handlers.MemoryHandler):
                 if 'flushLevel' in config:
                     config['flushLevel'] = logging._checkLevel(config['flushLevel'])
                 if 'target' in config:
@@ -806,7 +805,7 @@ class DictConfigurator(BaseConfigurator):
                         config['target'] = th
                     except Exception as e:
                         raise ValueError('Unable to set target handler %r' % tn) from e
-            elif issubclass(klass, logging.handlers.QueueHandler):
+            elif issubclass(klass, logging_handlers.QueueHandler):
                 # Another special case for handler which refers to other handlers
                 # if 'handlers' not in config:
                     # raise ValueError('No handlers specified for a QueueHandler')
@@ -828,13 +827,13 @@ class DictConfigurator(BaseConfigurator):
                 if 'listener' in config:
                     lspec = config['listener']
                     if isinstance(lspec, type):
-                        if not issubclass(lspec, logging.handlers.QueueListener):
+                        if not issubclass(lspec, logging_handlers.QueueListener):
                             raise TypeError('Invalid listener specifier %r' % lspec)
                     else:
                         if isinstance(lspec, str):
                             listener = self.resolve(lspec)
                             if isinstance(listener, type) and\
-                                not issubclass(listener, logging.handlers.QueueListener):
+                                not issubclass(listener, logging_handlers.QueueListener):
                                 raise TypeError('Invalid listener specifier %r' % lspec)
                         elif isinstance(lspec, dict):
                             if '()' not in lspec:
@@ -858,13 +857,13 @@ class DictConfigurator(BaseConfigurator):
                     except Exception as e:
                         raise ValueError('Unable to set required handler %r' % hn) from e
                     config['handlers'] = hlist
-            elif issubclass(klass, logging.handlers.SMTPHandler) and\
+            elif issubclass(klass, logging_handlers.SMTPHandler) and\
                 'mailhost' in config:
                 config['mailhost'] = self.as_tuple(config['mailhost'])
-            elif issubclass(klass, logging.handlers.SysLogHandler) and\
+            elif issubclass(klass, logging_handlers.SysLogHandler) and\
                 'address' in config:
                 config['address'] = self.as_tuple(config['address'])
-            if issubclass(klass, logging.handlers.QueueHandler):
+            if issubclass(klass, logging_handlers.QueueHandler):
                 factory = functools.partial(self._configure_queue_handler, klass)
             else:
                 factory = klass

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -24,21 +24,26 @@ Copyright (C) 2001-2022 Vinay Sajip. All Rights Reserved.
 To use, simply 'import logging.config' and log away!
 """
 
+lazy import configparser
 import errno
 import functools
 import io
+lazy import json
 import logging
-import logging.handlers
+# rebinds the name `logging`, so the first `logging.<attr>` use loads handlers
+lazy import logging.handlers
 import os
-import queue
+lazy import queue
 import re
-import socket
-import struct
+lazy import select
+lazy import socket
+lazy import struct
 import threading
 import traceback
 
-from bisect import bisect_left
-from socketserver import ThreadingTCPServer, StreamRequestHandler
+lazy from bisect import bisect_left
+lazy from multiprocessing.queues import Queue as MPQueue
+lazy from socketserver import ThreadingTCPServer, StreamRequestHandler
 
 
 DEFAULT_LOGGING_CONFIG_PORT = 9030
@@ -61,8 +66,6 @@ def fileConfig(fname, defaults=None, disable_existing_loggers=True, encoding=Non
     developer provides a mechanism to present the choices and load the chosen
     configuration).
     """
-    import configparser
-
     if isinstance(fname, str):
         if not os.path.exists(fname):
             raise FileNotFoundError(f"{fname} doesn't exist")
@@ -510,8 +513,6 @@ def _is_queue_like_object(obj):
     """Check that *obj* implements the Queue API."""
     if isinstance(obj, (queue.Queue, queue.SimpleQueue)):
         return True
-    # defer importing multiprocessing as much as possible
-    from multiprocessing.queues import Queue as MPQueue
     if isinstance(obj, MPQueue):
         return True
     # Depending on the multiprocessing start context, we cannot create
@@ -978,7 +979,6 @@ def listen(port=DEFAULT_LOGGING_CONFIG_PORT, verify=None):
                     if chunk is not None:   # verified, can process
                         chunk = chunk.decode("utf-8")
                         try:
-                            import json
                             d =json.loads(chunk)
                             assert isinstance(d, dict)
                             dictConfig(d)
@@ -1023,7 +1023,6 @@ def listen(port=DEFAULT_LOGGING_CONFIG_PORT, verify=None):
             self.verify = verify
 
         def serve_until_stopped(self):
-            import select
             abort = 0
             while not abort:
                 rd, wr, ex = select.select([self.socket.fileno()],

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -30,7 +30,6 @@ import functools
 import io
 lazy import json
 import logging
-# rebinds the name `logging`, so the first `logging.<attr>` use loads handlers
 lazy import logging.handlers
 import os
 lazy import queue

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -23,24 +23,23 @@ Copyright (C) 2001-2021 Vinay Sajip. All Rights Reserved.
 To use, simply 'import logging.handlers' and log away!
 """
 
+import io  # must stay eager to support finalization
+import logging
+import os
+import re
+import threading
+import time
 lazy import base64
 lazy import copy
 lazy import email.utils
 lazy import http.client
-import io # must stay eager to support finalization
-import logging
-import os
 lazy import pickle
 lazy import queue
-import re
 lazy import smtplib
 lazy import socket
 lazy import ssl
 lazy import struct
-import threading
-import time
 lazy import urllib.parse
-
 lazy from email.message import EmailMessage
 
 #

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -23,17 +23,26 @@ Copyright (C) 2001-2021 Vinay Sajip. All Rights Reserved.
 To use, simply 'import logging.handlers' and log away!
 """
 
-import copy
+lazy import base64
+lazy import copy
+lazy import email.utils
+lazy import http.client
+# io and os must stay eager to support finalization
 import io
 import logging
 import os
-import pickle
-import queue
+lazy import pickle
+lazy import queue
 import re
-import socket
-import struct
+lazy import smtplib
+lazy import socket
+lazy import ssl
+lazy import struct
 import threading
 import time
+lazy import urllib.parse
+
+lazy from email.message import EmailMessage
 
 #
 # Some constants...
@@ -1113,10 +1122,6 @@ class SMTPHandler(logging.Handler):
         Format the record and send it to the specified addressees.
         """
         try:
-            import smtplib
-            from email.message import EmailMessage
-            import email.utils
-
             port = self.mailport
             if not port:
                 port = smtplib.SMTP_PORT
@@ -1129,8 +1134,6 @@ class SMTPHandler(logging.Handler):
             msg.set_content(self.format(record))
             if self.username:
                 if self.secure is not None:
-                    import ssl
-
                     try:
                         keyfile = self.secure[0]
                     except IndexError:
@@ -1313,7 +1316,6 @@ class HTTPHandler(logging.Handler):
         Override when a custom connection is required, for example if
         there is a proxy.
         """
-        import http.client
         if secure:
             connection = http.client.HTTPSConnection(host, context=self.context)
         else:
@@ -1327,7 +1329,6 @@ class HTTPHandler(logging.Handler):
         Send the record to the web server as a percent-encoded dictionary
         """
         try:
-            import urllib.parse
             host = self.host
             h = self.getConnection(host, self.secure)
             url = self.url
@@ -1352,7 +1353,6 @@ class HTTPHandler(logging.Handler):
                             "application/x-www-form-urlencoded")
                 h.putheader("Content-length", str(len(data)))
             if self.credentials:
-                import base64
                 s = ('%s:%s' % self.credentials).encode('utf-8')
                 s = 'Basic ' + base64.b64encode(s).strip().decode('ascii')
                 h.putheader('Authorization', s)

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -29,7 +29,7 @@ lazy import email.utils
 lazy import http.client
 import io # must stay eager to support finalization
 import logging
-import os # must stay eager to support finalization
+import os
 lazy import pickle
 lazy import queue
 import re

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -27,10 +27,9 @@ lazy import base64
 lazy import copy
 lazy import email.utils
 lazy import http.client
-# io and os must stay eager to support finalization
-import io
+import io # must stay eager to support finalization
 import logging
-import os
+import os # must stay eager to support finalization
 lazy import pickle
 lazy import queue
 import re

--- a/Misc/NEWS.d/next/Library/2026-08-31-08-20-00.gh-issue-156777.La7yLg.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-31-08-20-00.gh-issue-156777.La7yLg.rst
@@ -1,2 +1,2 @@
 Optimize import time for :mod:`logging.handlers` and :mod:`logging.config` with
-lazy imports. Pull nested imports to module scope.
+lazy imports.

--- a/Misc/NEWS.d/next/Library/2026-08-31-08-20-00.gh-issue-156777.La7yLg.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-31-08-20-00.gh-issue-156777.La7yLg.rst
@@ -1,0 +1,2 @@
+Optimize import time for :mod:`logging.handlers` and :mod:`logging.config` with
+lazy imports. Pull nested imports to module scope.

--- a/Misc/NEWS.d/next/Library/2026-08-31-08-20-00.gh-issue-999999.La7yLg.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-31-08-20-00.gh-issue-999999.La7yLg.rst
@@ -1,5 +1,0 @@
-Speed up importing :mod:`logging.handlers` and :mod:`logging.config` by
-deferring rarely-used imports with :keyword:`lazy import`, and by lifting
-function-level imports to module scope. Imports that logging needs during
-interpreter finalization (:mod:`io`, :mod:`traceback`, :mod:`os` and
-:mod:`warnings`) deliberately remain eager.

--- a/Misc/NEWS.d/next/Library/2026-08-31-08-20-00.gh-issue-999999.La7yLg.rst
+++ b/Misc/NEWS.d/next/Library/2026-08-31-08-20-00.gh-issue-999999.La7yLg.rst
@@ -1,0 +1,5 @@
+Speed up importing :mod:`logging.handlers` and :mod:`logging.config` by
+deferring rarely-used imports with :keyword:`lazy import`, and by lifting
+function-level imports to module scope. Imports that logging needs during
+interpreter finalization (:mod:`io`, :mod:`traceback`, :mod:`os` and
+:mod:`warnings`) deliberately remain eager.


### PR DESCRIPTION
# summary
- Lift the function-level imports in logging/handlers.py and logging/config.py to module scope as lazy imports, and mark other cold-path imports lazy.
- Imports reachable from interpreter finalization stay eager and are now commented as such.
- The Windows-only (_winapi, winreg) and optional third-party (win32evtlogutil) imports stay function-level on purpose: as module-level lazy imports they would break inspect.getmembers() and pydoc on non-Windows.

# perf 
| Import | before | after | delta |
|---|---:|---:|---:|
| `import logging.config` | 29.42 ms | 21.09 ms | **−28.3%** |
| `import logging.handlers` | 25.60 ms | 21.05 ms | **−17.8%** |
| `import logging` | 20.15 ms | 20.08 ms | −0.4% (noise) |

<!-- gh-issue-number: gh-156777 -->
* Issue: gh-156777
<!-- /gh-issue-number -->
