### PR TITLE
gh-128805: Clarify the deprecation notice of xml.etree.cElementTree

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -15,7 +15,7 @@ for parsing and creating XML data.
    This module will use a fast implementation whenever available.
 
 .. deprecated:: 3.3
-   The :mod:`!xml.etree.cElementTree` module is deprecated.
+   The :mod:`!xml.etree.cElementTree` alias of this module is deprecated.
 
 
 .. note::


### PR DESCRIPTION
The notice was read as deprecating `xml.etree.ElementTree` itself, because the page does not mention `cElementTree` anywhere else, so there is nothing to tell the reader that it is only an alias.

Saying that the *alias* is deprecated is enough to scope it.

This revives GH-144459, which was closed for reasons unrelated to its content.


<!-- gh-issue-number: gh-128805 -->
* Issue: gh-128805
<!-- /gh-issue-number -->
