### PR TITLE
gh-140870: Add PyREPL's module attributes import completion feature to What's New

### DIFF
--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -904,7 +904,7 @@ Default interactive shell
 
 * Tab completions now suggest modules attributes in ``from ... import`` statements.
   The module needs to be imported to provide suggestions; if it's not, ask the user
-  for approval before auto-importing it (except for stdlib modules).
+  for approval before auto-importing it (except for :term:`stdlib` modules).
   (Contributed by Loïc Simon and Pablo Galindo in :gh:`140870`.)
 
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -905,7 +905,7 @@ Default interactive shell
 * Tab completion now suggests module attributes in ``from ... import`` statements.
   Attributes can only be suggested once the module is imported, so
   :term:`stdlib` modules are imported automatically, while for
-  other modules the completer offers to import it when :kbd:`Tab`
+  other modules the completer offers to import them when :kbd:`Tab`
   is pressed a second time.
   (Contributed by Loïc Simon and Pablo Galindo in :gh:`140870`.)
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -903,8 +903,10 @@ Default interactive shell
   (Contributed by Antonio Cuni and Pablo Galindo in :gh:`130472`.)
 
 * Tab completion now suggests module attributes in ``from ... import`` statements.
-  The module needs to be imported to provide suggestions; if it's not, ask the user
-  for approval before auto-importing it (except for :term:`stdlib` modules).
+  Attributes can only be suggested once the module is imported, so
+  :term:`stdlib` modules are imported automatically, while for
+  other modules the completer offers to import it when :kbd:`Tab`
+  is pressed a second time.
   (Contributed by Loïc Simon and Pablo Galindo in :gh:`140870`.)
 
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -903,7 +903,7 @@ Default interactive shell
   (Contributed by Antonio Cuni and Pablo Galindo in :gh:`130472`.)
 
 * Tab completions now suggest modules attributes in ``from ... import`` statements.
-  The module needs to be imported to provide suggestions; if it's not, ask the user 
+  The module needs to be imported to provide suggestions; if it's not, ask the user
   for approval before auto-importing it (except for stdlib modules).
   (Contributed by Loïc Simon and Pablo Galindo in :gh:`140870`.)
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -902,6 +902,11 @@ Default interactive shell
   <using-on-controlling-color>`.
   (Contributed by Antonio Cuni and Pablo Galindo in :gh:`130472`.)
 
+* Tab completions now suggest modules attributes in ``from ... import`` statements.
+  The module needs to be imported to provide suggestions; if it's not, ask the user 
+  for approval before auto-importing it (except for stdlib modules).
+  (Contributed by Loïc Simon and Pablo Galindo in :gh:`140870`.)
+
 
 New modules
 ===========

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -902,7 +902,7 @@ Default interactive shell
   <using-on-controlling-color>`.
   (Contributed by Antonio Cuni and Pablo Galindo in :gh:`130472`.)
 
-* Tab completions now suggest modules attributes in ``from ... import`` statements.
+* Tab completion now suggests module attributes in ``from ... import`` statements.
   The module needs to be imported to provide suggestions; if it's not, ask the user
   for approval before auto-importing it (except for :term:`stdlib` modules).
   (Contributed by Loïc Simon and Pablo Galindo in :gh:`140870`.)


### PR DESCRIPTION
Cf. https://github.com/python/cpython/issues/140870#issuecomment-4606050551; there has been no reaction and we're now really close to 3.15 release, so I went ahead and proposed a PR, because I really think this user-facing change should be documented.

Sorry for any inconvenience if it's not the process! 🙏 

<!-- gh-issue-number: gh-140870 -->
* Issue: gh-140870
<!-- /gh-issue-number -->
