### PR TITLE
gh-156780: Emscripten: add missing EM_JS_DEPS

### DIFF
--- a/Python/emscripten_syscalls.c
+++ b/Python/emscripten_syscalls.c
@@ -132,6 +132,10 @@ EM_JS_MACROS(void, _emscripten_promising_main_js, (void), {
     };
 })
 
+EM_JS_DEPS(_emscripten_promising_main,
+           "$FS,$PATH,$FS_getMode,$resolveGlobalSymbol,"
+           "emscripten_exit_with_live_runtime");
+
 __attribute__((constructor)) void _emscripten_promising_main(void) {
     _emscripten_promising_main_js();
 }
@@ -198,6 +202,8 @@ EM_JS_MACROS(__externref_t, __maybe_fd_read_async, (
     })();
 };
 );
+
+EM_JS_DEPS(__maybe_fd_read_async, "$SYSCALLS");
 
 // Bind original fd_read syscall to __wasi_fd_read_orig().
 __wasi_errno_t __wasi_fd_read_orig(__wasi_fd_t fd, const __wasi_iovec_t *iovs,
@@ -279,6 +285,8 @@ EM_JS_MACROS(__externref_t, __maybe_poll_async, (intptr_t fds, int nfds, int tim
         }
     })();
 });
+
+EM_JS_DEPS(__maybe_poll_async, "$FS");
 
 // Bind original poll syscall to syscall_poll_orig().
 int syscall_poll_orig(intptr_t fds, int nfds, int timeout)

--- a/Python/emscripten_trampoline.c
+++ b/Python/emscripten_trampoline.c
@@ -94,6 +94,9 @@ addOnPreRun(function setEmscriptenTrampoline() {
 });
 );
 
+EM_JS_DEPS(_PyEM_TrampolineCall,
+           "$wasmTable,$wasmMemory,$addFunction,$addOnPreRun");
+
 PyObject*
 _PyEM_TrampolineCall(PyCFunctionWithKeywords func,
                      PyObject* self,


### PR DESCRIPTION
Split out of #156781, as suggested by @hoodmane.

`EM_JS` bodies are emitted verbatim, so Emscripten's dependency tracker cannot see the JS symbols they reference and silently omits them.

Declared here: `$FS`, `$PATH`, `$FS_getMode`, `$resolveGlobalSymbol` and `emscripten_exit_with_live_runtime` in `emscripten_syscalls.c`, and `$wasmTable`, `$wasmMemory`, `$addFunction`, `$addOnPreRun` in `emscripten_trampoline.c`.

No change for `MAIN_MODULE` builds. Without it, the link now fails with

```
error: undefined symbol: $resolveGlobalSymbol
```

instead of a `ReferenceError` during `initRuntime`.


<!-- gh-issue-number: gh-156780 -->
* Issue: gh-156780
<!-- /gh-issue-number -->
