### PR TITLE
gh-156797: Escape the namespace URI in xml.sax.saxutils.XMLGenerator

### DIFF
--- a/Lib/test/test_sax.py
+++ b/Lib/test/test_sax.py
@@ -614,6 +614,22 @@ class XmlgenTest:
            '<ns1:doc xmlns:ns1="%s"><udoc></udoc></ns1:doc>' %
                                          ns_uri))
 
+    def test_xmlgen_ns_escaped_uri(self):
+        uri = 'http://example.org/?a="1"&b=<2>'
+        result = self.ioclass()
+        gen = XMLGenerator(result)
+
+        gen.startDocument()
+        gen.startPrefixMapping("ns1", uri)
+        gen.startElementNS((uri, "doc"), "ns1:doc", {})
+        gen.endElementNS((uri, "doc"), "ns1:doc")
+        gen.endPrefixMapping("ns1")
+        gen.endDocument()
+
+        self.assertEqual(result.getvalue(), self.xml(
+            """<ns1:doc xmlns:ns1='http://example.org/?a="1"&amp;b=&lt;2&gt;'>"""
+            "</ns1:doc>"))
+
     def test_xmlgen_ns_empty(self):
         result = self.ioclass()
         gen = XMLGenerator(result, short_empty_elements=True)

--- a/Lib/xml/sax/saxutils.py
+++ b/Lib/xml/sax/saxutils.py
@@ -186,9 +186,9 @@ class XMLGenerator(handler.ContentHandler):
 
         for prefix, uri in self._undeclared_ns_maps:
             if prefix:
-                self._write(' xmlns:%s="%s"' % (prefix, uri))
+                self._write(' xmlns:%s=%s' % (prefix, quoteattr(uri)))
             else:
-                self._write(' xmlns="%s"' % uri)
+                self._write(' xmlns=%s' % quoteattr(uri))
         self._undeclared_ns_maps = []
 
         for (name, value) in attrs.items():

--- a/Misc/NEWS.d/next/Library/2026-09-01-16-58-30.gh-issue-156797.Qm4tRs.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-01-16-58-30.gh-issue-156797.Qm4tRs.rst
@@ -1,0 +1,3 @@
+Fix :class:`xml.sax.saxutils.XMLGenerator`: the namespace URI is now escaped
+in the namespace declaration.  Previously a URI containing ``&``, ``<`` or a
+quote character produced a document which cannot be parsed.


### PR DESCRIPTION
The namespace declarations were the only attribute values written without `quoteattr()`, so a URI containing `&`, `<` or a quote character produced a document which cannot be parsed.

<!-- gh-issue-number: gh-156797 -->
* Issue: gh-156797
<!-- /gh-issue-number -->
