### PR TITLE
gh-154675: Use lazy imports in json package

### DIFF
--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -106,6 +106,8 @@ from .decoder import JSONDecoder, JSONDecodeError
 from .encoder import JSONEncoder
 import codecs
 
+lazy from warnings import _deprecated
+
 _default_encoder = JSONEncoder(
     skipkeys=False,
     ensure_ascii=True,
@@ -388,8 +390,6 @@ def loads(s, *, cls=None, object_hook=None, parse_float=None,
 
 def __getattr__(name):
     if name == "__version__":
-        from warnings import _deprecated
-
         _deprecated("__version__", remove=(3, 20))
         return "2.0.9"  # Do not change
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -3,11 +3,12 @@
 See `json.__main__` for a usage example (invocation as
 `python -m json.tool` is supported for backwards compatibility).
 """
-import argparse
 import json
 import re
 import sys
-from _colorize import get_theme, can_colorize
+
+lazy import argparse
+lazy from _colorize import can_colorize, get_theme
 
 
 # The string we are colorizing is valid JSON,

--- a/Misc/NEWS.d/next/Library/2026-09-01-14-20-00.gh-issue-154675.Kq7vZ2.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-01-14-20-00.gh-issue-154675.Kq7vZ2.rst
@@ -1,0 +1,2 @@
+Speed up ``import json.tool`` by importing :mod:`argparse` and ``_colorize``
+lazily.

--- a/Misc/NEWS.d/next/Library/2026-09-01-14-20-00.gh-issue-154675.Kq7vZ2.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-01-14-20-00.gh-issue-154675.Kq7vZ2.rst
@@ -1,2 +1,1 @@
-Speed up ``import json.tool`` by importing :mod:`argparse` and ``_colorize``
-lazily.
+Improve the import time of :mod:`json.tool` using lazy imports.


### PR DESCRIPTION
## summary
Apply lazy imports to json package to lift nested imports and optimize the modules.

## perf
  |                                | before   | after                   |
  | ------------------------------ | -------- | ----------------------- |
  | `python -c "import json.tool"` | 41.09 ms | 21.24 ms (−48%)         |
  | `python -c "import json"`      | 20.98 ms | 20.81 ms (−0.8%, neutral) |
  | `python -m json.tool f.json`   | 46.06 ms | 45.87 ms (−0.4%, neutral)        |

<!-- gh-issue-number: gh-154675 -->
* Issue: gh-154675
<!-- /gh-issue-number -->
