### PR TITLE
gh-128404: Run TestGetAsyncGenState without asyncio

### DIFF
--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -3052,6 +3052,9 @@ class TestGetAsyncGenState(unittest.TestCase):
         await anext(self.asyncgen)
         self.assertEqual(self._asyncgenstate(), inspect.AGEN_SUSPENDED)
 
+
+class TestGetAsyncGenLocals(unittest.TestCase):
+
     def test_easy_debugging(self):
         # repr() and str() of a asyncgen state should contain the state name
         names = 'AGEN_CREATED AGEN_RUNNING AGEN_SUSPENDED AGEN_CLOSED'.split()

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -1,5 +1,4 @@
 from annotationlib import Format, ForwardRef
-import asyncio
 import builtins
 import collections
 import copy
@@ -2991,8 +2990,16 @@ class TestGetCoroutineState(unittest.TestCase):
                          {'a': None, 'gencoro': gencoro, 'b': 'spam'})
 
 
-@support.requires_working_socket()
-class TestGetAsyncGenState(unittest.IsolatedAsyncioTestCase):
+def _async_test(async_fn):
+    """Decorator to turn an async function into a synchronous function"""
+    @functools.wraps(async_fn)
+    def wrapper(*args, **kwargs):
+        return run_no_yield_async_fn(async_fn, *args, **kwargs)
+
+    return wrapper
+
+
+class TestGetAsyncGenState(unittest.TestCase):
 
     def setUp(self):
         async def number_asyncgen():
@@ -3000,12 +3007,8 @@ class TestGetAsyncGenState(unittest.IsolatedAsyncioTestCase):
                 yield number
         self.asyncgen = number_asyncgen()
 
-    async def asyncTearDown(self):
-        await self.asyncgen.aclose()
-
-    @classmethod
-    def tearDownClass(cls):
-        asyncio.set_event_loop(None)
+    def tearDown(self):
+        run_no_yield_async_fn(self.asyncgen.aclose)
 
     def _asyncgenstate(self):
         return inspect.getasyncgenstate(self.asyncgen)
@@ -3013,11 +3016,13 @@ class TestGetAsyncGenState(unittest.IsolatedAsyncioTestCase):
     def test_created(self):
         self.assertEqual(self._asyncgenstate(), inspect.AGEN_CREATED)
 
+    @_async_test
     async def test_suspended(self):
         value = await anext(self.asyncgen)
         self.assertEqual(self._asyncgenstate(), inspect.AGEN_SUSPENDED)
         self.assertEqual(value, 0)
 
+    @_async_test
     async def test_closed_after_exhaustion(self):
         countdown = 7
         with self.assertRaises(StopAsyncIteration):
@@ -3026,11 +3031,13 @@ class TestGetAsyncGenState(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(countdown, 1)
         self.assertEqual(self._asyncgenstate(), inspect.AGEN_CLOSED)
 
+    @_async_test
     async def test_closed_after_immediate_exception(self):
         with self.assertRaises(RuntimeError):
             await self.asyncgen.athrow(RuntimeError)
         self.assertEqual(self._asyncgenstate(), inspect.AGEN_CLOSED)
 
+    @_async_test
     async def test_running(self):
         async def running_check_asyncgen():
             for number in range(5):
@@ -3053,6 +3060,7 @@ class TestGetAsyncGenState(unittest.IsolatedAsyncioTestCase):
             self.assertIn(name, repr(state))
             self.assertIn(name, str(state))
 
+    @_async_test
     async def test_getasyncgenlocals(self):
         async def each(lst, a=None):
             b=(1, 2, 3)
@@ -3080,6 +3088,7 @@ class TestGetAsyncGenState(unittest.IsolatedAsyncioTestCase):
             await anext(numbers)
         self.assertEqual(inspect.getasyncgenlocals(numbers), {})
 
+    @_async_test
     async def test_getasyncgenlocals_empty(self):
         async def yield_one():
             yield 1


### PR DESCRIPTION
inspect.getasyncgenstate() and getasyncgenlocals() are pure introspection: none of the awaits in these tests suspend, so the class does not need an event loop and does not need to be skipped when there is no working socket.

Drive the coroutines with support.run_no_yield_async_fn() instead, as the neighbouring TestGetCoroutineState already does, using the same _async_test decorator as test_contextlib_async.  This also drops the last use of asyncio in the module.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128404 -->
* Issue: gh-128404
<!-- /gh-issue-number -->
