### PR TITLE
gh-156810: Write the profiler's collapsed-stack export as UTF-8

### DIFF
--- a/Lib/profiling/sampling/stack_collector.py
+++ b/Lib/profiling/sampling/stack_collector.py
@@ -60,7 +60,8 @@ class CollapsedStackCollector(StackTraceCollector):
 
         lines.sort(key=lambda x: (-x[1], x[0]))
 
-        with open(filename, "w") as f:
+        with open(filename, "w",
+                  encoding="utf-8", errors="surrogatepass") as f:
             for stack, count in lines:
                 f.write(f"{stack} {count}\n")
         print(f"Collapsed stack output written to {filename}")

--- a/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
+++ b/Lib/test/test_profiling/test_sampling_profiler/test_collectors.py
@@ -466,6 +466,28 @@ class TestSampleProfilerComponents(unittest.TestCase):
         self.assertIn(stack1_expected, lines)
         self.assertIn(stack2_expected, lines)
 
+    def test_collapsed_stack_collector_export_non_ascii_names(self):
+        # gh-156810: frame names are written verbatim, so the output must be
+        # opened with an encoding that can represent non-ASCII and
+        # surrogate-escaped (undecodable-path) names.
+        collapsed_out = tempfile.NamedTemporaryFile(delete=False)
+        self.addCleanup(close_and_unlink, collapsed_out)
+
+        collector = CollapsedStackCollector(1000)
+        frame = MockFrameInfo("/tmp/ba\udc80d.py", 5, "计算")
+        collector.collect([
+            MockInterpreterInfo(0, [MockThreadInfo(1, [frame])])
+        ])
+
+        with captured_stdout(), captured_stderr():
+            collector.export(collapsed_out.name)
+
+        with open(collapsed_out.name, encoding="utf-8",
+                  errors="surrogatepass") as f:
+            content = f.read()
+        self.assertIn("计算", content)
+        self.assertIn("ba\udc80d.py", content)
+
     def test_flamegraph_collector_basic(self):
         """Test basic FlamegraphCollector functionality."""
         collector = FlamegraphCollector(1000)

--- a/Misc/NEWS.d/next/Library/2026-09-02-17-28-16.gh-issue-156810.cLpEnc.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-02-17-28-16.gh-issue-156810.cLpEnc.rst
@@ -1,0 +1,4 @@
+Fix a :exc:`UnicodeEncodeError` crash in the sampling profiler's
+collapsed-stack export (``--collapsed``) when a sampled frame's function or
+file name contains non-ASCII or surrogate-escaped characters. The output file
+is now written as UTF-8.


### PR DESCRIPTION
`CollapsedStackCollector.export` opened its output file with `open(filename, "w")` — the only exporter in `stack_collector.py` without an explicit `encoding=` (the flamegraph, JSONL and heatmap exporters all pass `encoding="utf-8"`). Since the collapsed format writes frame names verbatim, it crashed with `UnicodeEncodeError` on non-ASCII frame names under a non-UTF-8 locale, and on surrogate-escaped filenames on any locale.

Open the file as UTF-8 with `errors="surrogatepass"`: utf-8 matches the sibling exporters, and surrogatepass is needed because — unlike the json-based exporters, which escape via `ensure_ascii` — collapsed writes names verbatim and frame filenames can be surrogate-escaped (undecodable paths).

The added test fails without the fix; `test_profiling` passes.


<!-- gh-issue-number: gh-156810 -->
* Issue: gh-156810
<!-- /gh-issue-number -->
