### PR TITLE
gh-156812: Reject a trailing '-' when serializing an xml.dom.minidom comment

### DIFF
--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -1721,6 +1721,12 @@ class MinidomTest(unittest.TestCase):
         doc.appendChild(doc.createComment("foo--bar"))
         self.assertRaises(ValueError, doc.toxml)
 
+    def testSerializeCommentNodeWithTrailingHyphen(self):
+        # A trailing '-' would fuse with the closing '-->' into '--->'.
+        doc = create_doc_without_doctype()
+        doc.appendChild(doc.createComment("foo-"))
+        self.assertRaises(ValueError, doc.toxml)
+
 
     def testEmptyXMLNSValue(self):
         doc = parseString("<element xmlns=''>\n"

--- a/Lib/xml/dom/minidom.py
+++ b/Lib/xml/dom/minidom.py
@@ -1253,8 +1253,10 @@ class Comment(CharacterData):
         self._data = data
 
     def writexml(self, writer, indent="", addindent="", newl=""):
-        if "--" in self.data:
-            raise ValueError("'--' is not allowed in a comment node")
+        if "--" in self.data or self.data.endswith("-"):
+            raise ValueError(
+                "'--' is not allowed in a comment node, and a comment "
+                "node cannot end with '-'")
         writer.write("%s<!--%s-->%s" % (indent, self.data, newl))
 
 

--- a/Misc/NEWS.d/next/Library/2026-09-02-17-35-20.gh-issue-156812.mdCmt1.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-02-17-35-20.gh-issue-156812.mdCmt1.rst
@@ -1,0 +1,3 @@
+Serializing an :mod:`xml.dom.minidom` comment node whose data ends with ``-``
+now raises :exc:`ValueError` instead of producing non-well-formed XML,
+completing the existing check for ``--``.


### PR DESCRIPTION
`Comment.writexml` raises `ValueError` for `--` in comment data (illegal inside an XML comment) but not for data ending in `-`, which fuses with the closing `-->` into `--->` — so minidom silently serialized a comment it could not reparse.

Extend the existing guard to also reject a trailing `-`.

The added test fails without the fix; `test_minidom` passes.


<!-- gh-issue-number: gh-156812 -->
* Issue: gh-156812
<!-- /gh-issue-number -->
