### PR TITLE
Fix geohash TypeError and import lag in antigravity

### DIFF
--- a/Lib/antigravity.py
+++ b/Lib/antigravity.py
@@ -2,7 +2,8 @@
 import webbrowser
 import hashlib
 
-webbrowser.open("https://xkcd.com/353/")
+if __name__ == '__main__':
+    webbrowser.open("https://xkcd.com/353/")
 
 def geohash(latitude, longitude, datedow):
     '''Compute geohash() using the Munroe algorithm.
@@ -12,6 +13,8 @@ def geohash(latitude, longitude, datedow):
 
     '''
     # https://xkcd.com/426/
+    if isinstance(datedow, str):
+        datedow = datedow.encode('utf-8')
     h = hashlib.md5(datedow, usedforsecurity=False).hexdigest()
     p, q = [('%f' % float.fromhex('0.' + x)) for x in (h[:16], h[16:32])]
     print('%d%s %d%s' % (latitude, p[1:], longitude, q[1:]))


### PR DESCRIPTION
Hi! I noticed that importing antigravity immediately launches a browser, which causes severe lag on mobile environments (like Termux/Pydroid). I wrapped it in an if __name__ == '__main__': block to prevent this. I also fixed a TypeError in geohash so it automatically converts strings to bytes before hashing
