### PR TITLE
gh-129922: Promote _mdiff to a public function

### DIFF
--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -338,6 +338,23 @@ Diff generation
       + tree
       + emu
 
+.. function:: mdiff(fromlines, tolines, context=None, linejunk=None, charjunk=IS_CHARACTER_JUNK)
+
+   Return a generator yielding marked up *fromlines* and *tolines* side by side differences.
+
+   Optional keyword parameters *context* is number of lines to display on each side the difference, if ``None``, all from/to text lines will be generated; *linejunk* and *charjunk* are filtering functions.
+
+   from/to line tuple -- (line num, line text)
+      line num -- integer or None (to indicate a context separation)
+      line text -- original line text with following markers inserted:
+
+         '\0+' -- marks start of added text
+         '\0-' -- marks start of deleted text
+         '\0^' -- marks start of changed text
+         '\1' -- marks end of added/deleted/changed text
+
+   boolean flag -- None indicates context separation, True indicates
+        either "from" or "to" line contains a change, otherwise False.
 
 .. function:: restore(sequence, which)
 

--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -348,10 +348,13 @@ Diff generation
       line num -- integer or None (to indicate a context separation)
       line text -- original line text with following markers inserted:
 
-         '\0+' -- marks start of added text
-         '\0-' -- marks start of deleted text
-         '\0^' -- marks start of changed text
-         '\1' -- marks end of added/deleted/changed text
+         ``'\0+'`` -- marks start of added text
+
+         ``'\0-'`` -- marks start of deleted text
+
+         ``'\0^'`` -- marks start of changed text
+
+         ``'\1'`` -- marks end of added/deleted/changed text
 
    boolean flag -- None indicates context separation, True indicates
         either "from" or "to" line contains a change, otherwise False.

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1358,7 +1358,7 @@ def ndiff(a, b, linejunk=None, charjunk=IS_CHARACTER_JUNK):
     """
     return Differ(linejunk, charjunk).compare(a, b)
 
-def _mdiff(fromlines, tolines, context=None, linejunk=None,
+def mdiff(fromlines, tolines, context=None, linejunk=None,
            charjunk=IS_CHARACTER_JUNK):
     r"""Returns generator yielding marked up from/to side by side differences.
 
@@ -2025,7 +2025,7 @@ class HtmlDiff(object):
             context_lines = numlines
         else:
             context_lines = None
-        diffs = _mdiff(fromlines,tolines,context_lines,linejunk=self._linejunk,
+        diffs = mdiff(fromlines,tolines,context_lines,linejunk=self._linejunk,
                       charjunk=self._charjunk)
 
         # set up iterator to wrap lines that exceed desired width

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -10,6 +10,9 @@ Function context_diff(a, b):
 Function ndiff(a, b):
     Return a delta: the difference between `a` and `b` (lists of strings).
 
+Function mdiff(fromlines, tolines):
+    Return a generator yielding marked up from/to side by side differences.
+
 Function restore(delta, which):
     Return one of the two sequences that generated an ndiff delta.
 
@@ -26,7 +29,7 @@ Class HtmlDiff:
     For producing HTML side by side comparison with change highlights.
 """
 
-__all__ = ['get_close_matches', 'ndiff', 'restore', 'SequenceMatcher',
+__all__ = ['get_close_matches', 'ndiff', 'mdiff', 'restore', 'SequenceMatcher',
            'Differ','IS_CHARACTER_JUNK', 'IS_LINE_JUNK', 'context_diff',
            'unified_diff', 'diff_bytes', 'HtmlDiff', 'Match']
 

--- a/Lib/test/test_difflib.py
+++ b/Lib/test/test_difflib.py
@@ -114,7 +114,7 @@ class TestSFbugs(unittest.TestCase):
     def test_mdiff_catch_stop_iteration(self):
         # Issue #33224
         self.assertEqual(
-            list(difflib._mdiff(["2"], ["3"], 1)),
+            list(difflib.mdiff(["2"], ["3"], 1)),
             [((1, '\x00-2\x01'), (1, '\x00+3\x01'), True)],
         )
 

--- a/Misc/NEWS.d/next/Library/2026-09-02-23-38-40.gh-issue-129922.Klr4dt.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-02-23-38-40.gh-issue-129922.Klr4dt.rst
@@ -1,0 +1,1 @@
+Promote ``difflib._mdiff()`` to a public function named :func:`difflib.mdiff`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Promote `difflib._mdiff()` to public function.
Fixes #129922

<!-- gh-issue-number: gh-129922 -->
* Issue: gh-129922
<!-- /gh-issue-number -->
