### PR TITLE
Fix issue #156812: xml.dom.minidom comment ending with dash produces malformed XML

### DIFF
--- a/Lib/xml/dom/minidom.py
+++ b/Lib/xml/dom/minidom.py
@@ -1255,6 +1255,8 @@ class Comment(CharacterData):
     def writexml(self, writer, indent="", addindent="", newl=""):
         if "--" in self.data:
             raise ValueError("'--' is not allowed in a comment node")
+        if self.data.endswith('-'):
+            raise ValueError("'-' is not allowed at the end of a comment node")
         writer.write("%s<!--%s-->%s" % (indent, self.data, newl))
 
 


### PR DESCRIPTION
## Fix issue #156812: xml.dom.minidom: comments ending with `-` serialize to malformed XML

### Problem
When creating a comment with content ending in `-` (e.g., `doc.createComment("see note-")`), the serialized output is `<!--see note--->` which contains illegal `--` in `-->`, making it malformed XML.

### Solution
Added a check in `Comment.writexml()` to raise `ValueError` when comment data ends with `-`, similar to the existing check for `--` within comment content.

### Changes
- **Lib/xml/dom/minidom.py**: Added `if self.data.endswith('-'): raise ValueError("'-' is not allowed at the end of a comment node")` in `Comment.writexml()` method