### PR TITLE
gh-156796: Finalize the parser of an external entity in xml.sax

### DIFF
--- a/Lib/test/test_sax.py
+++ b/Lib/test/test_sax.py
@@ -1039,6 +1039,26 @@ class ExpatReaderTest(XmlTestBase):
         self.assertEqual(result.getvalue(), start +
                          b"<doc><entity></entity></doc>")
 
+    def test_expat_entityresolver_not_well_formed(self):
+        # gh-156796: the parser of an external entity was never finalized,
+        # so errors only detectable at the end of its input, such as an
+        # unclosed element, were silently ignored.
+        class NotWellFormedEntityResolver:
+            def resolveEntity(self, publicId, systemId):
+                inpsrc = InputSource()
+                inpsrc.setByteStream(BytesIO(b"<entity>"))
+                return inpsrc
+
+        parser = create_parser()
+        parser.setFeature(feature_external_ges, True)
+        parser.setEntityResolver(NotWellFormedEntityResolver())
+        parser.setContentHandler(XMLGenerator(BytesIO()))
+
+        with self.assertRaises(SAXParseException):
+            parser.feed('<!DOCTYPE doc [<!ENTITY test SYSTEM "whatever">]>'
+                        '<doc>&test;</doc>')
+            parser.close()
+
     def test_expat_entityresolver_default(self):
         parser = create_parser()
         self.assertEqual(parser.getFeature(feature_external_ges), False)

--- a/Lib/xml/sax/expatreader.py
+++ b/Lib/xml/sax/expatreader.py
@@ -238,9 +238,14 @@ class ExpatParser(xmlreader.IncrementalParser, xmlreader.Locator):
                 file.close()
 
     def close(self):
-        if (self._entity_stack or self._parser is None or
-            isinstance(self._parser, _ClosedParser)):
-            # If we are completing an external entity, do nothing here
+        if self._parser is None or isinstance(self._parser, _ClosedParser):
+            return
+        if self._entity_stack:
+            # We are completing an external entity.  Finalize its parser so
+            # that errors which are only detectable at the end of the input,
+            # such as an unclosed element, are reported, but do not end the
+            # document: the enclosing parse is still in progress.
+            self.feed(b"", isFinal=True)
             return
         try:
             self.feed(b"", isFinal=True)

--- a/Misc/NEWS.d/next/Library/2026-09-02-00-00-00.gh-issue-156796.k7Qw2P.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-02-00-00-00.gh-issue-156796.k7Qw2P.rst
@@ -1,0 +1,4 @@
+Fix :mod:`xml.sax` not reporting an external entity whose content is not
+well-formed. The parser created for the entity was never finalized, so errors
+which are only detectable at the end of its input, such as an unclosed
+element, were silently ignored.


### PR DESCRIPTION
`ExpatParser.close()` returned early whenever `_entity_stack` was non-empty:

```python
if (self._entity_stack or self._parser is None or
    isinstance(self._parser, _ClosedParser)):
    # If we are completing an external entity, do nothing here
    return
```

`external_entity_ref()` swaps in a parser from `ExternalEntityParserCreate()` and then calls `IncrementalParser.parse()`, which ends with `self.close()`. Because the stack is non-empty at that point, `feed(b"", isFinal=True)` was never reached, so expat never checked the entity's input for completeness and content that is not well-formed was accepted silently.

The guard is still needed — ending the document while an entity is being parsed would be wrong — so this finalizes the entity's parser and returns without calling `endDocument()`. The `None`/`_ClosedParser` checks are hoisted above it so they still apply on that path.

### Verification

The reproducer from the issue silently succeeds on `main`. With this change it fails as you described:

```
xml.sax._exceptions.SAXParseException: <unknown>:1:8: error in processing external entity reference
```

`test_expat_entityresolver_not_well_formed` in `Lib/test/test_sax.py` covers it, and fails on unpatched `main`. The full `test_sax` passes (188 tests), which matches your note that finalizing the entity parser leaves the existing suite green.

I confirmed the behaviour is longstanding — the reproducer is silently accepted on 3.12 as well.

Fixes #156796


<!-- gh-issue-number: gh-156796 -->
* Issue: gh-156796
<!-- /gh-issue-number -->
