### PR TITLE
gh-156831: Fix reference ownership in _testcapi.sequence_fast_get_item

### DIFF
--- a/Lib/test/test_capi/test_abstract.py
+++ b/Lib/test/test_capi/test_abstract.py
@@ -1,4 +1,6 @@
+import sys
 import unittest
+
 from collections import OrderedDict
 from test import support
 from test.support import import_helper
@@ -1042,6 +1044,12 @@ class CAPITest(unittest.TestCase):
 
         # CRASHES sequence_fast_get_size(NULL)
         # CRASHES sequence_fast_get_item(NULL, 0)
+        obj = object()
+        lst = [obj]
+        refcount = sys.getrefcount(obj)
+        result = sequence_fast_get_item(lst, 0)
+        self.assertIs(result, obj)
+        self.assertEqual(sys.getrefcount(obj), refcount + 1)
 
     def test_object_generichash(self):
         # Test PyObject_GenericHash()

--- a/Misc/NEWS.d/next/C_API/2026-09-02-13-36-59.gh-issue-156831.fWgLbF.rst
+++ b/Misc/NEWS.d/next/C_API/2026-09-02-13-36-59.gh-issue-156831.fWgLbF.rst
@@ -1,0 +1,2 @@
+Fix a reference counting error in ``_testcapi.sequence_fast_get_item()``
+that could cause a debug build to abort with a negative reference count.

--- a/Modules/_testcapi/abstract.c
+++ b/Modules/_testcapi/abstract.c
@@ -174,7 +174,7 @@ sequence_fast_get_item(PyObject *self, PyObject *args)
         return NULL;
     }
     NULLABLE(obj);
-    return PySequence_Fast_GET_ITEM(obj, index);
+    return Py_NewRef(PySequence_Fast_GET_ITEM(obj, index));
 }
 
 


### PR DESCRIPTION
gh-156831

`_testcapi.sequence_fast_get_item()` returns the value from
`PySequence_Fast_GET_ITEM()` directly.

`PySequence_Fast_GET_ITEM()` returns a borrowed reference, so the wrapper
needs to create a new reference before returning the object.

Use `Py_NewRef()` for the returned item and add a regression test that checks
the reference count is increased by one.

Tests:

- `./python -m test test_capi.test_abstract -v`