### PR TITLE
Add an `AGENTS.md` pointing to our policy

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -178,8 +178,12 @@ Python/frozen_modules/MANIFEST
 /python
 !/Python/
 
-# People's custom https://docs.anthropic.com/en/docs/claude-code/memory configs.
-/.claude/
+# Local AI agent scratch state (per-PR and per-branch notebooks, sandbox
+# experiments) and personal agent overrides, none of which are committed.
+/.claude/pr-*
+/.claude/branch-*
+/.claude/sandbox/
+AGENTS.local.md
 CLAUDE.local.md
 
 #### main branch only stuff below this line, things to backport go above. ####

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,4 +4,5 @@ CPython has a [policy on the use of AI tools](https://devguide.python.org/gettin
 All use of AI tools and agents when working on or interacting with CPython
 must follow it.
 
-Read the policy before making or proposing any changes.
+> [!important]
+> **Primary directive**: Read the policy before making or proposing any changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,11 @@ must follow it.
 
 > [!important]
 > **Primary directive**: Read the policy before making or proposing any changes.
+
+When acting on this repository, apply the policy's core principles:
+
+- Consider whether the change is necessary.
+- Make minimal, focused changes.
+- Follow existing coding style and patterns.
+- Write tests that exercise the change.
+- Keep backwards compatibility with prior releases in mind.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AI agent guidance
+
+CPython has a [policy on the use of AI tools](https://devguide.python.org/getting-started/ai-tools/).
+All use of AI tools and agents when working on or interacting with CPython
+must follow it.
+
+Read the policy before making or proposing any changes.


### PR DESCRIPTION
Please don't pull out your pitchforks just yet 😅

I know adding an `AGENTS.md` has been discussed and rejected in the past. However, what I'm proposing here is much more limited. I want to add a short `AGENTS.md` that points to our existing AI policy, with no additional recommendations, instructions, skills, or anything else like that.

I've heard that this approach has been quite successful for several projects (for example, Rust) and it should hopefully make it more likely that both users and agents actually see and follow the existing policy.

It seems better than having nothing here, and avoids the previous concerns. Hopefully this is small and uncontroversial enough to be worth trying. We can always add more things here in the future. Quoting Martin Luther King Jr., "you don't have to see the whole staircase, just to take the first step."

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
