### PR TITLE
gh-154675: Avoid importing inspect when creating a slotted dataclass

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1284,6 +1284,23 @@ def _get_slots(cls):
             raise TypeError(f"Slots of '{cls.__name__}' cannot be determined")
 
 
+def _unwrap(func):
+    # A copy of `inspect.unwrap()`, to avoid importing `inspect` module.
+    # Keep this in sync with the original.
+    f = func  # remember the original func for error reporting
+    # Memoise by id to tolerate non-hashable objects, but store objects to
+    # ensure they aren't destroyed, which would allow their IDs to be reused.
+    memo = {id(f): f}
+    recursion_limit = sys.getrecursionlimit()
+    while not isinstance(func, type) and hasattr(func, '__wrapped__'):
+        func = func.__wrapped__
+        id_func = id(func)
+        if (id_func in memo) or (len(memo) >= recursion_limit):
+            raise ValueError(f'wrapper loop when unwrapping {f!r}')
+        memo[id_func] = func
+    return func
+
+
 def _update_func_cell_for__class__(f, oldcls, newcls):
     # Returns True if we update a cell, else False.
     if f is None:
@@ -1392,8 +1409,7 @@ def _add_slots(cls, is_frozen, weakref_slot, defined_fields):
 
         # If this is a wrapped function, unwrap it.
         if not isinstance(member, type) and hasattr(member, '__wrapped__'):
-            import inspect
-            member = inspect.unwrap(member)
+            member = _unwrap(member)
 
         if isinstance(member, types.FunctionType):
             if _update_func_cell_for__class__(member, cls, newcls):

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -27,7 +27,7 @@ import typing       # Needed for the string "typing.ClassVar[int]" to work as an
 import dataclasses  # Needed for the string "dataclasses.InitVar[int]" to work as an annotation.
 
 from test import support
-from test.support import cpython_only, import_helper
+from test.support import cpython_only, import_helper, script_helper
 
 # Just any custom exception we can catch.
 class CustomError(Exception): pass
@@ -40,6 +40,20 @@ class TestImportTime(unittest.TestCase):
         import_helper.ensure_lazy_imports(
             "dataclasses", {"inspect", "re", "copy"}
         )
+
+    @cpython_only
+    def test_slots_does_not_import_inspect(self):
+        code = textwrap.dedent("""
+            import sys
+            from dataclasses import dataclass
+
+            @dataclass(slots=True)
+            class C:
+                x: int = 0
+
+            assert 'inspect' not in sys.modules
+        """)
+        script_helper.assert_python_ok("-c", code)
 
 
 class TestCase(unittest.TestCase):

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -27,7 +27,7 @@ import typing       # Needed for the string "typing.ClassVar[int]" to work as an
 import dataclasses  # Needed for the string "dataclasses.InitVar[int]" to work as an annotation.
 
 from test import support
-from test.support import cpython_only, import_helper, script_helper
+from test.support import cpython_only, import_helper
 
 # Just any custom exception we can catch.
 class CustomError(Exception): pass
@@ -43,17 +43,17 @@ class TestImportTime(unittest.TestCase):
 
     @cpython_only
     def test_slots_does_not_import_inspect(self):
-        code = textwrap.dedent("""
-            import sys
-            from dataclasses import dataclass
-
-            @dataclass(slots=True)
+        create_slotted_class = textwrap.dedent(
+            """
+            @dataclasses.dataclass(slots=True)
             class C:
                 x: int = 0
-
-            assert 'inspect' not in sys.modules
-        """)
-        script_helper.assert_python_ok("-c", code)
+            """
+        )
+        import_helper.ensure_lazy_imports(
+            "dataclasses", {"inspect"},
+            additional_code=create_slotted_class,
+        )
 
 
 class TestCase(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2026-09-03-00-42-32.gh-issue-154675.NX8eYm.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-03-00-42-32.gh-issue-154675.NX8eYm.rst
@@ -1,0 +1,2 @@
+Creating a :func:`~dataclasses.dataclass` with ``slots=True`` no longer
+imports the :mod:`inspect` module.


### PR DESCRIPTION
Using `@dataclass(slots=True)` always imports `inspect`, just for the single `inspect.unwrap()` call in `_add_slots()`.

[`typing`](https://github.com/python/cpython/blob/2271fbb369a78fcd3ac00c526ca6711140144e43/Lib/typing.py#L2494-L2499) and [`annotationlib`](https://github.com/python/cpython/blob/2271fbb369a78fcd3ac00c526ca6711140144e43/Lib/annotationlib.py#L1042-L1059) already inline the same `__wrapped__` walk to avoid the import, so `dataclasses` can too. Perhaps in the future `unwrap()` could move into a small private module that `inspect` and all these copies import, so the implementations do not drift apart.

Importing a module that defines one slotted dataclass, best of 30 runs.

```console
$ cat app.py
from dataclasses import dataclass

@dataclass(slots=True)
class Point:
    x: int = 0
    y: int = 0

$ ./python -c 'import time; t = time.perf_counter(); import app; print(time.perf_counter() - t)'
0.022856871997646522   # before
0.010011243997723795   # after
```

About 2.3x faster.


<!-- gh-issue-number: gh-154675 -->
* Issue: gh-154675
<!-- /gh-issue-number -->
