### PR TITLE
gh-122862: Fix description of the GC allocation counter in set_threshold() docs

### DIFF
--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -124,12 +124,13 @@ The :mod:`!gc` module provides the following functions:
    generation (generation ``0``).  If an object survives a collection it is moved
    into the next older generation.  Since generation ``2`` is the oldest
    generation, objects in that generation remain there after a collection.  In
-   order to decide when to run, the collector keeps track of the number object
-   allocations and deallocations since the last collection.  When the number of
-   allocations minus the number of deallocations exceeds *threshold0*, collection
-   starts.  Initially only generation ``0`` is examined.  If generation ``0`` has
-   been examined more than *threshold1* times since generation ``1`` has been
-   examined, then generation ``1`` is examined as well.
+   order to decide when to run, the collector keeps a counter that is reset by
+   each collection, incremented by each object allocation, and decremented by
+   each object deallocation, but never below zero.  When this counter exceeds
+   *threshold0*, collection starts.  Initially only generation ``0`` is
+   examined.  If generation ``0`` has been examined more than *threshold1* times
+   since generation ``1`` has been examined, then generation ``1`` is examined
+   as well.
    With the third generation, things are a bit more complicated,
    see `Collecting the oldest generation <https://github.com/python/cpython/blob/ff0ef0a54bef26fc507fbf9b7a6009eb7d3f17f5/InternalDocs/garbage_collector.md#collecting-the-oldest-generation>`_ for more information.
 


### PR DESCRIPTION
The `gc.set_threshold()` documentation says the collector tracks "the number of allocations minus the number of deallocations" since the last collection. The implementation doesn't quite do that: the generation 0 counter is incremented on each allocation and decremented on each deallocation, but it's never decremented below zero, and it's reset when a collection runs. This means deallocations that happen before allocations don't offset them, as described in the issue.

This rewrites the sentence to describe the actual behavior. It also fixes the missing "of" in "the number object allocations".

Fixes #122862


<!-- gh-issue-number: gh-122862 -->
* Issue: gh-122862
<!-- /gh-issue-number -->
