### PR TITLE
gh-156886: Fix spurious ZeroDivisionError for complex powers

### DIFF
--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -366,6 +366,16 @@ class ComplexTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         self.assertRaises(TypeError, pow, None, 1j)
         self.assertAlmostEqual(pow(1j, 0.5), 0.7071067811865476+0.7071067811865475j)
 
+        # gh-156886: an infinite phase is not a zero base.
+        for base, exp in [(complex(INF), 1j),
+                          (complex(INF, 1), 1j),
+                          (1e300, 1e308j),
+                          (complex(2), complex(0, INF))]:
+            with self.subTest(base=base, exponent=exp):
+                r = base ** exp
+                self.assertTrue(isnan(r.real))
+                self.assertTrue(isnan(r.imag))
+
         a = 3.33+4.43j
         self.assertEqual(a ** 0j, 1)
         self.assertEqual(a ** 0.+0.j, 1)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-09-03-12-40-00.gh-issue-156886.Kx7mQt.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-09-03-12-40-00.gh-issue-156886.Kx7mQt.rst
@@ -1,0 +1,3 @@
+Fix :exc:`ZeroDivisionError` spuriously raised for a complex power
+with a non-zero base when the phase of the result is infinite,
+e.g. ``1e300**1e308j`` or ``complex('inf')**1j``.

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -331,6 +331,9 @@ _Py_c_pow(Py_complex a, Py_complex b)
         r.real = len*cos(phase);
         r.imag = len*sin(phase);
 
+        /* Discard errno set by the math functions above: cos() and sin()
+           set EDOM for an infinite phase.  ERANGE is recovered below. */
+        errno = 0;
         if (isfinite(a.real) && isfinite(a.imag)
             && isfinite(b.real) && isfinite(b.imag))
         {

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -331,8 +331,8 @@ _Py_c_pow(Py_complex a, Py_complex b)
         r.real = len*cos(phase);
         r.imag = len*sin(phase);
 
-        /* Discard errno set by the math functions above: cos() and sin()
-           set EDOM for an infinite phase.  ERANGE is recovered below. */
+        /* Don't rely on errno set by the math functions above, for
+           example cos() and sin() set EDOM for an infinite phase. */
         errno = 0;
         if (isfinite(a.real) && isfinite(a.imag)
             && isfinite(b.real) && isfinite(b.imag))


### PR DESCRIPTION
`cos()` and `sin()` of an infinite phase set `errno` to `EDOM`, which `complex_pow()` reported as a zero base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-issue-number: gh-156886 -->
* Issue: gh-156886
<!-- /gh-issue-number -->
