### PR TITLE
gh-144446: Fix _PyFrame_GetFrameObject() for test_cppext (C++)

### DIFF
--- a/Include/internal/pycore_interpframe.h
+++ b/Include/internal/pycore_interpframe.h
@@ -345,7 +345,7 @@ _PyFrame_GetFrameObject(_PyInterpreterFrame *frame)
 {
 
     assert(!_PyFrame_IsIncomplete(frame));
-    PyFrameObject *res = FT_ATOMIC_LOAD_PTR_ACQUIRE(frame->frame_obj);
+    PyFrameObject *res = (PyFrameObject*)FT_ATOMIC_LOAD_PTR_ACQUIRE(frame->frame_obj);
     if (res != NULL) {
         return res;
     }


### PR DESCRIPTION
Do an explicit cast to fix the C++ compiler warning:

  In file included from Include/internal/pycore_object.h:13,
                   from Include/internal/pycore_cell.h:5,
                   from extension.cpp:29:
  Include/internal/pycore_interpframe.h: In function 'PyFrameObject*
  _PyFrame_GetFrameObject(_PyInterpreterFrame*)':
  Include/internal/pycore_pyatomic_ft_wrappers.h:33:32: error:
  invalid conversion from 'void*' to 'PyFrameObject*' {aka '_frame*'}
  [-fpermissive]
     33 |     _Py_atomic_load_ptr_acquire(&value)
        |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
        |                                |
        |                                void*
  Include/internal/pycore_interpframe.h:348:26: note: in expansion of
  macro 'FT_ATOMIC_LOAD_PTR_ACQUIRE'
    348 |     PyFrameObject *res = FT_ATOMIC_LOAD_PTR_ACQUIRE(frame->frame_obj);
        |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-144446 -->
* Issue: gh-144446
<!-- /gh-issue-number -->
