### PR TITLE
gh-156894: Fix the position of syntax errors which cover a range

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -233,6 +233,21 @@ class ExceptionTests(unittest.TestCase):
         check = self.check
         check('"\\\n"(1 for c in I,\\\n\\', 2, 2)
 
+    def testSyntaxErrorRange(self):
+        # gh-156894: the position was reported in bytes, not in characters,
+        # for the errors which cover a range
+        for source, offset, end_offset in [
+            ('abcd = 00010', 8, 11),
+            ('\u03b1\u03b2\u03b3\u03b4 = 00010', 8, 11),
+            ("abcd = ub'a'", 8, 10),
+            ("\u03b1\u03b2\u03b3\u03b4 = ub'a'", 8, 10),
+        ]:
+            with self.subTest(source=source):
+                with self.assertRaises(SyntaxError) as cm:
+                    compile(source, '<testcase>', 'exec')
+                self.assertEqual(cm.exception.offset, offset)
+                self.assertEqual(cm.exception.end_offset, end_offset)
+
     def testSyntaxErrorOffset(self):
         check = self.check
         check('def fact(x):\n\treturn x!\n', 2, 10)

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -239,8 +239,10 @@ class ExceptionTests(unittest.TestCase):
         for source, offset, end_offset in [
             ('abcd = 00010', 8, 11),
             ('\u03b1\u03b2\u03b3\u03b4 = 00010', 8, 11),
+            ('a\u0301b\u0308c\u20d7d\u1ab0 = 00010', 12, 15),
             ("abcd = ub'a'", 8, 10),
             ("\u03b1\u03b2\u03b3\u03b4 = ub'a'", 8, 10),
+            ("a\u0301b\u0308c\u20d7d\u1ab0 = ub'a'", 12, 14),
         ]:
             with self.subTest(source=source):
                 with self.assertRaises(SyntaxError) as cm:

--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -2566,7 +2566,7 @@ class CTokenizeTest(TestCase):
             self._get_tokens('bé )tf"2 ', extra_tokens=True)
         self.assertEqual(
             caught.exception.args,
-            ("'f' and 't' prefixes are incompatible", (1, 6)),
+            ("'f' and 't' prefixes are incompatible", (1, 5)),
         )
 
     def test_tolerant_fstring_closer_at_expression_entry_depth(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-09-03-15-20-00.gh-issue-156894.Rt9Bx4.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-09-03-15-20-00.gh-issue-156894.Rt9Bx4.rst
@@ -1,0 +1,2 @@
+Fix the position of syntax errors which cover a range if the line contains
+non-ASCII characters before the error.

--- a/Parser/tokenizer/helpers.c
+++ b/Parser/tokenizer/helpers.c
@@ -9,6 +9,20 @@
 
 /* ############## ERRORS ############## */
 
+/* Convert a 1-based column in bytes into a 1-based column in characters.
+   The line is UTF-8 encoded, so it is enough to skip continuation bytes. */
+static int
+byte_col_to_char_col(const char *line, int byte_col)
+{
+    int char_col = 1;
+    for (int i = 0; i < byte_col - 1; i++) {
+        if ((line[i] & 0xC0) != 0x80) {
+            char_col++;
+        }
+    }
+    return char_col;
+}
+
 static int
 _syntaxerror_range(struct tok_state *tok, const char *format,
                    int col_offset, int end_col_offset,
@@ -35,8 +49,14 @@ _syntaxerror_range(struct tok_state *tok, const char *format,
     if (col_offset == -1) {
         col_offset = (int)PyUnicode_GET_LENGTH(errtext);
     }
+    else if (col_offset > 0) {
+        col_offset = byte_col_to_char_col(tok->line_start, col_offset);
+    }
     if (end_col_offset == -1) {
         end_col_offset = col_offset;
+    }
+    else if (end_col_offset > 0) {
+        end_col_offset = byte_col_to_char_col(tok->line_start, end_col_offset);
     }
 
     Py_ssize_t line_len = strcspn(tok->line_start, "\n");


### PR DESCRIPTION
`SyntaxError.offset` and `end_offset` are columns in characters, but all callers of `_PyTokenizer_syntaxerror_known_range()` pass columns in bytes, so the reported position drifts by one column per preceding non-ASCII character:

```pycon
>>> compile("abcd = 00010", "<t>", "exec")     # before and after
  File "<t>", line 1
    abcd = 00010
           ^^^
>>> compile("αβγδ = 00010", "<t>", "exec")     # before
  File "<t>", line 1
    αβγδ = 00010
               ^
>>> compile("αβγδ = 00010", "<t>", "exec")     # after
  File "<t>", line 1
    αβγδ = 00010
           ^^^
```

The conversion is done in `_syntaxerror_range()`, so all three call sites are fixed at once, and the `-1` case is unaffected: it already counts characters.

`test_tokenize.test_tolerant_incompatible_prefix_position_after_non_ascii` asserted the column in bytes, so its expected value changes from 6 to 5.

<!-- gh-issue-number: gh-156894 -->
* Issue: gh-156894
<!-- /gh-issue-number -->
