### PR TITLE
gh-122988: Clarify that types.get_original_bases() ignores inherited __orig_bases__

### DIFF
--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -89,10 +89,12 @@ Dynamic Type Creation
     (following the mechanisms laid out in :pep:`560`). This is useful for
     introspecting :ref:`Generics <user-defined-generics>`.
 
-    For classes that have an ``__orig_bases__`` attribute, this
-    function returns the value of ``cls.__orig_bases__``.
-    For classes without the ``__orig_bases__`` attribute,
-    :attr:`cls.__bases__ <type.__bases__>` is returned.
+    If ``__orig_bases__`` is defined in the namespace of *cls* itself, this
+    function returns its value.  Otherwise,
+    :attr:`cls.__bases__ <type.__bases__>` is returned.  Unlike accessing
+    ``cls.__orig_bases__`` directly, this function never returns an
+    ``__orig_bases__`` attribute inherited from a base class, so the result
+    always describes the bases of *cls* and not those of one of its ancestors.
 
     Examples::
 
@@ -101,12 +103,17 @@ Dynamic Type Creation
         T = TypeVar("T")
         class Foo(Generic[T]): ...
         class Bar(Foo[int], float): ...
+        class Ham(Bar): ...
         class Baz(list[str]): ...
         Eggs = NamedTuple("Eggs", [("a", int), ("b", str)])
         Spam = TypedDict("Spam", {"a": int, "b": str})
 
         assert Bar.__bases__ == (Foo, float)
         assert get_original_bases(Bar) == (Foo[int], float)
+
+        assert Ham.__orig_bases__ == (Foo[int], float)  # inherited from Bar
+        assert Ham.__bases__ == (Bar,)
+        assert get_original_bases(Ham) == (Bar,)
 
         assert Baz.__bases__ == (list,)
         assert get_original_bases(Baz) == (list[str],)


### PR DESCRIPTION
The docs for `types.get_original_bases()` say that for classes that have an `__orig_bases__` attribute, the function returns `cls.__orig_bases__`. That reads as if the function is equivalent to attribute access, but the implementation only looks in `cls.__dict__`. A class whose base defines `__orig_bases__` will inherit the attribute, while `get_original_bases()` correctly falls back to `cls.__bases__` for it.

This rewords the paragraph to say the lookup is on the class's own namespace and that inherited attributes are ignored, and adds a short example of that case to the existing examples block.

Fixes #122988


<!-- gh-issue-number: gh-122988 -->
* Issue: gh-122988
<!-- /gh-issue-number -->
