### PR TITLE
gh-100239: specialize small integer powers (x**2, x**3) of compact ints

### DIFF
--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -1538,6 +1538,44 @@ class TestSpecializer(TestBase):
 
     @cpython_only
     @requires_specialization
+    def test_binary_op_small_power(self):
+        def small_power():
+            for _ in range(_testinternalcapi.SPECIALIZATION_THRESHOLD):
+                a = 7
+                self.assertEqual(a ** 2, 49)
+                b = -9
+                self.assertEqual(b ** 3, -729)
+                c = 2 ** 20 - 1  # largest base accepted by the exponent-3 bound
+                self.assertEqual(c ** 3, (2 ** 20 - 1) ** 3)
+                z = 0  # result is the immortal cached 0
+                self.assertEqual(z ** 2, 0)
+
+        small_power()
+        self.assert_specialized(small_power, "BINARY_OP_EXTEND")
+        self.assert_no_opcode(small_power, "BINARY_OP")
+
+        def small_power_inplace():
+            for _ in range(_testinternalcapi.SPECIALIZATION_THRESHOLD):
+                a = 7
+                a **= 2
+                self.assertEqual(a, 49)
+
+        small_power_inplace()
+        self.assert_specialized(small_power_inplace, "BINARY_OP_EXTEND")
+
+        def power_not_extended(x):
+            for _ in range(_testinternalcapi.SPECIALIZATION_THRESHOLD):
+                self.assertEqual(x ** 4, 2401)
+                self.assertEqual((x + 2 ** 20) ** 3, (7 + 2 ** 20) ** 3)
+                self.assertEqual((x + (1 << 40)) ** 2, (7 + (1 << 40)) ** 2)
+                self.assertEqual(bool(x) ** 2, True)
+                self.assertEqual(float(x) ** 3, 343.0)
+
+        power_not_extended(7)
+        self.assert_no_opcode(power_not_extended, "BINARY_OP_EXTEND")
+
+    @cpython_only
+    @requires_specialization
     def test_load_super_attr(self):
         """Ensure that LOAD_SUPER_ATTR is specialized as expected."""
 

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -2179,6 +2179,40 @@ BITWISE_LONGS_ACTION(compactlongs_and, &)
 BITWISE_LONGS_ACTION(compactlongs_xor, ^)
 #undef BITWISE_LONGS_ACTION
 
+static int
+small_power_guard(PyObject *lhs, PyObject *rhs)
+{
+    if (!is_compactlong(lhs) || !is_compactlong(rhs)) {
+        return false;
+    }
+    Py_ssize_t exponent = _PyLong_CompactValue((PyLongObject *)rhs);
+    if (exponent == 2) {
+        /* |x| < 2^30 (compact), so x*x < 2^60: fits a 64-bit
+           intermediate even where Py_ssize_t is 32 bits. */
+        return true;
+    }
+    if (exponent == 3) {
+        /* Need |x*x*x| < 2^60, so |x| < 2^20. */
+        Py_ssize_t x = _PyLong_CompactValue((PyLongObject *)lhs);
+        return x < (1 << 20) && x > -(1 << 20);
+    }
+    return false;
+}
+
+static PyObject *
+small_power(PyObject *lhs, PyObject *rhs)
+{
+    /* Compute in int64_t (not Py_ssize_t): the guard bounds keep the
+       product below 2^60, which overflows a 32-bit Py_ssize_t. */
+    int64_t x = (int64_t)_PyLong_CompactValue((PyLongObject *)lhs);
+    int64_t exponent = (int64_t)_PyLong_CompactValue((PyLongObject *)rhs);
+    assert(exponent == 2 || exponent == 3);
+    if (exponent == 2) {
+        return PyLong_FromLongLong(x * x);
+    }
+    return PyLong_FromLongLong(x * x * x);
+}
+
 /* float-long */
 
 static inline int
@@ -2258,6 +2292,11 @@ static _PyBinaryOpSpecializationDescr binaryop_extend_descrs[] = {
     {NB_INPLACE_OR, compactlongs_guard, compactlongs_or, &PyLong_Type, 1, NULL, NULL},
     {NB_INPLACE_AND, compactlongs_guard, compactlongs_and, &PyLong_Type, 1, NULL, NULL},
     {NB_INPLACE_XOR, compactlongs_guard, compactlongs_xor, &PyLong_Type, 1, NULL, NULL},
+
+    /* x ** 2 / x ** 3 for compact ints; PyLong_FromLongLong may return
+       the cached immortal small ints, which result_unique accepts. */
+    {NB_POWER, small_power_guard, small_power, &PyLong_Type, 1, NULL, NULL},
+    {NB_INPLACE_POWER, small_power_guard, small_power, &PyLong_Type, 1, NULL, NULL},
 
     /* float-long arithmetic: guards also check NaN and compactness. */
     {NB_ADD, float_compactlong_guard, float_compactlong_add, &PyFloat_Type, 1, NULL, NULL},


### PR DESCRIPTION
Extend the `binaryop_extend_descrs` table with `NB_POWER/NB_INPLACE_POWER` descriptors that strength-reduce `x ** 2` and `x ** 3` on exact compact ints into `x*x` and `x*x*x`.

Test on `Apple M5 Pro, 15 cores 48 GB macOS 26.6.2`, n = 2,000,000 x 4 passes for every workload;:


```python
def pow_mixed(n):
    t = 0
    for i in range(n):
        t += (i & 7) ** 2 + (i & 3) ** 3
    return t

def pow2(n):
    t = 0
    for i in range(n):
        t += (i & 1023) ** 2
    return t

def pow3(n):
    t = 0
    for i in range(n):
        t += (i & 63) ** 3
    return t

def poly(n):
    t = 0
    for i in range(n):
        a = i & 255
        t += 3 * a ** 2 + 5 * a + 7
    return t

def miss(n):
    t = 0
    for i in range(n):
        t += (i & 7) ** 4
    return t
```

| Workload | main (ms) | optimized (ms) | Relative |
| --- | ---: | ---: | ---: |
| `pow_mixed` (`(i&7)**2 + (i&3)**3`) | 310.1 ± 4.9 | 229.0 ± 4.2 | **1.35 ± 0.03** |
| `pow3` (`x**3`) | 289.7 ± 7.8 | 239.3 ± 13.5 | 1.21 ± 0.08 |
| `pow2` (`x**2`) | 268.5 ± 14.8 | 232.5 ± 6.4 | 1.16 ± 0.07 |
| `poly` (`3*a**2 + 5*a + 7`) | 413.3 ± 5.0 | 387.8 ± 15.7 | 1.07 ± 0.05 |
| `miss` (`(i&7)**4`, guard must reject) | 257.3 ± 4.7 | 255.1 ± 5.7 | 1.01 ± 0.03 |


<!-- gh-issue-number: gh-100239 -->
* Issue: gh-100239
<!-- /gh-issue-number -->
