### PR TITLE
[3.13] gh-156894: Fix the position of syntax errors which cover a range (GH-156901)

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -230,6 +230,23 @@ class ExceptionTests(unittest.TestCase):
         check = self.check
         check('"\\\n"(1 for c in I,\\\n\\', 2, 2)
 
+    def testSyntaxErrorRange(self):
+        # gh-156894: the position was reported in bytes, not in characters,
+        # for the errors which cover a range
+        for source, offset, end_offset in [
+            ('abcd = 00010', 8, 11),
+            ('\u03b1\u03b2\u03b3\u03b4 = 00010', 8, 11),
+            ('a\u0301b\u0308c\u20d7d\u1ab0 = 00010', 12, 15),
+            ("abcd = ub'a'", 8, 10),
+            ("\u03b1\u03b2\u03b3\u03b4 = ub'a'", 8, 10),
+            ("a\u0301b\u0308c\u20d7d\u1ab0 = ub'a'", 12, 14),
+        ]:
+            with self.subTest(source=source):
+                with self.assertRaises(SyntaxError) as cm:
+                    compile(source, '<testcase>', 'exec')
+                self.assertEqual(cm.exception.offset, offset)
+                self.assertEqual(cm.exception.end_offset, end_offset)
+
     def testSyntaxErrorOffset(self):
         check = self.check
         check('def fact(x):\n\treturn x!\n', 2, 10)

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -237,9 +237,9 @@ class ExceptionTests(unittest.TestCase):
             ('abcd = 00010', 8, 11),
             ('\u03b1\u03b2\u03b3\u03b4 = 00010', 8, 11),
             ('a\u0301b\u0308c\u20d7d\u1ab0 = 00010', 12, 15),
-            ("abcd = ub'a'", 8, 10),
-            ("\u03b1\u03b2\u03b3\u03b4 = ub'a'", 8, 10),
-            ("a\u0301b\u0308c\u20d7d\u1ab0 = ub'a'", 12, 14),
+            ("abcd = ub'a'", 10, 13),
+            ("\u03b1\u03b2\u03b3\u03b4 = ub'a'", 10, 13),
+            ("a\u0301b\u0308c\u20d7d\u1ab0 = ub'a'", 14, 17),
         ]:
             with self.subTest(source=source):
                 with self.assertRaises(SyntaxError) as cm:

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-09-03-15-20-00.gh-issue-156894.Rt9Bx4.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-09-03-15-20-00.gh-issue-156894.Rt9Bx4.rst
@@ -1,0 +1,2 @@
+Fix the position of syntax errors which cover a range if the line contains
+non-ASCII characters before the error.

--- a/Parser/tokenizer/helpers.c
+++ b/Parser/tokenizer/helpers.c
@@ -7,6 +7,20 @@
 
 /* ############## ERRORS ############## */
 
+/* Convert a 1-based column in bytes into a 1-based column in characters.
+   The line is UTF-8 encoded, so it is enough to skip continuation bytes. */
+static int
+byte_col_to_char_col(const char *line, int byte_col)
+{
+    int char_col = 1;
+    for (int i = 0; i < byte_col - 1; i++) {
+        if ((line[i] & 0xC0) != 0x80) {
+            char_col++;
+        }
+    }
+    return char_col;
+}
+
 static int
 _syntaxerror_range(struct tok_state *tok, const char *format,
                    int col_offset, int end_col_offset,
@@ -33,8 +47,14 @@ _syntaxerror_range(struct tok_state *tok, const char *format,
     if (col_offset == -1) {
         col_offset = (int)PyUnicode_GET_LENGTH(errtext);
     }
+    else if (col_offset > 0) {
+        col_offset = byte_col_to_char_col(tok->line_start, col_offset);
+    }
     if (end_col_offset == -1) {
         end_col_offset = col_offset;
+    }
+    else if (end_col_offset > 0) {
+        end_col_offset = byte_col_to_char_col(tok->line_start, end_col_offset);
     }
 
     Py_ssize_t line_len = strcspn(tok->line_start, "\n");


### PR DESCRIPTION
The callers of `_PyTokenizer_syntaxerror_known_range()` pass columns in bytes, but `SyntaxError.offset` and `end_offset` are columns in characters.
(cherry picked from commit 59a691361cb7b1d4fde3b92f98a61490381c62c9)

In 3.13 the error for incompatible string prefixes points at the string itself, not at the prefixes, so the expected positions of these test cases differ from the main branch.

Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>

<!-- gh-issue-number: gh-156894 -->
* Issue: gh-156894
<!-- /gh-issue-number -->
