### PR TITLE
gh-142349: Document `LazyImportType.resolve()` method

### DIFF
--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -354,6 +354,10 @@ Standard names are defined for the following types:
 
    .. seealso:: :pep:`810`
 
+   .. method:: resolve()
+
+      Resolve the lazy object by reifying the lazily imported module.
+
 
 .. class:: GetSetDescriptorType
 

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -356,7 +356,7 @@ Standard names are defined for the following types:
 
    .. method:: resolve()
 
-      Resolve the lazy object by reifying the lazily imported module.
+      Reify the lazy import and return the "real" object being imported.
 
 
 .. class:: GetSetDescriptorType


### PR DESCRIPTION
`resolve()` is referenced several times in [PEP 810](https://peps.python.org/pep-0810/), but not documented. I believe it would make sense to explicitly document it.

See also https://github.com/python/cpython/issues/156924.

<!-- gh-issue-number: gh-142349 -->
* Issue: gh-142349
<!-- /gh-issue-number -->
