### PR TITLE
gh-156946: Unlink a curses panel before dropping its user pointer

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -2428,6 +2428,22 @@ class TestCurses(unittest.TestCase):
         panel.set_userptr(A())
         panel.set_userptr(None)
 
+    @requires_curses_func('panel')
+    def test_userptr_dealloc_segfault(self):
+        w = curses.newwin(10, 10)
+        panel = curses.panel.new_panel(w)
+        seen = []
+        class A:
+            def __del__(self):
+                # The panel is being deallocated, so it must already be off
+                # the stack: handing it back here would resurrect an object
+                # whose refcount is zero -- segfaults.
+                seen.append(curses.panel.top_panel() is None)
+        panel.set_userptr(A())
+        del panel
+        gc_collect()
+        self.assertEqual(seen, [True])
+
     @cpython_only
     @requires_curses_func('panel')
     def test_disallow_instantiation(self):

--- a/Misc/NEWS.d/next/Library/2026-09-04-16-05-45.gh-issue-156946.0ZYCdh.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-04-16-05-45.gh-issue-156946.0ZYCdh.rst
@@ -1,0 +1,3 @@
+Fix a crash in :mod:`curses.panel` when the finalizer of a panel's user
+pointer runs while the panel is being deallocated.  The panel is now taken
+off the panel stack before its user pointer is dropped.

--- a/Modules/_curses_panel.c
+++ b/Modules/_curses_panel.c
@@ -454,20 +454,21 @@ PyCursesPanel_Dealloc(PyObject *self)
     PyObject_GC_UnTrack(self);
 
     PyCursesPanelObject *po = _PyCursesPanelObject_CAST(self);
-    if (PyCursesPanel_Clear(self) < 0) {
+    PyObject *extra = (PyObject *)panel_userptr(po->pan);
+    if (extra != NULL && set_panel_userptr(po->pan, NULL) == ERR) {
+        curses_panel_panel_set_error(po, "set_panel_userptr", "__del__");
+        PyErr_FormatUnraisable("Exception ignored in PyCursesPanel_Dealloc()");
+    }
+    if (po->wo != NULL && remove_lop(po) < 0) {
+        PyErr_SetString(PyExc_RuntimeError, "__del__: no panel object to delete");
         PyErr_FormatUnraisable("Exception ignored in PyCursesPanel_Dealloc()");
     }
     if (del_panel(po->pan) == ERR && !PyErr_Occurred()) {
         curses_panel_panel_set_error(po, "del_panel", "__del__");
         PyErr_FormatUnraisable("Exception ignored in PyCursesPanel_Dealloc()");
     }
-    if (po->wo != NULL) {
-        Py_DECREF(po->wo);
-        if (remove_lop(po) < 0) {
-            PyErr_SetString(PyExc_RuntimeError, "__del__: no panel object to delete");
-            PyErr_FormatUnraisable("Exception ignored in PyCursesPanel_Dealloc()");
-        }
-    }
+    Py_XDECREF(extra);
+    Py_XDECREF(po->wo);
     tp->tp_free(po);
     Py_DECREF(tp);
 }


### PR DESCRIPTION
`PyCursesPanel_Dealloc()` released the panel's user pointer before it took the panel off the panel stack and out of `lop`, so a `__del__` running from that `Py_DECREF` could fetch the dying panel back through `top_panel()` and crash the interpreter.

The deallocator now unlinks first (`set_panel_userptr(NULL)`, `remove_lop()`, `del_panel()`) and releases the user pointer and the window afterwards. `remove_lop()` also moves ahead of `del_panel()`, closing a second window where the registry held an entry whose `PANEL` had already been freed. It cannot just call `PyCursesPanel_Clear()` in the new order, because that function is also `tp_clear`, where `del_panel()` must not run.

The new test segfaults the worker without the change to `Modules/_curses_panel.c`, which is also true of the neighbouring `test_userptr_segfault`.

With the test but without the C change:

```
$ TERM=xterm-256color ./python -m test -u all -v test_curses -m test_userptr_dealloc_segfault; echo "rc=$?"
test_userptr_dealloc_segfault (test.test_curses.TestCurses.test_userptr_dealloc_segfault) ... Fatal Python error: Segmentation fault

Current thread 0x00007059a8a4e780 [python] (most recent call first):
  File "Lib/test/test_curses.py", line 2443 in test_userptr_dealloc_segfault
  ...
rc=139
```

With the change:

```
$ TERM=xterm-256color ./python -m test -u all -v test_curses -m test_userptr_dealloc_segfault
test_userptr_dealloc_segfault (test.test_curses.TestCurses.test_userptr_dealloc_segfault) ... ok
== Tests result: SUCCESS ==
```

Full module:

```
$ TERM=xterm-256color ./python -m test -u all test_curses
Total tests: run=184 skipped=3
Result: SUCCESS
```


<!-- gh-issue-number: gh-156946 -->
* Issue: gh-156946
<!-- /gh-issue-number -->
