### PR TITLE
gh-156951: Do not truncate the color pair in curses.slk_color()

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -3479,10 +3479,10 @@ class SLKTests(NewtermTestBase):
     # slk_init() must run before newterm()/initscr(), so each test sets up its
     # own screen rather than reusing the one TestCurses builds in setUp().
 
-    def make_slk_screen(self, fmt=0):
+    def make_slk_screen(self, fmt=0, term='xterm'):
         s = self.make_pty()
         curses.slk_init(fmt)
-        return curses.newterm('xterm', s, s)
+        return curses.newterm(term, s, s)
 
     def test_init_reserves_a_line(self):
         # Every layout takes the bottom line for the labels; the index-line
@@ -3564,6 +3564,26 @@ class SLKTests(NewtermTestBase):
         curses.slk_attr_set(curses.A_BOLD)
         curses.slk_attr_set(curses.A_BOLD, 0)
         curses.slk_color(0)
+
+    def test_color_wide_pair(self):
+        # Drive a terminal with enough color pairs to reach past a short,
+        # rather than relying on whatever $TERM happens to be.
+        try:
+            self.make_slk_screen(term='xterm-256color')
+        except curses.error:
+            self.skipTest('no xterm-256color terminfo entry')
+        if not curses.has_colors():
+            self.skipTest('requires colors support')
+        curses.start_color()
+        if not (curses.has_extended_color_support()
+                and curses.COLOR_PAIRS > SHORT_MAX + 1):
+            self.skipTest('requires extended color support')
+        # A pair that does not fit in a short is still a valid pair here.
+        curses.slk_color(SHORT_MAX + 1)
+        # The low 16 bits of this are pair 5, but the pair itself is out of
+        # range, so it must raise instead of selecting pair 5.
+        self.assertRaises(curses.error, curses.slk_color,
+                          curses.COLOR_PAIRS * 2 + 5)
 
 
 @unittest.skipUnless(hasattr(curses, 'newterm'), 'requires curses.newterm()')

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -8863,7 +8863,13 @@ _curses_slk_color_impl(PyObject *module, int pair)
 /*[clinic end generated code: output=ffe4de805f9c65f5 input=b1e691a9cc6177ee]*/
 {
     PyCursesStatefulInitialised(module);
-    return curses_check_err(module, slk_color((short)pair), "slk_color", NULL);
+    int rtn;
+#if _NCURSES_EXTENDED_COLOR_FUNCS
+    rtn = extended_slk_color(pair);
+#else
+    rtn = slk_color((short)pair);
+#endif
+    return curses_check_err(module, rtn, "slk_color", NULL);
 }
 #endif /* HAVE_CURSES_SLK_COLOR */
 


### PR DESCRIPTION
`slk_color()` cast its color pair to a `short`, so pairs of 32768 and above were rejected and a pair whose low 16 bits named a valid pair was silently applied in its place. It now calls `extended_slk_color()` under the module's existing `_NCURSES_EXTENDED_COLOR_FUNCS` guard, as `slk_attr_set()` and `window.color_set()` already do.

No `Misc/NEWS.d` entry: `slk_color()` is `versionadded:: next` and has not been in a release.


<!-- gh-issue-number: gh-156951 -->
* Issue: gh-156951
<!-- /gh-issue-number -->
