### PR TITLE
gh-156953: Fix a reference leak in curses window.insnstr()

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -3383,6 +3383,23 @@ class ScreenTests(NewtermTestBase):
         # close() is idempotent.
         screen.close()
 
+    def test_close_then_write_with_attr_keeps_no_reference(self):
+        # A write with an *attr* argument on a detached window fails while
+        # setting the rendition, and has to release the bytes it converted.
+        s = self.make_pty()
+        screen = curses.newterm('xterm', s, s)
+        win = screen.stdscr
+        screen.close()
+        writes = [lambda b: win.addstr(b, curses.A_BOLD),
+                  lambda b: win.addnstr(b, 4, curses.A_BOLD),
+                  lambda b: win.insstr(b, curses.A_BOLD),
+                  lambda b: win.insnstr(b, 4, curses.A_BOLD)]
+        data = b'x' * 8
+        nrefs = sys.getrefcount(data)
+        for write in writes:
+            self.assertRaises(curses.error, write, data)
+        self.assertEqual(sys.getrefcount(data), nrefs)
+
     @requires_curses_func('panel')
     def test_close_then_panel_replace(self):
         # A detached window has no underlying curses window, so replace()

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -4361,6 +4361,7 @@ _curses_window_insnstr_impl(PyCursesWindowObject *self, int group_left_1,
             curses_wattrset(self, attr, "insnstr") < 0)
         {
             curses_release_wstr(strtype, wstr);
+            Py_XDECREF(bytesobj);
             return NULL;
         }
     }


### PR DESCRIPTION
`_curses_window_insnstr_impl()` frees the wide string when `curses_wattr_save()` or `curses_wattrset()` fails, but never decrefs the bytes object `PyCurses_ConvertToString()` returned as a new reference, so each failing call leaks one reference to the caller's argument. GH-145609 added that decref to `addstr()`, `addnstr()` and `insstr()` and skipped `insnstr()`; this adds the missing line and a test covering all four.

There is no NEWS entry because no released version can reach the leak: 3.15 has the same omission, but detaching a window arrived with the multi-terminal screen API in GH-151748, so nothing there makes the rendition call fail.


<!-- gh-issue-number: gh-156953 -->
* Issue: gh-156953
<!-- /gh-issue-number -->
