### PR TITLE
[3.14] gh-156896: Stop scrubbing tkinter submodules upon idlelib.run import (GH-156915)

### DIFF
--- a/Lib/idlelib/run.py
+++ b/Lib/idlelib/run.py
@@ -1,6 +1,6 @@
 """ idlelib.run
 
-Simplified, pyshell.ModifiedInterpreter spawns a subprocess with
+Simplified: pyshell.ModifiedInterpreter spawns a subprocess with
 f'''{sys.executable} -c "__import__('idlelib.run').run.main()"'''
 '.run' is needed because __import__ returns idlelib, not idlelib.run.
 """
@@ -26,18 +26,23 @@ from idlelib import iomenu  # encoding
 from idlelib import rpc  # multiple objects
 from idlelib import stackviewer  # StackTreeItem
 from idlelib import util  # fix_scaling
-import __main__
+import __main__  # self.locals in Executive.__init__.
 
 import tkinter  # Use tcl and, if startup fails, messagebox.
-if not hasattr(sys.modules['idlelib.run'], 'firstrun'):
-    # Undo modifications of tkinter by idlelib imports; see bpo-25507.
+
+def scrub_tkinter_submodules():  # Call in main when starting user process.
+    # Undo modifications of tkinter by idlelib imports; see gh-69693.
+    # Which of these submodules got imported (and thus added as a tkinter
+    # attribute) depends on what idlelib pulled in, so tolerate missing
+    # ones rather than assuming a fixed set; see gh-59396.
     for mod in ('simpledialog', 'messagebox', 'font',
                 'dialog', 'filedialog', 'commondialog',
                 'ttk'):
-        delattr(tkinter, mod)
-        del sys.modules['tkinter.' + mod]
-    # Avoid AttributeError if run again; see bpo-37038.
-    sys.modules['idlelib.run'].firstrun = False
+        try:
+            delattr(tkinter, mod)
+            del sys.modules['tkinter.' + mod]
+        except (AttributeError, KeyError):
+            pass
 
 LOCALHOST = '127.0.0.1'
 
@@ -133,6 +138,9 @@ def main(del_exitfunc=False):
     register and unregister themselves.
 
     """
+
+    scrub_tkinter_submodules()
+
     global exit_now
     global quitting
     global no_exitfunc
@@ -699,8 +707,7 @@ class Executive:
         item = stackviewer.StackTreeItem(exc, flist)
         return debugobj_r.remote_object_tree_item(item)
 
-
-if __name__ == '__main__':
+if __name__ == '__main__':  # __name__ is 'idlelib.run' in user subprocess.
     from unittest import main
     main('idlelib.idle_test.test_run', verbosity=2)
 

--- a/Misc/NEWS.d/next/IDLE/2026-09-03-17-16-26.gh-issue-156896.XTQJlq.rst
+++ b/Misc/NEWS.d/next/IDLE/2026-09-03-17-16-26.gh-issue-156896.XTQJlq.rst
@@ -1,0 +1,1 @@
+Stop deleting tkinter submodules when idlelib.run is imported.


### PR DESCRIPTION
Instead, invoke the scrubbing within `run.main`, which is called after the import when starting the IDLE user process.

This also includes the `idlelib.run` part of GH-152036, which was not backported and which the scrubbing code in main is based on: missing tkinter submodules are tolerated rather than assuming a fixed set. `Lib/idlelib/run.py` is now identical in main, 3.15, 3.14 and 3.13.

(cherry picked from commit e50d23389be07bf702bde74c3cda794c6febb53e)

Co-authored-by: Terry Jan Reedy <tjreedy@udel.edu>

<!-- gh-issue-number: gh-156896 -->
* Issue: gh-156896
<!-- /gh-issue-number -->
