### PR TITLE
gh-156963: Raise TypeError when concatenating complexstr with another type

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -796,6 +796,9 @@ class TestCurses(unittest.TestCase):
         self.assertEqual(str(s[1:]), 'bc')
         self.assertEqual(str(s[::-1]), 'cbA')
         self.assertEqual(str(s + curses.complexstr(['Z'])), 'AbcZ')
+        # Concatenating anything else raises instead of returning NotImplemented.
+        self.assertRaises(TypeError, lambda: s + 'Z')
+        self.assertRaises(TypeError, lambda: s + cc('Z'))
         # The empty complexstr.
         self.assertEqual(len(curses.complexstr([])), 0)
         self.assertEqual(str(curses.complexstr('')), '')

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -1590,7 +1590,10 @@ complexstr_concat(PyObject *a, PyObject *b)
 {
     cursesmodule_state *state = get_cursesmodule_state_by_cls(Py_TYPE(a));
     if (!Py_IS_TYPE(b, state->complexstr_type)) {
-        Py_RETURN_NOTIMPLEMENTED;
+        PyErr_Format(PyExc_TypeError,
+                     "can only concatenate complexstr to complexstr, not %T",
+                     b);
+        return NULL;
     }
     PyCursesComplexStrObject *sa = _PyCursesComplexStrObject_CAST(a);
     PyCursesComplexStrObject *sb = _PyCursesComplexStrObject_CAST(b);


### PR DESCRIPTION
`complexstr_concat()` is installed as `Py_sq_concat` and returned `Py_NotImplemented` for a non-`complexstr` operand, but `PyNumber_Add()` checks for `NotImplemented` only on the `nb_add` path and returns an `sq_concat` result verbatim, so the singleton reached Python code and `s += 'x'` rebound the name to it. It now raises `TypeError`, matching the two `tp_richcompare` slots that use the protocol where it does apply. `__radd__` is unaffected, since `PyNumber_Add()` tries `nb_add` on both operands before falling back to `sq_concat`.

There is no NEWS entry because `complexstr` is new in 3.16 and unreleased, so no user could hit this.


<!-- gh-issue-number: gh-156963 -->
* Issue: gh-156963
<!-- /gh-issue-number -->
