### PR TITLE
gh-136952: Fix C analyzer handling of static assertions

### DIFF
--- a/Lib/test/test_tools/test_c_analyzer.py
+++ b/Lib/test/test_tools/test_c_analyzer.py
@@ -1,5 +1,6 @@
 import os.path
 import shutil
+import subprocess
 import tempfile
 import unittest
 
@@ -53,7 +54,11 @@ class StaticAssertTests(unittest.TestCase):
                 self.assertEqual(items[-1].name, 'global_after')
 
     @unittest.skipUnless(shutil.which('gcc'), 'requires gcc')
+    @unittest.skipIf(os.name == 'nt', 'GCC backend does not handle Windows paths')
     def test_preprocess(self):
+        version = subprocess.check_output(['gcc', '--version'], text=True)
+        if 'clang' in version.lower():
+            self.skipTest('requires GNU GCC, not Clang')
         with tempfile.TemporaryDirectory() as tmpdir:
             filename = os.path.join(tmpdir, 'test.c')
             with open(filename, 'w', encoding='utf-8') as source:

--- a/Lib/test/test_tools/test_c_analyzer.py
+++ b/Lib/test/test_tools/test_c_analyzer.py
@@ -1,0 +1,73 @@
+import os.path
+import shutil
+import tempfile
+import unittest
+
+from test.test_tools import imports_under_tool, skip_if_missing
+
+
+skip_if_missing('c-analyzer')
+
+with imports_under_tool('c-analyzer'):
+    from c_parser.info import FileInfo
+    from c_parser.parser import parse
+    from c_parser.preprocessor import gcc
+
+
+class StaticAssertTests(unittest.TestCase):
+    def parse(self, text):
+        return list(parse(
+            (FileInfo('test.c', lno), line)
+            for lno, line in enumerate(text.splitlines(), 1)
+        ))
+
+    def test_global(self):
+        for keyword in ('_Static_assert', 'static_assert'):
+            with self.subTest(keyword=keyword):
+                items = self.parse(f'''
+                    int before;
+                    {keyword}(
+                        256 > 0 && !(256 & (256 - 1)),
+                        "buffer size; ("
+                    )
+                    ; int after;
+                ''')
+                self.assertEqual([item.name for item in items],
+                                 ['before', 'after'])
+
+    def test_struct(self):
+        for keyword in ('_Static_assert', 'static_assert'):
+            with self.subTest(keyword=keyword):
+                items = self.parse(f'''
+                    struct example {{
+                        int before;
+                        {keyword}(sizeof(int) > 0, "int size");
+                        int after;
+                    }};
+                    int global_after;
+                ''')
+                struct = next(item for item in items
+                              if item.name == 'example' and item.data)
+                self.assertEqual([field.name for field in struct.data],
+                                 ['before', 'after'])
+                self.assertEqual(items[-1].name, 'global_after')
+
+    @unittest.skipUnless(shutil.which('gcc'), 'requires gcc')
+    def test_preprocess(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filename = os.path.join(tmpdir, 'test.c')
+            with open(filename, 'w', encoding='utf-8') as source:
+                source.write('''
+                    #define _GNU_SOURCE 1
+                    #include <assert.h>
+                    static_assert(256 > 0 && !(256 & 255), "buffer size");
+                    int global_after;
+                ''')
+            lines = gcc.preprocess(filename, samefiles=(), cwd=tmpdir)
+            items = list(parse((line.file, line.data) for line in lines
+                               if line.kind == 'source'))
+        self.assertEqual([item.name for item in items], ['global_after'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Misc/NEWS.d/next/Tools-Demos/2026-09-05-00-00-00.gh-issue-136952.Jx7mQp.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2026-09-05-00-00-00.gh-issue-136952.Jx7mQp.rst
@@ -1,0 +1,2 @@
+Fix the C analyzer failing on static assertions in free-threaded builds by
+using C11 preprocessing and handling static assertion declarations.

--- a/Tools/c-analyzer/c_parser/parser/_common.py
+++ b/Tools/c-analyzer/c_parser/parser/_common.py
@@ -78,6 +78,21 @@ def match_paren(text, depth=0):
         raise ValueError(f'could not find matching parens for {text!r}')
 
 
+def skip_static_assert(srcinfo):
+    m = re.match(r'^\s*(?:_Static_assert|static_assert)\b', srcinfo.text)
+    if not m:
+        return False
+    text = srcinfo.text[m.end():]
+    try:
+        end = match_paren(text)
+    except ValueError:
+        return True
+    remainder = text[end:].lstrip()
+    if remainder.startswith(';'):
+        srcinfo.advance(remainder[1:])
+    return True
+
+
 VAR_DECL = set_capture_groups(_VAR_DECL, (
     'STORAGE',
     'TYPE_QUAL',

--- a/Tools/c-analyzer/c_parser/parser/_compound_decl_body.py
+++ b/Tools/c-analyzer/c_parser/parser/_compound_decl_body.py
@@ -8,6 +8,7 @@ from ._common import (
     log_match,
     parse_var_decl,
     set_capture_groups,
+    skip_static_assert,
 )
 
 
@@ -31,6 +32,8 @@ def parse_struct_body(source, anon_name, parent):
     while not done:
         done = True
         for srcinfo in source:
+            if skip_static_assert(srcinfo):
+                continue
             m = STRUCT_MEMBER_RE.match(srcinfo.text)
             if m:
                 break

--- a/Tools/c-analyzer/c_parser/parser/_global.py
+++ b/Tools/c-analyzer/c_parser/parser/_global.py
@@ -7,6 +7,7 @@ from ._common import (
     log_match,
     parse_var_decl,
     set_capture_groups,
+    skip_static_assert,
 )
 from ._compound_decl_body import DECL_BODY_PARSERS
 from ._func_body import parse_function_statics as parse_function_body
@@ -36,6 +37,8 @@ GLOBAL_RE = re.compile(rf'^ \s* {GLOBAL}', re.VERBOSE)
 
 def parse_globals(source, anon_name):
     for srcinfo in source:
+        if skip_static_assert(srcinfo):
+            continue
         m = GLOBAL_RE.match(srcinfo.text)
         if not m:
             # We need more text.

--- a/Tools/c-analyzer/c_parser/preprocessor/gcc.py
+++ b/Tools/c-analyzer/c_parser/preprocessor/gcc.py
@@ -56,7 +56,7 @@ COMPILER_DIRECTIVE_RE = re.compile(r'''
 
 POST_ARGS = (
     '-pthread',
-    '-std=c99',
+    '-std=c11',
     #'-g',
     #'-Og',
     #'-Wno-unused-result',

--- a/Tools/c-analyzer/cpython/_parser.py
+++ b/Tools/c-analyzer/cpython/_parser.py
@@ -178,6 +178,9 @@ INCLUDES = format_tsv_lines([
 MACROS = format_tsv_lines([
     # (glob, name, value)
 
+    # Alignment does not affect global-state classification.
+    ('*', '_Py_ALIGNED_DEF(N, T)', 'T'),
+
     ('Include/internal/*.h', 'Py_BUILD_CORE', '1'),
     ('Python/**/*.c', 'Py_BUILD_CORE', '1'),
     ('Python/**/*.h', 'Py_BUILD_CORE', '1'),


### PR DESCRIPTION
Fixes #136952.

The C analyzer preprocesses source files in C99 mode. With the headers used
in the reported configuration, static assertions expand into compatibility
declarations that the parser cannot handle. This causes analysis of
`Python/gc_free_threading.c` to fail when configured with `--disable-gil`.

This change:
- Uses C11 preprocessing to avoid the compatibility expansion.
- Handles `_Static_assert` and `static_assert` declarations at file scope
  and inside structs and unions, reusing the existing parenthesis-matching
  logic.
- Adds focused regression tests to verify that declarations following
  static assertions are still discovered.

The assertions in CPython's C code remain unchanged.

### Testing

Validated with a locally built CPython 3.16 free-threading interpreter:

- Reproduced the reported analysis failure before the fix.
- Ran `python -m test test_tools`: 80 tests run, 1 skipped, successful.
- Ran `check-c-globals.py` on `Python/gc.c`,
  `Python/gc_free_threading.c`, and `Objects/listobject.c`:
  0 failures.
- Temporarily restored C99 preprocessing in memory and confirmed that
  the preprocessing regression test fails.
- `git diff --check` passes.

The full CPython test suite was not run.

### AI assistance

GPT-6 Astra via OpenCode v2 assisted with investigating the issue,
implementing the changes, and preparing the tests and this PR description.


<!-- gh-issue-number: gh-136952 -->
* Issue: gh-136952
<!-- /gh-issue-number -->
