### PR TITLE
gh-156970: Set the docstring of `Mock.return_value` correctly

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -595,7 +595,7 @@ class NonCallableMock(Base):
 
     __return_value_doc = "The value to be returned when the mock is called."
     return_value = property(__get_return_value, __set_return_value,
-                            __return_value_doc)
+                            doc=__return_value_doc)
 
 
     @property

--- a/Misc/NEWS.d/next/Library/2026-09-05-15-27-11.gh-issue-156970.DxlgbB.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-05-15-27-11.gh-issue-156970.DxlgbB.rst
@@ -1,1 +1,1 @@
-Set the docstring of :attr:`unittest.mock.Mock.return_value` correctly.
+Set the docstring of :attr:`unittest.mock.Mock.return_value`.

--- a/Misc/NEWS.d/next/Library/2026-09-05-15-27-11.gh-issue-156970.DxlgbB.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-05-15-27-11.gh-issue-156970.DxlgbB.rst
@@ -1,1 +1,1 @@
-Set the docstring of :attr:`Mock.return_value` correctly.
+Set the docstring of :attr:`unittest.mock.Mock.return_value` correctly.

--- a/Misc/NEWS.d/next/Library/2026-09-05-15-27-11.gh-issue-156970.DxlgbB.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-05-15-27-11.gh-issue-156970.DxlgbB.rst
@@ -1,0 +1,1 @@
+Set the docstring of :attr:`Mock.return_value` correctly.


### PR DESCRIPTION


<!-- gh-issue-number: gh-156970 -->
* Issue: gh-156970
<!-- /gh-issue-number -->
