### PR TITLE
gh-152433: Windows: use ``LoadLibrary`` in UWP for system libs

### DIFF
--- a/Include/internal/pycore_fileutils_windows.h
+++ b/Include/internal/pycore_fileutils_windows.h
@@ -55,11 +55,7 @@ static inline BOOL _Py_GetFileInformationByName(
     static int GetFileInformationByName_init = -1;
 
     if (GetFileInformationByName_init < 0) {
-#ifdef MS_WINDOWS_DESKTOP
         HMODULE hMod = LoadLibraryW(L"api-ms-win-core-file-l2-1-4");
-#else
-        HMODULE hMod = LoadPackagedLibrary(L"api-ms-win-core-file-l2-1-4", 0);
-#endif
         GetFileInformationByName_init = 0;
         if (hMod) {
             GetFileInformationByName = (PGetFileInformationByName)GetProcAddress(


### PR DESCRIPTION
`LoadPackagedLibrary` only should be used in UWP for apps package libs (not system libs).

This is a partial revert of https://github.com/python/cpython/commit/ba289460069fbdb5b035b48c5c0ba667d42a7ab9.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-152433 -->
* Issue: gh-152433
<!-- /gh-issue-number -->
