### PR TITLE
gh-135623: Document that json sorts the keys before coercing them to strings

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -261,6 +261,8 @@ Basic Usage
       into JSON and then back into a dictionary, the dictionary may not equal
       the original one. That is, ``loads(dumps(x)) != x`` if x has non-string
       keys.
+      *sort_keys* sorts the keys before they are coerced to strings,
+      so numeric keys are sorted by value, not by their string representation.
 
 .. function:: load(fp, *, cls=None, object_hook=None, parse_float=None, \
                    parse_int=None, parse_constant=None, \


### PR DESCRIPTION
`sort_keys` sorts the keys of a dictionary, not the strings written to the output, so numeric keys are sorted by value.  This is not obvious, because the keys are coerced to strings, and re-dumping the loaded result gives a different order.

<!-- gh-issue-number: gh-135623 -->
* Issue: gh-135623
<!-- /gh-issue-number -->
