### PR TITLE
[3.11] Fix download links for old PDF achives in docs

### DIFF
--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -38,11 +38,11 @@ Python in one of various formats, follow one of links in this table.</p>
 
 <p>
 We no longer provide updates to the pre-built PDFs of the documentation.
-The previously-built archives are still available and may be of use:
-<a href="{{ dlbase }}/python-{{ release }}-docs-pdf-a4.zip">A4 PDF (.zip archive)</a>;
-<a href="{{ dlbase }}/python-{{ release }}-docs-pdf-a4.tar.bz2">A4 PDF (.tar.bz2 archive)</a>;
-<a href="{{ dlbase }}/python-{{ release }}-docs-pdf-letter.zip">US-Letter PDF (.zip archive)</a>;
-<a href="{{ dlbase }}/python-{{ release }}-docs-pdf-letter.tar.bz2">US-Letter PDF (.tar.bz2 archive)</a>.
+The previously built archives are still available and may be of use:
+<a href="{{ dlbase }}/python-3.11.14-docs-pdf-a4.zip">A4 PDF (.zip archive)</a>;
+<a href="{{ dlbase }}/python-3.11.14-docs-pdf-a4.tar.bz2">A4 PDF (.tar.bz2 archive)</a>;
+<a href="{{ dlbase }}/python-3.11.14-docs-pdf-letter.zip">US-Letter PDF (.zip archive)</a>;
+<a href="{{ dlbase }}/python-3.11.14-docs-pdf-letter.tar.bz2">US-Letter PDF (.tar.bz2 archive)</a>.
 To build a PDF archive, follow the instructions in the
 <a href="https://devguide.python.org/documentation/start-documenting/#building-the-documentation">Developer's Guide</a>
 and run <code>make dist-pdf</code> in the <code>Doc/</code> directory of a copy of the CPython repository.


### PR DESCRIPTION
https://github.com/python/cpython/pull/124489 wasn't backported to 3.11 and earlier, so the archives live at a specific version. Hardcode the links to the latest one, instead of sending users to a 404. Since this is a ~recent regression, I think it should be fixed, but I'll leave it up to Thomas.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
