### PR TITLE
gh-131798: Propagate iterator types from GET_ITER in the JIT

### DIFF
--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -458,10 +458,34 @@ class TestUops(unittest.TestCase):
         self.assertIsNotNone(ex)
         uops = get_opnames(ex)
         self.assertIn("_GET_ITER_TRAD", uops)
+        self.assertIn("_ITER_NEXT_INLINE", uops)
+        self.assertNotIn("_GUARD_TYPE_ITER", uops)
         self.assertNotIn("_GET_ITER", uops)
         self.assertNotIn("_GET_ITER_VIRTUAL", uops)
         self.assertNotIn("_GET_ITER_SELF", uops)
 
+    def test_get_iter_trad_set(self):
+        s = set(range(10))
+        def testfunc(n):
+            total = 0
+            while n:
+                n -= 1
+                for value in s:
+                    total += value
+                    break
+            return total
+
+        total = testfunc(TIER2_THRESHOLD)
+        self.assertEqual(total, next(iter(s)) * TIER2_THRESHOLD)
+        ex = get_first_executor(testfunc)
+        self.assertIsNotNone(ex)
+        uops = get_opnames(ex)
+        self.assertIn("_GET_ITER_TRAD", uops)
+        self.assertIn("_ITER_NEXT_INLINE", uops)
+        self.assertNotIn("_GUARD_TYPE_ITER", uops)
+        self.assertNotIn("_GET_ITER", uops)
+        self.assertNotIn("_GET_ITER_VIRTUAL", uops)
+        self.assertNotIn("_GET_ITER_SELF", uops)
 
     def test_for_iter_range(self):
         def testfunc(n):

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -1448,7 +1448,15 @@ dummy_func(void) {
             index_or_null = sym_new_null(ctx);
         }
         else if (is_trad) {
-            iter = sym_new_not_null(ctx);
+            if (tp == &PyDict_Type || tp == &PyFrozenDict_Type) {
+                iter = sym_new_type(ctx, &PyDictIterKey_Type);
+            }
+            else if (tp == &PySet_Type || tp == &PyFrozenSet_Type) {
+                iter = sym_new_type(ctx, &PySetIter_Type);
+            }
+            else {
+                iter = sym_new_not_null(ctx);
+            }
             index_or_null = sym_new_null(ctx);
         }
         else {

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -3605,7 +3605,15 @@
                 index_or_null = sym_new_null(ctx);
             }
             else if (is_trad) {
-                iter = sym_new_not_null(ctx);
+                if (tp == &PyDict_Type || tp == &PyFrozenDict_Type) {
+                    iter = sym_new_type(ctx, &PyDictIterKey_Type);
+                }
+                else if (tp == &PySet_Type || tp == &PyFrozenSet_Type) {
+                    iter = sym_new_type(ctx, &PySetIter_Type);
+                }
+                else {
+                    iter = sym_new_not_null(ctx);
+                }
                 index_or_null = sym_new_null(ctx);
             }
             else {


### PR DESCRIPTION
This PR propagates the iterator result types for dicts and sets  in the jit optimiser.
This removes a `_GUARD_TYPE_ITER`guard when `GET_ITER` and `FOR_ITER` are in the same trace.

I ran a small microbenchmark on macOS aarch64 that repeatedly iterated over small dictionaries and sets: it seems like this change shows up a 1% improvement, but results are very noisy.

<!-- gh-issue-number: gh-131798 -->
* Issue: gh-131798
<!-- /gh-issue-number -->
