### PR TITLE
gh-157003: Add flush() method to HTMLParser.

### DIFF
--- a/Doc/library/html.parser.rst
+++ b/Doc/library/html.parser.rst
@@ -101,6 +101,12 @@ The output will then be:
    :meth:`close` is called.  *data* must be :class:`str`.
 
 
+.. method:: HTMLParser.flush()
+
+   Process all data fed insofar as it consists of complete elements. Incomplete
+   data remains buffered.
+
+
 .. method:: HTMLParser.close()
 
    Force processing of all buffered data as if it were followed by an end-of-file

--- a/Lib/html/parser.py
+++ b/Lib/html/parser.py
@@ -192,6 +192,17 @@ class HTMLParser(_markupbase.ParserBase):
                 # Nothing was parsed; wait until the buffer doubles.
                 self._parse_threshold = len(self.rawdata)
 
+    def flush(self):
+        """Process all data fed insofar as it consists of complete elements.
+        Incomplete data remains buffered.
+        """
+        if self._pending:
+            self.rawdata += ''.join(self._pending)
+            self._pending.clear()
+            self._pending_len = 0
+            self._parse_threshold = 1
+        self.goahead(0)
+
     def close(self):
         """Handle any buffered data."""
         if self._pending:

--- a/Lib/test/test_htmlparser.py
+++ b/Lib/test/test_htmlparser.py
@@ -42,7 +42,9 @@ class EventCollector(html.parser.HTMLParser):
             else:
                 L.append(event)
             prevtype = type
+        # Reset events and append for re-testing
         self.events = L
+        self.append = self.events.append
         return L
 
     # structure markup

--- a/Lib/test/test_htmlparser.py
+++ b/Lib/test/test_htmlparser.py
@@ -1023,6 +1023,24 @@ text
              ('endtag', 'a'), ('data', ' bar & baz')]
         )
 
+    def test_flush(self):
+        attrs = [(f"a{i}", str(i)) for i in range(8)]
+        parts = ["<div", *[f' {attr[0]}="{attr[1]}"' for attr in attrs], ">", "</div>"]
+        parser = EventCollector()
+        for part in parts:
+            parser.feed(part)
+        # confirm the fed data is buffered and not processed yet
+        self.assertEqual(parser.get_events(), [])
+        parser.flush()
+        expected = [
+            ('starttag', 'div', attrs),
+            ('endtag', 'div'),
+        ]
+        self.assertEqual(parser.get_events(), expected)
+        parser.close()
+        # close should do nothing, event log is the same as before
+        self.assertEqual(parser.get_events(), expected)
+
     @support.requires_resource('cpu')
     def test_eof_no_quadratic_complexity(self):
         # Each of these examples used to take about an hour.

--- a/Misc/NEWS.d/next/Library/2026-09-05-15-21-00.gh-issue-157003.BOCIir.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-05-15-21-00.gh-issue-157003.BOCIir.rst
@@ -1,0 +1,3 @@
+Add ``HTMLParser.flush()`` to process all buffered data that consists of
+complete elements.  This method will be useful now that
+``HTMLParser.feed()``  utilizes more extensive buffering.


### PR DESCRIPTION
- Add flush() method to HTMLParser
    - Add docstring
    - Add test
    - Add blurb
- Small fix to HTMLParser's EventCollector test fixture

<!-- gh-issue-number: gh-157003 -->
* Issue: gh-157003
<!-- /gh-issue-number -->
