### PR TITLE
gh-143201: warnings writes the full source line instead of the truncated one

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -1094,6 +1094,31 @@ class _WarningsTests(BaseTest, unittest.TestCase):
                 self.module._showwarnmsg = show
         self.assertIn(text, result)
 
+    def test_showwarning_fallback_truncates_source_line(self):
+        # gh-143201: C implementation's show_warning fallback should truncate leading whitespace
+        text = 'test fallback truncates source line'
+        with self.module.catch_warnings():
+            self.module.filterwarnings("always", category=UserWarning)
+
+            show = self.module._showwarnmsg
+            show_orig = getattr(self.module, 'showwarning', None)
+            try:
+                del self.module._showwarnmsg
+                if hasattr(self.module, 'showwarning'):
+                    del self.module.showwarning
+                with support.captured_output('stderr') as stream:
+                    def my_warn():
+                        self.module.warn(text)
+                    my_warn()
+                    result = stream.getvalue()
+            finally:
+                self.module._showwarnmsg = show
+                if show_orig is not None:
+                    self.module.showwarning = show_orig
+
+        self.assertIn('self.module.warn(text)', result)
+        self.assertNotIn('                        self.module.warn(text)', result)
+
     def test_showwarning_not_callable(self):
         orig = self.module.showwarning
         try:

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-12-26-17-18-18.gh-issue-143201.UbXuX4.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-12-26-17-18-18.gh-issue-143201.UbXuX4.rst
@@ -1,0 +1,1 @@
+Fix an issue where the :mod:`warnings` module printed the full source line instead of the truncated one.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -698,7 +698,7 @@ show_warning(PyThreadState *tstate, PyObject *filename, int lineno,
         if (truncated == NULL)
             goto error;
 
-        PyFile_WriteObject(sourceline, f_stderr, Py_PRINT_RAW);
+        PyFile_WriteObject(truncated, f_stderr, Py_PRINT_RAW);
         Py_DECREF(truncated);
         PyFile_WriteString("\n", f_stderr);
     }


### PR DESCRIPTION
The truncated object is meant to be written instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-143201 -->
* Issue: gh-143201
<!-- /gh-issue-number -->
