### PR TITLE
gh-157015: Fix double-decref in PyContext_Exit()

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -928,6 +928,16 @@ class CAPITest(unittest.TestCase):
             _testcapi.create_heapctype_with_none_bases_slot
         )
 
+    def test_context_exit_uaf(self):
+        # gh-157015: test that PyContext_Exit() doesn't double de-ref
+        # the context if the caller drops its reference right before calling it.
+        import contextvars
+        var = contextvars.ContextVar("test_var")
+        var.set("hello")
+        for _ in range(100):
+            _testcapi.test_context_exit_uaf()
+        self.assertEqual(var.get(), "hello")
+
 
 @requires_limited_api
 class TestHeapTypeRelative(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-09-05-18-00-00.gh-issue-157015.uaf-context.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-09-05-18-00-00.gh-issue-157015.uaf-context.rst
@@ -1,0 +1,1 @@
+Fix a possible double-decref when exiting a context due to decrementing the context object before updating its internal state.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3027,7 +3027,26 @@ uptime_bsd(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
 #endif
 
 
+static PyObject *
+test_context_exit_uaf(PyObject *self, PyObject *Py_UNUSED(args))
+{
+    PyObject *ctx = PyContext_New();
+    if (ctx == NULL) {
+        return NULL;
+    }
+    if (PyContext_Enter(ctx) < 0) {
+        Py_DECREF(ctx);
+        return NULL;
+    }
+    Py_DECREF(ctx);
+    if (PyContext_Exit(ctx) < 0) {
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
 static PyMethodDef TestMethods[] = {
+    {"test_context_exit_uaf", test_context_exit_uaf, METH_NOARGS},
     {"set_errno",               set_errno,                       METH_VARARGS},
     {"test_config",             test_config,                     METH_NOARGS},
     {"test_sizeof_c_types",     test_sizeof_c_types,             METH_NOARGS},

--- a/Python/context.c
+++ b/Python/context.c
@@ -285,10 +285,11 @@ _PyContext_Exit(PyThreadState *ts, PyObject *octx)
         return -1;
     }
 
-    Py_SETREF(ts->context, (PyObject *)ctx->ctx_prev);
-
+    PyObject *prev = (PyObject *)ctx->ctx_prev;
     ctx->ctx_prev = NULL;
     FT_ATOMIC_STORE_INT(ctx->ctx_entered, 0);
+
+    Py_SETREF(ts->context, prev);
     context_switched(ts);
     return 0;
 }


### PR DESCRIPTION
There was a double-decref bug in _PyContext_Exit() in Python/context.c. The function was calling Py_SETREF(ts->context, (PyObject *)ctx->ctx_prev) before clearing the ctx->ctx_prev and ctx->ctx_entered internal states.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-157015 -->
* Issue: gh-157015
<!-- /gh-issue-number -->
