### PR TITLE
Fix anext awaitable ag gen

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -139,7 +139,13 @@ are always available.  They are listed here in alphabetical order.
    iterator. If *default* is given, it is returned if the iterator is exhausted,
    otherwise :exc:`StopAsyncIteration` is raised.
 
+   The awaitable returned by :func:`anext` exposes the generator it drives as a
+   read-only ``ag_gen`` attribute if *async_iterator* is an asynchronous generator.
+
    .. versionadded:: 3.10
+
+   .. versionadded:: 3.16
+      The ``ag_gen`` attribute.
 
 .. function:: any(iterable, /)
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1238,6 +1238,14 @@ the underlying generator function:
    that does nothing.
 
 
+The awaitables returned by :meth:`~agen.asend`, :meth:`~agen.athrow` and
+:meth:`~agen.aclose` expose the generator they drive as a read-only
+``ag_gen`` attribute.
+
+.. versionadded:: 3.16
+   The ``ag_gen`` attribute.
+
+
 .. _typesseq:
 
 Sequence Types --- :class:`list`, :class:`tuple`, :class:`range`

--- a/Lib/asyncio/graph.py
+++ b/Lib/asyncio/graph.py
@@ -66,7 +66,7 @@ def _build_graph_for_future(
             st.append(FrameCallGraphEntry(coro.ag_frame))
             coro = coro.ag_await
         elif hasattr(coro, 'ag_gen'):
-            # gh-156980: An asend()/athrow() awaitable: step over it to its generator
+            # gh-156980, gh-157032: An asend()/athrow()/anext() awaitable: step over it to its generator
             coro = coro.ag_gen
         else:
             break

--- a/Lib/asyncio/graph.py
+++ b/Lib/asyncio/graph.py
@@ -65,6 +65,9 @@ def _build_graph_for_future(
             # A native async generator or duck-type compatible iterator
             st.append(FrameCallGraphEntry(coro.ag_frame))
             coro = coro.ag_await
+        elif hasattr(coro, 'ag_gen'):
+            # gh-156980: An asend()/athrow() awaitable: step over it to its generator
+            coro = coro.ag_gen
         else:
             break
 

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -414,6 +414,33 @@ class AsyncGenTest(unittest.TestCase):
             asend.close()
             athrow.close()
 
+    def test_async_gen_anext_default_ag_gen(self):
+        # gh-157032: anext(agen, default) awaitables expose the generator they drive
+        async def gen():
+            yield 1
+
+        g = gen()
+        an = anext(g, None)
+        try:
+            self.assertIs(an.ag_gen, g)
+            with self.assertRaises(AttributeError):
+                an.ag_gen = None
+        finally:
+            an.close()
+
+        # Non-generator async iterator should not have ag_gen
+        class CustomAsyncIter:
+            async def __anext__(self):
+                return 1
+
+        c = CustomAsyncIter()
+        an_custom = anext(c, None)
+        try:
+            with self.assertRaises(AttributeError):
+                _ = an_custom.ag_gen
+        finally:
+            an_custom.close()
+
     def test_async_gen_asend_throw_concurrent_with_send(self):
         import types
 

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -397,6 +397,23 @@ class AsyncGenTest(unittest.TestCase):
                 r"cannot reuse already awaited __anext__\(\)/asend\(\)"):
             an.send(None)
 
+    def test_async_gen_asend_athrow_ag_gen(self):
+        # gh-156980: asend()/athrow() awaitables expose the generator they drive
+        async def gen():
+            yield 1
+
+        g = gen()
+        asend = g.asend(None)
+        athrow = g.athrow(ValueError)
+        try:
+            self.assertIs(asend.ag_gen, g)
+            self.assertIs(athrow.ag_gen, g)
+            with self.assertRaises(AttributeError):
+                asend.ag_gen = None
+        finally:
+            asend.close()
+            athrow.close()
+
     def test_async_gen_asend_throw_concurrent_with_send(self):
         import types
 

--- a/Lib/test/test_asyncio/test_graph.py
+++ b/Lib/test/test_asyncio/test_graph.py
@@ -173,6 +173,77 @@ class CallStackTestBase:
 
         self.assertEqual(len(result.call_stack), 2)
 
+    async def test_stack_async_gen_asend(self):
+        # gh-156980: an async_generator_asend must not truncate the stack
+        fut = asyncio.Future()
+        stack_for_consumer = None
+
+        async def deep():
+            await fut
+
+        async def gen():
+            await deep()
+            yield 1
+
+        async def consumer():
+            async for _ in gen():
+                pass
+
+        async def main():
+            nonlocal stack_for_consumer
+
+            async with asyncio.TaskGroup() as g:
+                t = g.create_task(consumer(), name='consumer')
+                for _ in range(5):
+                    await asyncio.sleep(0)
+
+                stack_for_consumer = capture_test_stack(fut=t)
+                fut.set_result(None)
+
+        await main()
+
+        self.assertEqual(stack_for_consumer[0][:2], [
+            'T<consumer>',
+            ['a deep', 'ag gen', 'a consumer'],
+        ])
+
+    async def test_stack_async_gen_aclose(self):
+        # gh-156980: an async_generator_athrow must not truncate the stack
+        fut = asyncio.Future()
+        stack_for_consumer = None
+
+        async def deep():
+            await fut
+
+        async def gen():
+            try:
+                yield 1
+            finally:
+                await deep()
+
+        async def consumer():
+            agen = gen()
+            await anext(agen)
+            await agen.aclose()
+
+        async def main():
+            nonlocal stack_for_consumer
+
+            async with asyncio.TaskGroup() as g:
+                t = g.create_task(consumer(), name='consumer')
+                for _ in range(5):
+                    await asyncio.sleep(0)
+
+                stack_for_consumer = capture_test_stack(fut=t)
+                fut.set_result(None)
+
+        await main()
+
+        self.assertEqual(stack_for_consumer[0][:2], [
+            'T<consumer>',
+            ['a deep', 'ag gen', 'a consumer'],
+        ])
+
     async def test_stack_gather(self):
 
         stack_for_deep = None

--- a/Lib/test/test_asyncio/test_graph.py
+++ b/Lib/test/test_asyncio/test_graph.py
@@ -244,6 +244,39 @@ class CallStackTestBase:
             ['a deep', 'ag gen', 'a consumer'],
         ])
 
+    async def test_stack_async_gen_anext_default(self):
+        # gh-157032: an anext(agen, default) awaitable must not truncate the stack
+        fut = asyncio.Future()
+        stack_for_consumer = None
+
+        async def deep():
+            await fut
+
+        async def gen():
+            await deep()
+            yield 1
+
+        async def consumer():
+            await anext(gen(), None)
+
+        async def main():
+            nonlocal stack_for_consumer
+
+            async with asyncio.TaskGroup() as g:
+                t = g.create_task(consumer(), name='consumer')
+                for _ in range(5):
+                    await asyncio.sleep(0)
+
+                stack_for_consumer = capture_test_stack(fut=t)
+                fut.set_result(None)
+
+        await main()
+
+        self.assertEqual(stack_for_consumer[0][:2], [
+            'T<consumer>',
+            ['a deep', 'ag gen', 'a consumer'],
+        ])
+
     async def test_stack_gather(self):
 
         stack_for_deep = None

--- a/Misc/NEWS.d/next/Library/2026-09-05-17-29-50.gh-issue-156980.W6kHva.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-05-17-29-50.gh-issue-156980.W6kHva.rst
@@ -1,0 +1,2 @@
+:func:`asyncio.print_call_graph` no longer truncates the call stack of a
+task suspended inside an asynchronous generator.

--- a/Misc/NEWS.d/next/Library/2026-09-06-12-00-00.gh-issue-157032.XyZ123.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-06-12-00-00.gh-issue-157032.XyZ123.rst
@@ -1,0 +1,3 @@
+:func:`asyncio.print_call_graph` no longer loses the call stack of a task
+waiting on :func:`anext` with a default value. The awaitable returned by
+``anext(agen, default)`` now exposes the underlying generator as ``ag_gen``.

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -2171,6 +2171,11 @@ async_gen_asend_finalize(PyObject *self)
     }
 }
 
+static PyMemberDef async_gen_asend_memberlist[] = {
+    {"ag_gen", Py_T_OBJECT_EX, offsetof(PyAsyncGenASend, ags_gen), Py_READONLY},
+    {NULL}      /* Sentinel */
+};
+
 static PyMethodDef async_gen_asend_methods[] = {
     {"send", async_gen_asend_send, METH_O, send_doc},
     {"throw", _PyCFunction_CAST(async_gen_asend_throw), METH_FASTCALL, throw_doc},
@@ -2215,7 +2220,7 @@ PyTypeObject _PyAsyncGenASend_Type = {
     PyObject_SelfIter,                          /* tp_iter */
     async_gen_asend_iternext,                   /* tp_iternext */
     async_gen_asend_methods,                    /* tp_methods */
-    0,                                          /* tp_members */
+    async_gen_asend_memberlist,                 /* tp_members */
     0,                                          /* tp_getset */
     0,                                          /* tp_base */
     0,                                          /* tp_dict */
@@ -2634,6 +2639,11 @@ async_gen_athrow_finalize(PyObject *op)
     }
 }
 
+static PyMemberDef async_gen_athrow_memberlist[] = {
+    {"ag_gen", Py_T_OBJECT_EX, offsetof(PyAsyncGenAThrow, agt_gen), Py_READONLY},
+    {NULL}      /* Sentinel */
+};
+
 static PyMethodDef async_gen_athrow_methods[] = {
     {"send", async_gen_athrow_send, METH_O, send_doc},
     {"throw", _PyCFunction_CAST(async_gen_athrow_throw),
@@ -2681,7 +2691,7 @@ PyTypeObject _PyAsyncGenAThrow_Type = {
     PyObject_SelfIter,                          /* tp_iter */
     async_gen_athrow_iternext,                  /* tp_iternext */
     async_gen_athrow_methods,                   /* tp_methods */
-    0,                                          /* tp_members */
+    async_gen_athrow_memberlist,                /* tp_members */
     0,                                          /* tp_getset */
     0,                                          /* tp_base */
     0,                                          /* tp_dict */

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -582,6 +582,19 @@ static PyMethodDef anextawaitable_methods[] = {
 };
 
 
+static PyObject *
+anextawaitable_getag_gen(PyObject *op, void *Py_UNUSED(ignored))
+{
+    anextawaitableobject *obj = anextawaitableobject_CAST(op);
+    return PyObject_GetAttrString(obj->wrapped, "ag_gen");
+}
+
+static PyGetSetDef anextawaitable_getsetlist[] = {
+    {"ag_gen", anextawaitable_getag_gen, NULL, NULL},
+    {NULL}      /* Sentinel */
+};
+
+
 static PyAsyncMethods anextawaitable_as_async = {
     PyObject_SelfIter,                          /* am_await */
     0,                                          /* am_aiter */
@@ -619,6 +632,8 @@ PyTypeObject _PyAnextAwaitable_Type = {
     PyObject_SelfIter,                          /* tp_iter */
     anextawaitable_iternext,                    /* tp_iternext */
     anextawaitable_methods,                     /* tp_methods */
+    0,                                          /* tp_members */
+    anextawaitable_getsetlist,                  /* tp_getset */
 };
 
 PyObject *


### PR DESCRIPTION
Description 

  Fixes gh-157032.

  When calling anext(agen, default) with a default value, Python wraps the underlying __anext__() awaitable in an internal
  anext_awaitable instance (iterobject.c:406-410 in Objects/iterobject.c).

  During task call-stack inspection, _build_graph_for_future in graph.py:40-82 traverses cr_await, ag_await, and ag_gen to walk
  through coroutines, async generators, and generator-driving awaitables. Because anext_awaitable lacked an ag_gen attribute,
  traversal terminated early upon encountering anext_awaitable, losing the entire call stack inside the async generator and any
  child coroutines it was waiting on.

  This PR exposes a read-only ag_gen attribute on anext_awaitable that delegates to self.wrapped.ag_gen.
  ──────
  ### Changes Made:

  1. **iterobject.c**:
      • Added getter anextawaitable_getag_gen to read ag_gen from obj->wrapped.
      • Added anextawaitable_getsetlist and hooked it into _PyAnextAwaitable_Type.tp_getset.
  2. **graph.py**:
      • Updated the comment on ag_gen traversal to reference both gh-156980 and gh-157032.
  3. **test_asyncgen.py**:
      • Added test_async_gen_anext_default_ag_gen to verify anext(agen, default).ag_gen returns the generator, is read-only, and
      raises AttributeError for non-generator async iterators.
  4. **test_graph.py**:
      • Added test_stack_async_gen_anext_default testing both C and Python event loop implementations.
  5. **functions.rst**:
      • Documented the ag_gen attribute on the awaitable returned by anext().
  6. Misc/NEWS.d/next/Library/:
      • Added NEWS entry for gh-157032.

  ──────
  ### Repro & Verification

    import asyncio
    
    async def deep():
        await asyncio.Event().wait()

    async def rows():
        await deep()
        yield 1

    async def worker():
        await anext(rows(), None)

    async def main():
        t = asyncio.create_task(worker(), name='worker')
        await asyncio.sleep(0.05)
        asyncio.print_call_graph(t)
        t.cancel()
        try:
            await t
        except asyncio.CancelledError:
            pass

    asyncio.run(main())

  #### Before:

    * Task(name='worker', id=0x1035c89b0)
      + Call stack:
      |   File 'repro.py', line 11, in async worker()

  #### After:

    * Task(name='worker', id=0x244549256d0)
      + Call stack:
      |   File '.../Lib/asyncio/locks.py', line 210, in async Event.wait()
      |   File 'repro.py', line 5, in async deep()
      |   File 'repro.py', line 8, in async generator rows()
      |   File 'repro.py', line 12, in async worker()
  ──────
  ### Test Suite Results:

  • python -m test test_asyncgen: Passed (100%)
  • python -m test test_asyncio: Passed (35/35 test suites, 2,749 tests, 0 failures)