### PR TITLE
gh-148501: Disable AArch64 Mach-O LOH for JIT stencils

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-09-06-16-13-12.gh-issue-148501.a5odxo.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-09-06-16-13-12.gh-issue-148501.a5odxo.rst
@@ -1,0 +1,2 @@
+Improve JIT stencils on macOS AArch64 by disabling unused linker
+optimization hints.

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -65,6 +65,7 @@ class _Target(typing.Generic[_S, _R]):
     condition: str
     _: dataclasses.KW_ONLY
     args: typing.Sequence[str] = ()
+    stencil_args: typing.Sequence[str] = ()
     optimizer: type[_optimizers.Optimizer] = _optimizers.Optimizer
     label_prefix: typing.ClassVar[str]
     symbol_prefix: typing.ClassVar[str]
@@ -250,6 +251,7 @@ class _Target(typing.Generic[_S, _R]):
         if self.frame_pointers:
             args_s += ["-Xclang", "-mframe-pointer=reserved"]
         args_s += self._compile_args()
+        args_s += self.stencil_args
         # Allow user-provided CFLAGS to override any defaults
         args_s += shlex.split(self.cflags)
         await _llvm.run(
@@ -720,7 +722,12 @@ def get_target(host: str) -> _COFF32 | _COFF64 | _ELF | _MachO:
         host = "aarch64-apple-darwin"
         condition = "defined(__aarch64__) && defined(__APPLE__)"
         optimizer = _optimizers.OptimizerAArch64
-        target = _MachO(host, condition, optimizer=optimizer)
+        target = _MachO(
+            host,
+            condition,
+            optimizer=optimizer,
+            stencil_args=["-mllvm", "-aarch64-enable-collect-loh=false"],
+        )
     elif re.fullmatch(r"aarch64-pc-windows-msvc", host):
         host = "aarch64-pc-windows-msvc"
         condition = "defined(_M_ARM64)"


### PR DESCRIPTION
Currently, LLVM’s AArch64 Mach-O linker optimisation hints prevent the JIT optimiser from folding `adrp`/`ldr` constant loads into `movz`. These hints are actually unused because stencils are not directly passed to the Mach-O linker.

This PR disables the linker hints on macOS Aarch64 with `-aarch64-enable-collect-loh=false`.

E.g. the stencil for `_LOAD_SMALL_INT_r01` on macOS currently looks something like this:
```
Lloh0:
jit_temp_0_x8:
    adrp    x8, __JIT_OPARG_16@GOTPAGE
Lloh1:
    ldr     x8, [x8, __JIT_OPARG_16@GOTPAGEOFF]
    and     x8, x8, #0xffff

Lloh2:
    adrp    x9, __PyRuntime@GOTPAGE
Lloh3:
    ldr     x9, [x9, __PyRuntime@GOTPAGEOFF]

    add     x8, x9, x8, lsl #5
    mov     w9, #13889
    add     x24, x8, x9

    .loh AdrpLdrGot Lloh2, Lloh3
    .loh AdrpLdrGot Lloh0, Lloh1
```
After this PR, the linker optimisation hints are removed and the JIT optimiser can correctly fold `adrp`/`ldr` constant loads.
```
    movz    x8, 0

    adrp    x9, __PyRuntime@GOTPAGE
    ldr     x9, [x9, __PyRuntime@GOTPAGEOFF]

    add     x8, x9, x8, lsl #5
    mov     w9, #13889
    add     x24, x8, x9
```

Overall, this reduces the size of all stencils on macOS by 4.5%:
| Metric           |       Before |        After |                Reduction |
| ---------------- | -----------: | -----------: | -----------------------: |
| Machine code     | 56,340 bytes | 55,468 bytes |    872 bytes (1.55%) |
| Instructions     |       14,085 |       13,867 |     218 instructions |
| Stencil data     |  3,632 bytes |  1,784 bytes | 1,848 bytes (50.88%) |
| Combined | 59,972 bytes | 57,252 bytes |  2,720 bytes (4.54%) |

I ran the pyperformance suite before and after on a Apple M5 Pro which suggests a **geometric mean improvement of 0.57%** and up to **7.3% faster** on `scimark_sparse_mat_mult`.

<details><summary><strong>Expand for full benchmarking results</strong></summary>
<p>

<img width="1600" height="6760" alt="full-suite" src="https://github.com/user-attachments/assets/ef5038aa-014f-47fb-879b-2f15133e989e" />

</p>
</details> 

Benchmarks and code size analysis was run by GPT 5.6 Sol. Code changes are authored by myself.

I realised too late that work on the JIT is currently paused. I'm still opening the PR since #148501 is labeled as a bug, but feel free to ignore it until there's an official decision on the PEP by the steering council.

A follow up to this would be to recognise the `@GOTPAGE`/`@GOTPAGEOFF` Darwin syntax similar to what's done for the [`:got:`/`:got_l12:` ELF syntax](https://github.com/python/cpython/blob/90ac5398e49a80d3c2976621f5a8e449ec0db7d5/Tools/jit/_optimizers.py#L586-L591) so `patch_aarch64_33rx` can deal with it. 

<!-- gh-issue-number: gh-148501 -->
* Issue: gh-148501
<!-- /gh-issue-number -->
