### PR TITLE
gh-156341: Fix threading local fallback import

### DIFF
--- a/Lib/_threading_local.py
+++ b/Lib/_threading_local.py
@@ -36,14 +36,14 @@ class _localimpl:
     def get_dict(self):
         """Return the dict for the current thread. Raises KeyError if none
         defined."""
-        thread = current_thread()
+        thread = threading.current_thread()
         return self.dicts[id(thread)][1]
 
     def create_dict(self):
         """Create a new dict for the current thread, and return it."""
         localdict = {}
         key = self.key
-        thread = current_thread()
+        thread = threading.current_thread()
         idt = id(thread)
         def local_deleted(_, key=key):
             # When the localimpl is deleted, remove the thread attribute.
@@ -88,7 +88,7 @@ class local:
         self = object.__new__(cls)
         impl = _localimpl()
         impl.localargs = (args, kw)
-        impl.locallock = RLock()
+        impl.locallock = threading.RLock()
         object.__setattr__(self, '_local__impl', impl)
         # We need to create the thread dict in anticipation of
         # __init__ being called, to make sure we don't call it
@@ -117,4 +117,4 @@ class local:
             return object.__delattr__(self, name)
 
 
-from threading import current_thread, RLock
+import threading

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -2608,6 +2608,27 @@ class ThreadingIteratorToolsTests(BaseTestCase):
 
 
 class MiscTestCase(unittest.TestCase):
+    def test_threading_local_fallback_import(self):
+        # gh-156341: threading must still be importable when the platform's
+        # `_thread` module doesn't provide the `_local` type, forcing the
+        # pure Python fallback implementation in `_threading_local`. This
+        # used to raise ImportError due to a circular import between the
+        # two modules.
+        rc, out, err = assert_python_ok("-c", """if 1:
+            import _thread
+            del _thread._local
+            import threading
+            import _threading_local
+            # Sanity check: the pure Python fallback is actually in use,
+            # and it still behaves like a normal thread-local object.
+            assert threading.local is _threading_local.local
+            tlocal = threading.local()
+            tlocal.x = 1
+            assert tlocal.x == 1
+            print("ok")
+            """)
+        self.assertEqual(out.strip(), b"ok")
+
     def test__all__(self):
         restore_default_excepthook(self)
 

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1537,11 +1537,6 @@ class _MainThread(Thread):
             _active[self._ident] = self
 
 
-# Helper thread-local instance to detect when a _DummyThread
-# is collected. Not a part of the public API.
-_thread_local_info = local()
-
-
 class _DeleteDummyThreadOnDel:
     '''
     Helper class to remove a dummy thread from threading._active on __del__.
@@ -1691,6 +1686,24 @@ from _thread import stack_size
 # (Py_Main) as threading._shutdown.
 
 _main_thread = _MainThread()
+
+# Helper thread-local instance to detect when a _DummyThread is collected.
+# Not a part of the public API.
+#
+# This must be created only after _main_thread has been constructed and
+# registered in `_active` above (rather than immediately after the
+# _MainThread class, where it conceptually belongs). Constructing a
+# local() instance immediately populates the thread-local dict for the
+# creating thread, which calls current_thread(). When the platform's
+# `_thread` module doesn't provide `_local` (see the `local` import near
+# the top of this file), that population is done by the pure Python
+# fallback implementation in `_threading_local`. Creating this any earlier
+# either reintroduces the circular import described in gh-156341 (if
+# current_thread isn't defined yet), or -- if current_thread is defined
+# but the main thread hasn't been registered in `_active` yet -- causes
+# current_thread() to construct a _DummyThread, whose __init__ itself
+# needs _thread_local_info to already exist.
+_thread_local_info = local()
 
 def _shutdown():
     """

--- a/Misc/NEWS.d/next/Core and Builtins/2026-09-06-18-00-00.gh-issue-156341.Sl7kQ2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2026-09-06-18-00-00.gh-issue-156341.Sl7kQ2.rst
@@ -1,0 +1,2 @@
+﻿Fix fallback importing of the :mod:`_threading_local` module when the
+standard library `threading` module has not yet been fully initialized.

--- a/Misc/NEWS.d/next/Core and Builtins/2026-09-06-18-00-00.gh-issue-156341.Sl7kQ2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2026-09-06-18-00-00.gh-issue-156341.Sl7kQ2.rst
@@ -1,2 +1,0 @@
-﻿Fix fallback importing of the :mod:`_threading_local` module when the
-standard library `threading` module has not yet been fully initialized.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-09-06-18-00-00.gh-issue-156341.Sl7kQ2.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-09-06-18-00-00.gh-issue-156341.Sl7kQ2.rst
@@ -1,0 +1,2 @@
+Fix fallback importing of ``_threading_local`` when the standard
+library ``threading`` module has not yet been fully initialized.


### PR DESCRIPTION
Fixes #156341.

When `_thread._local` is unavailable, importing `threading` falls back to the pure Python `_threading_local` implementation. The fallback currently creates a circular initialization path that prevents `threading` from importing.

This change delays `_thread_local_info` initialization until after the main thread is registered and updates the fallback implementation to use the `threading` module explicitly.

Adds a regression test for the fallback import path.

<!-- gh-issue-number: gh-156341 -->
* Issue: gh-156341
<!-- /gh-issue-number -->
