### PR TITLE
gh-156895: Document CXX in ./configure --help output

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-09-07-00-30-00.gh-issue-156895.Jakqud.rst
+++ b/Misc/NEWS.d/next/Build/2026-09-07-00-30-00.gh-issue-156895.Jakqud.rst
@@ -1,0 +1,1 @@
+Document the ``CXX`` environment variable in the :program:`configure` ``--help`` output.

--- a/Misc/NEWS.d/next/Build/2026-09-07-00-30-00.gh-issue-156895.Jakqud.rst
+++ b/Misc/NEWS.d/next/Build/2026-09-07-00-30-00.gh-issue-156895.Jakqud.rst
@@ -1,1 +1,0 @@
-Document the ``CXX`` environment variable in the :program:`configure` ``--help`` output.

--- a/configure
+++ b/configure
@@ -1175,6 +1175,7 @@ LDFLAGS
 LIBS
 CPPFLAGS
 CPP
+CXX
 PROFILE_TASK
 BOLT_COMMON_FLAGS
 BOLT_INSTRUMENT_FLAGS
@@ -2030,6 +2031,7 @@ Some influential environment variables:
   CPPFLAGS    (Objective) C/C++ preprocessor flags, e.g. -I<include dir> if
               you have headers in a nonstandard directory <include dir>
   CPP         C preprocessor
+  CXX         C++ compiler command
   PROFILE_TASK
               Python args for PGO generation task
   BOLT_COMMON_FLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -1148,7 +1148,7 @@ AC_CACHE_CHECK([for GCC compatible compiler],
                [ac_cv_gcc_compat=yes],
                [ac_cv_gcc_compat=no])])
 
-AC_SUBST([CXX])
+AC_ARG_VAR([CXX], [C++ compiler command])
 
 preset_cxx="$CXX"
 if test -z "$CXX"


### PR DESCRIPTION
`configure.ac` detects and uses `CXX` for the C++ compiler, but never declares it with `AC_ARG_VAR`, so `./configure --help` never lists it next to `CC`. This adds `AC_ARG_VAR([CXX], [C++ compiler command])` so it shows up the same way `CC` already does, and regenerates `configure` with autoconf 2.72.

Fixes #156895


<!-- gh-issue-number: gh-156895 -->
* Issue: gh-156895
<!-- /gh-issue-number -->
