### PR TITLE
gh-157047: Support sharing of `complex` types in subinterpreters

### DIFF
--- a/Doc/library/concurrent.interpreters.rst
+++ b/Doc/library/concurrent.interpreters.rst
@@ -189,6 +189,7 @@ objects are either directly shared or copied efficiently.  For example:
 * :class:`str`
 * :class:`int`
 * :class:`float`
+* :class:`complex`
 * :class:`tuple` (of similarly supported objects)
 
 There are a small number of Python types that actually share mutable

--- a/Lib/test/test__interpreters.py
+++ b/Lib/test/test__interpreters.py
@@ -104,6 +104,7 @@ class IsShareableTests(unittest.TestCase):
                 True,
                 False,
                 100.0,
+                1+2j,
                 (1, ('spam', 'eggs')),
                 ]
         for obj in shareables:
@@ -603,6 +604,7 @@ class RunStringTests(TestBase):
             'spam',
             b'spam',
             42,
+            1+2j,
         ]
         for obj in objects:
             with self.subTest(obj):

--- a/Lib/test/test_crossinterp.py
+++ b/Lib/test/test_crossinterp.py
@@ -124,6 +124,10 @@ BUILTIN_SIMPLE = [
     -1.0,
     0.12345678,
     -0.12345678,
+    # complex
+    0j,
+    1+2j,
+    -1-2j,
 ]
 TUPLE_EXCEPTION = (0, 1.0, EXCEPTION)
 TUPLE_OBJECT = (0, 1.0, OBJECT)
@@ -1325,6 +1329,9 @@ class ShareableTypeTests(_GetXIDataTests):
             0.12345678,
             -0.12345678,
         ])
+
+    def test_complex(self):
+        self.assert_roundtrip_equal([0j, 1+2j, -1-2j, 1.5+2.5j])
 
     def test_tuple(self):
         self.assert_roundtrip_equal([

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -1306,6 +1306,7 @@ class TestInterpreterCall(TestBase):
         for arg in [
             None,
             10,
+            1+2j,
             'spam!',
             b'spam!',
             (1, 2, 'spam!'),
@@ -1903,6 +1904,7 @@ class TestIsShareable(TestBase):
                 True,
                 False,
                 100.0,
+                1+2j,
                 (),
                 (1, ('spam', 'eggs'), True),
                 ]

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-09-06-22-43-15.gh-issue-157047.ecyJp1.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-09-06-22-43-15.gh-issue-157047.ecyJp1.rst
@@ -1,0 +1,1 @@
+Support sharing of :class:`complex` types in subinterpreters.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-09-06-22-43-15.gh-issue-157047.ecyJp1.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-09-06-22-43-15.gh-issue-157047.ecyJp1.rst
@@ -1,1 +1,1 @@
-Support sharing of :class:`complex` types in subinterpreters.
+Added support for sharing of :class:`complex` type with interpreters API.

--- a/Python/crossinterp_data_lookup.h
+++ b/Python/crossinterp_data_lookup.h
@@ -555,6 +555,30 @@ _float_shared(PyThreadState *tstate, PyObject *obj, _PyXIData_t *xidata)
     return 0;
 }
 
+// complex
+
+static PyObject *
+_new_complex_object(_PyXIData_t *xidata)
+{
+    Py_complex * value_ptr = xidata->data;
+    return PyComplex_FromCComplex(*value_ptr);
+}
+
+static int
+_complex_shared(PyThreadState *tstate, PyObject *obj, _PyXIData_t *xidata)
+{
+    if (_PyXIData_InitWithSize(
+            xidata, tstate->interp, sizeof(Py_complex), NULL,
+            _new_complex_object
+            ) < 0)
+    {
+        return -1;
+    }
+    Py_complex *shared = (Py_complex *)xidata->data;
+    *shared = PyComplex_AsCComplex(obj);
+    return 0;
+}
+
 // None
 
 static PyObject *
@@ -823,6 +847,11 @@ _register_builtins_for_crossinterpreter_data(dlregistry_t *xidregistry)
     // float
     if (REGISTER(&PyFloat_Type, _float_shared) != 0) {
         Py_FatalError("could not register float for cross-interpreter sharing");
+    }
+
+    // complex
+    if (REGISTER(&PyComplex_Type, _complex_shared) != 0) {
+        Py_FatalError("could not register complex for cross-interpreter sharing");
     }
 
     // tuple

--- a/Python/crossinterp_data_lookup.h
+++ b/Python/crossinterp_data_lookup.h
@@ -560,7 +560,7 @@ _float_shared(PyThreadState *tstate, PyObject *obj, _PyXIData_t *xidata)
 static PyObject *
 _new_complex_object(_PyXIData_t *xidata)
 {
-    Py_complex * value_ptr = xidata->data;
+    Py_complex *value_ptr = xidata->data;
     return PyComplex_FromCComplex(*value_ptr);
 }
 


### PR DESCRIPTION
This PR adds support for sharing `complex` types in subinterpreters similar to `int`/`float` which is much faster than going via pickle.

<!-- gh-issue-number: gh-157047 -->
* Issue: gh-157047
<!-- /gh-issue-number -->
