### PR TITLE
gh-156866: Document that pack_into() does not guarantee memory access shape

### DIFF
--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -70,6 +70,13 @@ The module defines the following exception and functions:
    position *offset*.  Note that *offset* is a required argument.
    A negative *offset* counts from the end of *buffer*.
 
+   .. note::
+
+      This function only specifies the packed bytes written to *buffer*; it
+      does not guarantee the number, width, or ordering of the underlying
+      memory accesses used to write them, including for buffers backed by
+      memory-mapped I/O.
+
 
 .. function:: unpack(format, buffer)
 


### PR DESCRIPTION
struct.pack_into() only documents which bytes end up in the buffer, not how the write happens underneath. On ordinary memory that distinction never matters, but on a buffer backed by memory-mapped I/O the number, width, and ordering of the actual stores can be significant, and a single pack_into() call isn't guaranteed to turn into one native store. This adds a short note to that effect so nobody assumes pack_into() is a register-width MMIO write primitive.

Fixes #156866

<!-- gh-issue-number: gh-156866 -->
* Issue: gh-156866
<!-- /gh-issue-number -->
