### PR TITLE
[3.13] Fix unused value warnings and clean up unused map() in standard library modules (GH - 157053)

### DIFF
--- a/Lib/_markupbase.py
+++ b/Lib/_markupbase.py
@@ -221,7 +221,7 @@ class ParserBase:
                 if (j + 1) == n:
                     # end of buffer; incomplete
                     return -1
-                s, j = self._scan_name(j + 1, declstartpos)
+                _, j = self._scan_name(j + 1, declstartpos)
                 if j < 0:
                     return j
                 if rawdata[j] == ";":
@@ -286,7 +286,7 @@ class ParserBase:
                     # end of buffer, incomplete
                     return -1
             else:
-                name, j = self._scan_name(j, declstartpos)
+                _, j = self._scan_name(j, declstartpos)
             c = rawdata[j:j+1]
             if not c:
                 return -1
@@ -303,7 +303,7 @@ class ParserBase:
                 if rawdata[j:] == "#":
                     # end of buffer
                     return -1
-                name, j = self._scan_name(j + 1, declstartpos)
+                _, j = self._scan_name(j + 1, declstartpos)
                 if j < 0:
                     return j
                 c = rawdata[j:j+1]

--- a/Lib/idlelib/multicall.py
+++ b/Lib/idlelib/multicall.py
@@ -192,7 +192,7 @@ class _ComplexBinder:
         self.typename = _types[type][0]
         self.widget = widget
         self.widgetinst = widgetinst
-        self.bindedfuncs = {None: [[] for s in _states]}
+        self.bindedfuncs = {None: [[] for _ in _states]}
         self.handlerids = []
         # we don't want to change the lists of functions while a handler is
         # running - it will mess up the loop and anyway, we usually want the
@@ -212,7 +212,7 @@ class _ComplexBinder:
 
     def bind(self, triplet, func):
         if triplet[2] not in self.bindedfuncs:
-            self.bindedfuncs[triplet[2]] = [[] for s in _states]
+            self.bindedfuncs[triplet[2]] = [[] for _ in _states]
             for s in _states:
                 lists = [ self.bindedfuncs[detail][i]
                           for detail in (triplet[2], None)

--- a/Lib/idlelib/searchengine.py
+++ b/Lib/idlelib/searchengine.py
@@ -180,7 +180,7 @@ class SearchEngine:
                 wrapped = 1
                 wrap = 0
                 pos = text.index("end-1c")
-                line, col = map(int, pos.split("."))
+                line = int(pos.split(".")[0])
             chars = text.get("%d.0" % line, "%d.0" % (line+1))
             col = len(chars) - 1
         return None

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -4092,7 +4092,7 @@ if __name__ == "__main__":
         write("start", 1)
         color("red")
         # staircase
-        for i in range(5):
+        for _ in range(5):
             forward(20)
             left(90)
             forward(20)


### PR DESCRIPTION
Fixes #157053

Replaced unused variables with `_` in `Lib/_markupbase.py`, `Lib/idlelib/multicall.py`, `Lib/turtle.py` to address static analysis warnings.
Remove redundant `map()` call in `Lib/idlelib/searchengine.py`