### PR TITLE
gh-155292: Skip updating unicodedata with mismatched interpreter

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-09-07-15-13-19.gh-issue-155292._WNxL7.rst
+++ b/Misc/NEWS.d/next/Build/2026-09-07-15-13-19.gh-issue-155292._WNxL7.rst
@@ -1,0 +1,3 @@
+In ``makeunicodedata.py``, the script for updating Unicode data, skip
+generating ``stringprep.py`` if the current interpreter's Unicode data
+version does not match the target version.

--- a/Tools/unicode/makeunicodedata.py
+++ b/Tools/unicode/makeunicodedata.py
@@ -816,9 +816,30 @@ def makeunicodename(unicode, trace):
 def makestringprep():
     FILE = "Lib/stringprep.py"
 
+    RFC_LOCAL = os.path.join(DATA_DIR, "rfc3454.txt")
+    RFC_URL = "https://www.rfc-editor.org/rfc/rfc3454.txt"
+
     print("--- Preparing", FILE, "...")
 
+    # mkstringprep expects a local copy of RFC 3454. Download it now.
+    # (stringprep is used for URL handling, and if it's not matched
+    # with the compiled unicodedata, downloads would fail.)
+    if not os.path.exists(RFC_LOCAL):
+        download_data(RFC_LOCAL, RFC_URL)
+
     MKSTRINGPREP = "Tools/unicode/mkstringprep.py"
+
+    # mkstringprep needs to be run with a Python version that has "its"
+    # unicode data, since it uses str.lower() and similar.
+    import unicodedata
+    if unicodedata.unidata_version != UNIDATA_VERSION:
+        print()
+        print("!! Skipping mkstringprep -- mimatched Unicode version !!")
+        print()
+        print("Please compile CPython with the updated Unicode database,")
+        print("then use that interpreter to run:")
+        print(f"    python {MKSTRINGPREP} > {FILE}")
+        return
 
     with open(FILE, "w") as f:
         f.truncate()
@@ -934,19 +955,24 @@ DATA_DIR = os.path.join('Tools', 'unicode', 'data')
 def open_data(template, version):
     local = os.path.join(DATA_DIR, template % ('-'+version,))
     if not os.path.exists(local):
-        import urllib.request
         if version == '3.2.0':
             # irregular url structure
             url = ('https://www.unicode.org/Public/3.2-Update/'+template) % ('-'+version,)
         else:
             url = ('https://www.unicode.org/Public/%s/ucd/'+template) % (version, '')
-        os.makedirs(os.path.dirname(local), exist_ok=True)
-        urllib.request.urlretrieve(url, filename=local)
+        download_data(local, url)
     if local.endswith('.txt'):
         return open(local, encoding='utf-8')
     else:
         # Unihan.zip
         return open(local, 'rb')
+
+
+def download_data(local, url):
+    import urllib.request
+    os.makedirs(os.path.dirname(local), exist_ok=True)
+    print(f'Downloading {url} to {local}')
+    urllib.request.urlretrieve(url, filename=local)
 
 
 def expand_range(char_range: str) -> Iterator[int]:

--- a/Tools/unicode/makeunicodedata.py
+++ b/Tools/unicode/makeunicodedata.py
@@ -837,7 +837,7 @@ def makestringprep():
     import unicodedata
     if unicodedata.unidata_version != UNIDATA_VERSION:
         print()
-        print("!! Skipping mkstringprep -- mimatched Unicode version !!")
+        print("!! Skipping mkstringprep -- mismatched Unicode version !!")
         print()
         print("Please compile CPython with the updated Unicode database,")
         print("then use that interpreter to run:")

--- a/Tools/unicode/makeunicodedata.py
+++ b/Tools/unicode/makeunicodedata.py
@@ -40,6 +40,9 @@ from typing import Iterator, List, Optional, Set, Tuple
 SCRIPT = os.path.normpath(sys.argv[0])
 VERSION = "3.3"
 
+# Local cache location
+DATA_DIR = os.path.join('Tools', 'unicode', 'data')
+
 # The Unicode Database
 # --------------------
 # When changing UCD version please update
@@ -949,8 +952,6 @@ def merge_old_version(version, new, old):
                                           numeric_changes)),
                         normalization_changes))
 
-
-DATA_DIR = os.path.join('Tools', 'unicode', 'data')
 
 def open_data(template, version):
     local = os.path.join(DATA_DIR, template % ('-'+version,))

--- a/Tools/unicode/mkstringprep.py
+++ b/Tools/unicode/mkstringprep.py
@@ -3,9 +3,6 @@ import os
 import unicodedata as unicodedata_current
 from unicodedata import ucd_3_2_0 as unicodedata_320
 
-FILENAME = "Tools/unicode/data/rfc3454.txt"
-URL = "https://www.rfc-editor.org/rfc/rfc3454.txt"
-
 def gen_category(cats):
     for i in range(0, 0x110000):
         if unicodedata_320.category(chr(i)) in cats:
@@ -52,15 +49,7 @@ def compact_set(l):
 
 ############## Read the tables in the RFC #######################
 
-try:
-    data_file = open(FILENAME, encoding='utf-8')
-except FileNotFoundError:
-    import urllib.request
-    os.makedirs(os.path.dirname(FILENAME), exist_ok=True)
-    urllib.request.urlretrieve(URL, filename=FILENAME)
-    data_file = open(FILENAME, encoding='utf-8')
-
-with data_file:
+with open("Tools/unicode/data/rfc3454.txt", encoding='utf-8') as data_file:
     data = data_file.readlines()
 
 tables = []

--- a/Tools/unicode/mkstringprep.py
+++ b/Tools/unicode/mkstringprep.py
@@ -1,5 +1,4 @@
 import re
-import os
 import unicodedata as unicodedata_current
 from unicodedata import ucd_3_2_0 as unicodedata_320
 


### PR DESCRIPTION
mkstringprep uses things like str.lower(), so it generates the wrong
result if run in an interpreter with a different Unicode data version
than the target.

This means that updating the Unicode version is a two-step process:
run makeunicodedata.py, then compile, then run mkstringprep.py.

The two steps can (and should) be combined when re-running
regen-unicodedata to verify that the data is up to date.
The https://github.com/python/cpython/issues/155292 fix only considered that case.

Change makeunicodedata.py to only run mkstringprep.py when the
current interpreter is up to it. Otherwise, show a reminder.

For an extra complication, download the input (rcf3454.txt) in
the "first step", since an out-of-date stringprep.py's freshness
assertion may break URL encoding in urllib.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-155292 -->
* Issue: gh-155292
<!-- /gh-issue-number -->
