### PR TITLE
gh-156939: Fix struct.pack('0p', bytes)

### DIFF
--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -2424,7 +2424,9 @@ s_pack_internal(PyStructObject *soself, PyObject *const *args,
                     memcpy(res + 1, p, n);
                 if (n > 255)
                     n = 255;
-                *res = Py_SAFE_DOWNCAST(n, Py_ssize_t, unsigned char);
+                if (n > 0) {
+                    *res = Py_SAFE_DOWNCAST(n, Py_ssize_t, unsigned char);
+                }
             } else {
                 if (e->pack(state, res, v, e) < 0) {
                     if (PyLong_Check(v) && PyErr_ExceptionMatches(PyExc_OverflowError))


### PR DESCRIPTION
If the Pascal string is empty (size=0), do not write the size prefix. Previously, a NUL byte was written outsize the buffer (buffer overflow).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156939 -->
* Issue: gh-156939
<!-- /gh-issue-number -->
