### PR TITLE
gh-156939: Fix xmlcharrefreplace() buffer overflow

### DIFF
--- a/Misc/NEWS.d/next/Security/2026-09-07-22-32-49.gh-issue-156939.vXc73v.rst
+++ b/Misc/NEWS.d/next/Security/2026-09-07-22-32-49.gh-issue-156939.vXc73v.rst
@@ -1,4 +1,0 @@
-Fix a buffer overflow in the ``xmlcharrefreplace`` error handler of 8-bit
-encoding (such as ``ascii`` and ``latin1``). Previously, a buffer overflow
-wrote one NUL byte in the stack memory if the output length was exactly 512
-bytes. Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/Security/2026-09-07-22-32-49.gh-issue-156939.vXc73v.rst
+++ b/Misc/NEWS.d/next/Security/2026-09-07-22-32-49.gh-issue-156939.vXc73v.rst
@@ -1,0 +1,4 @@
+Fix a buffer overflow in the ``xmlcharrefreplace`` error handler of 8-bit
+encoding (such as ``ascii`` and ``latin1``). Previously, a buffer overflow
+wrote one NUL byte in the stack memory if the output length was exactly 512
+bytes. Patch by Victor Stinner.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -886,7 +886,7 @@ xmlcharrefreplace(PyBytesWriter *writer, char *str,
         char buffer[11];
         Py_UCS4 ch = PyUnicode_READ(kind, data, i);
         size = snprintf(buffer, sizeof(buffer), "&#%d;", ch);
-        assert(5 <= size && (size_t)size <= (sizeof(buffer) - 1));
+        assert(4 <= size && (size_t)size <= (sizeof(buffer) - 1));
 
         memcpy(str, buffer, size);
         str += size;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -879,10 +879,16 @@ xmlcharrefreplace(PyBytesWriter *writer, char *str,
 
     /* generate replacement */
     for (i = collstart; i < collend; ++i) {
-        size = sprintf(str, "&#%d;", PyUnicode_READ(kind, data, i));
-        if (size < 0) {
-            return NULL;
-        }
+        // Use snprintf() with a temporary buffer to not write the trailing
+        // NUL byte in the writer buffer.
+        Py_BUILD_ASSERT(_Py_MAX_UNICODE <= 0x10ffff);
+        // len('&#1114111;\0') is 11 bytes.
+        char buffer[11];
+        Py_UCS4 ch = PyUnicode_READ(kind, data, i);
+        size = snprintf(buffer, sizeof(buffer), "&#%d;", ch);
+        assert(5 <= size && (size_t)size <= (sizeof(buffer) - 1));
+
+        memcpy(str, buffer, size);
         str += size;
     }
     return str;


### PR DESCRIPTION
Write into a temporay buffer to not write the trailing NUL byte.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156939 -->
* Issue: gh-156939
<!-- /gh-issue-number -->
