### PR TITLE
gh-157127: Reword the argparse mutually exclusive group error message

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -2099,7 +2099,7 @@ Mutual exclusion
      >>> group.add_argument('--bar', action='store_false')
      >>> parser.parse_args([])
      usage: PROG [-h] (--foo | --bar)
-     PROG: error: one of the arguments --foo, --bar is required
+     PROG: error: one of the following arguments is required: --foo, --bar
 
    Note that currently mutually exclusive argument groups do not support the
    *title* and *description* arguments of

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -2099,7 +2099,7 @@ Mutual exclusion
      >>> group.add_argument('--bar', action='store_false')
      >>> parser.parse_args([])
      usage: PROG [-h] (--foo | --bar)
-     PROG: error: one of the arguments --foo --bar is required
+     PROG: error: one of the arguments --foo, --bar is required
 
    Note that currently mutually exclusive argument groups do not support the
    *title* and *description* arguments of

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2499,7 +2499,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                     names = [_get_action_name(action)
                              for action in group._group_actions
                              if action.help is not SUPPRESS]
-                    msg = _('one of the arguments %s is required')
+                    msg = _('one of the following arguments is required: %s')
                     raise ArgumentError(None, msg % ', '.join(names))
 
         # return the updated namespace and the extra arguments

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2500,7 +2500,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                              for action in group._group_actions
                              if action.help is not SUPPRESS]
                     msg = _('one of the arguments %s is required')
-                    raise ArgumentError(None, msg % ' '.join(names))
+                    raise ArgumentError(None, msg % ', '.join(names))
 
         # return the updated namespace and the extra arguments
         return namespace, extras

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -6866,7 +6866,7 @@ class TestIntermixedArgs(TestCase):
         args = parser.parse_intermixed_args('1 --foo 2'.split())
         self.assertEqual(NS(badger=['1', '2'], foo=True, spam=None), args)
         self.assertRaisesRegex(argparse.ArgumentError,
-                'one of the arguments --foo --spam is required',
+                'one of the arguments --foo, --spam is required',
                 parser.parse_intermixed_args, '1 2'.split())
         self.assertEqual(group.required, True)
 
@@ -6882,7 +6882,7 @@ class TestIntermixedArgs(TestCase):
         args = parser.parse_intermixed_args(['a', 'b'])
         self.assertEqual(NS(foo=False, spam=None, badger=['a', 'b']), args)
         self.assertRaisesRegex(argparse.ArgumentError,
-                'one of the arguments --foo --spam badger is required',
+                'one of the arguments --foo, --spam, badger is required',
                 parser.parse_intermixed_args, [])
         self.assertRaisesRegex(argparse.ArgumentError,
                 'argument badger: not allowed with argument --foo',
@@ -7258,7 +7258,7 @@ class TestExitOnError(TestCase):
         group.add_argument('--bar')
         group.add_argument('--baz')
         self.assertRaisesRegex(argparse.ArgumentError,
-                               'one of the arguments --bar --baz is required',
+                               'one of the arguments --bar, --baz is required',
                                self.parser.parse_args, [])
 
     def test_conflicting_mutually_exclusive_args_optional_with_metavar(self):

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -6866,7 +6866,7 @@ class TestIntermixedArgs(TestCase):
         args = parser.parse_intermixed_args('1 --foo 2'.split())
         self.assertEqual(NS(badger=['1', '2'], foo=True, spam=None), args)
         self.assertRaisesRegex(argparse.ArgumentError,
-                'one of the arguments --foo, --spam is required',
+                'one of the following arguments is required: --foo, --spam',
                 parser.parse_intermixed_args, '1 2'.split())
         self.assertEqual(group.required, True)
 
@@ -6882,7 +6882,7 @@ class TestIntermixedArgs(TestCase):
         args = parser.parse_intermixed_args(['a', 'b'])
         self.assertEqual(NS(foo=False, spam=None, badger=['a', 'b']), args)
         self.assertRaisesRegex(argparse.ArgumentError,
-                'one of the arguments --foo, --spam, badger is required',
+                'one of the following arguments is required: --foo, --spam, badger',
                 parser.parse_intermixed_args, [])
         self.assertRaisesRegex(argparse.ArgumentError,
                 'argument badger: not allowed with argument --foo',
@@ -7258,7 +7258,7 @@ class TestExitOnError(TestCase):
         group.add_argument('--bar')
         group.add_argument('--baz')
         self.assertRaisesRegex(argparse.ArgumentError,
-                               'one of the arguments --bar, --baz is required',
+                               'one of the following arguments is required: --bar, --baz',
                                self.parser.parse_args, [])
 
     def test_conflicting_mutually_exclusive_args_optional_with_metavar(self):

--- a/Lib/test/translationdata/argparse/msgids.txt
+++ b/Lib/test/translationdata/argparse/msgids.txt
@@ -18,7 +18,7 @@ invalid %(type)s value: %(value)r
 invalid choice: %(value)r (choose from %(choices)s)
 invalid choice: %(value)r, maybe you meant %(closest)r? (choose from %(choices)s)
 not allowed with argument %s
-one of the arguments %s is required
+one of the following arguments is required: %s
 option '%(option)s' is deprecated
 options
 positional arguments

--- a/Misc/NEWS.d/next/Library/2026-09-08-00-31-56.gh-issue-157127.gduPd0.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-08-00-31-56.gh-issue-157127.gduPd0.rst
@@ -1,0 +1,2 @@
+Separate the argument names with commas in the :mod:`argparse` error message
+reported for a missing required mutually exclusive group.

--- a/Misc/NEWS.d/next/Library/2026-09-08-00-31-56.gh-issue-157127.gduPd0.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-08-00-31-56.gh-issue-157127.gduPd0.rst
@@ -1,2 +1,3 @@
-Separate the argument names with commas in the :mod:`argparse` error message
-reported for a missing required mutually exclusive group.
+Reword the :mod:`argparse` error message reported for a missing required
+mutually exclusive group to ``one of the following arguments is required:
+--foo, --bar``, so that the argument names are separated by commas.


### PR DESCRIPTION
When a required mutually exclusive group is not satisfied, argparse joins the
argument names with a plain space:

```
error: one of the arguments --stdout repository is required
```

With a positional in the group this reads as broken grammar, since nothing
separates one name from the next.

The error for missing required arguments a few lines above in
`_parse_known_args()` puts its names at the end of the sentence and joins them
with `', '`. This makes the mutually exclusive group error do the same:

```
error: one of the following arguments is required: --stdout, repository
```

The doc example and the three affected test assertions are updated to match.

Fixes #157127


<!-- gh-issue-number: gh-157127 -->
* Issue: gh-157127
<!-- /gh-issue-number -->
