### PR TITLE
gh-157135: Fix documentation errors in the half-turn `*pi` functions

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -90,7 +90,7 @@ noted otherwise, all return values are floats.
 :func:`atan(x) <atan>`                                Arc tangent of *x*, in radians
 :func:`atanpi(x) <atanpi>`                            Arc tangent of *x*, in half-turns
 :func:`atan2(y, x) <atan2>`                           ``atan(y / x)``, in radians
-:func:`atan2pi(y, x) <atan2pi>`                       ``atan(y / x)``, in half-turns
+:func:`atan2pi(y, x) <atan2pi>`                       ``atanpi(y / x)``, in half-turns
 :func:`cos(x) <cos>`                                  Cosine of *x* radians
 :func:`cospi(x) <cospi>`                              Cosine of *x⋅π* radians
 :func:`sin(x) <sin>`                                  Sine of *x* radians

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -256,7 +256,7 @@ m_asinpi(double x)
 
 #ifndef HAVE_ATANPI
 /*
-   asin(x)/pi.  It conforms to C23 Annex 'F'.
+   atan(x)/pi.  It conforms to C23 Annex 'F'.
 */
 
 static double
@@ -274,7 +274,7 @@ m_atanpi(double x)
 
 #ifndef HAVE_ATAN2PI
 /*
-   asin(x)/pi.  It conforms to C23 Annex 'F'.
+   atan2(y, x)/pi.  It conforms to C23 Annex 'F'.
 */
 
 static double
@@ -1136,7 +1136,7 @@ FUNC1D(atanh, atanh, 0,
 FUNC1D(atanpi, m_atanpi, 0,
       "atanpi($module, x, /)\n--\n\n"
       "Return the arc tangent (measured in half-turns) of x.\n\n"
-      "The result is between 0 and 1.",
+      "The result is between -1/2 and 1/2.",
       "expected a number in range from -1 up to 1, got %s")
 FUNC1(cbrt, cbrt, 0,
       "cbrt($module, x, /)\n--\n\n"


### PR DESCRIPTION
`atanpi`'s docstring gave `acospi`'s result range, the trigonometric summary table in `Doc/library/math.rst` described `atan2pi` with `atan`'s formula, and the comments above `m_atanpi` and `m_atan2pi` both read `asin(x)/pi`. This corrects the four statements to say what the functions compute.

No changelog entry: these functions have not been released.


<!-- gh-issue-number: gh-157135 -->
* Issue: gh-157135
<!-- /gh-issue-number -->
