### PR TITLE
gh-157142: Fix linking _freeze_module with built-in test modules

### DIFF
--- a/Misc/NEWS.d/next/Build/2026-09-07-23-40-00.gh-issue-157142.gpnoop.rst
+++ b/Misc/NEWS.d/next/Build/2026-09-07-23-40-00.gh-issue-157142.gpnoop.rst
@@ -1,0 +1,4 @@
+Fix the link of ``Programs/_freeze_module`` when extension modules are built
+in (``MODULE_BUILDTYPE=static``) and the test modules are enabled:
+``Modules/getpath_noop.c`` now defines ``_Py_Get_Getpath_CodeObject()``,
+which ``_testinternalcapi`` uses.

--- a/Modules/getpath_noop.c
+++ b/Modules/getpath_noop.c
@@ -1,10 +1,21 @@
 /* Implements the getpath API for compiling with no functionality */
 
 #include "Python.h"
-#include "pycore_pathconfig.h"
+#include "pycore_initconfig.h"    // _Py_Get_Getpath_CodeObject()
+#include "pycore_pathconfig.h"    // _PyConfig_InitPathConfig()
 
 PyStatus
 _PyConfig_InitPathConfig(PyConfig *config, int compute_path_config)
 {
     return PyStatus_Error("path configuration is unsupported");
+}
+
+/* Used by _testinternalcapi, which is linked into Programs/_freeze_module
+   when extension modules are built in (MODULE_BUILDTYPE=static). */
+PyObject *
+_Py_Get_Getpath_CodeObject(void)
+{
+    PyErr_SetString(PyExc_RuntimeError,
+                    "path configuration is unsupported");
+    return NULL;
 }


### PR DESCRIPTION
Programs/_freeze_module is linked with Modules/getpath_noop.o rather than Modules/getpath.o, and getpath_noop.c only defined _PyConfig_InitPathConfig(). With MODULE_BUILDTYPE=static (the default on wasm), _testinternalcapi.o is part of LIBRARY_OBJS_OMIT_FROZEN and its get_getpath_codeobject() left _Py_Get_Getpath_CodeObject() as an undefined reference. Define a stub for it.

<!-- gh-issue-number: gh-157142 -->
* Issue: gh-157142
<!-- /gh-issue-number -->
