### PR TITLE
gh-131178: Add tests for `ensurepip` command-line interface

### DIFF
--- a/Lib/test/test_ensurepip.py
+++ b/Lib/test/test_ensurepip.py
@@ -342,6 +342,115 @@ class TestBootstrappingMainFunction(EnsurepipMixin, unittest.TestCase):
         exit_code = ensurepip._main([])
         self.assertEqual(exit_code, 2)
 
+    def test_bootstrapping_with_root(self):
+        exit_code = ensurepip._main(["--root", "/foo/bar/"])
+
+        self.run_pip.assert_called_once_with(
+            [
+                "install", "--no-cache-dir", "--no-index", "--find-links",
+                unittest.mock.ANY, "--root", "/foo/bar/", *COMPILE_OPT,
+                "pip",
+            ],
+            unittest.mock.ANY,
+        )
+        self.assertEqual(exit_code, 0)
+
+    def test_bootstrapping_with_user(self):
+        ensurepip._main(["--user"])
+
+        self.run_pip.assert_called_once_with(
+            [
+                "install", "--no-cache-dir", "--no-index", "--find-links",
+                unittest.mock.ANY, "--user", *COMPILE_OPT, "pip",
+            ],
+            unittest.mock.ANY,
+        )
+
+    def test_bootstrapping_with_upgrade(self):
+        for option in ("--upgrade", "-U"):
+            with self.subTest(option=option):
+                self.run_pip.reset_mock()
+                ensurepip._main([option])
+
+                self.run_pip.assert_called_once_with(
+                    [
+                        "install", "--no-cache-dir", "--no-index",
+                        "--find-links", unittest.mock.ANY, "--upgrade",
+                        *COMPILE_OPT, "pip",
+                    ],
+                    unittest.mock.ANY,
+                )
+
+    def test_bootstrapping_with_verbosity(self):
+        for argv, expected in (
+            (["-v"], "-v"),
+            (["--verbose"], "-v"),
+            (["-vv"], "-vv"),
+            (["-v", "-v", "-v"], "-vvv"),
+        ):
+            with self.subTest(argv=argv):
+                self.run_pip.reset_mock()
+                ensurepip._main(argv)
+
+                self.run_pip.assert_called_once_with(
+                    [
+                        "install", "--no-cache-dir", "--no-index",
+                        "--find-links", unittest.mock.ANY, expected,
+                        *COMPILE_OPT, "pip",
+                    ],
+                    unittest.mock.ANY,
+                )
+
+    def test_bootstrapping_with_altinstall(self):
+        ensurepip._main(["--altinstall"])
+        self.assertEqual(self.os_environ["ENSUREPIP_OPTIONS"], "altinstall")
+
+    def test_bootstrapping_with_default_pip(self):
+        ensurepip._main(["--default-pip"])
+        self.assertNotIn("ENSUREPIP_OPTIONS", self.os_environ)
+
+    def test_altinstall_default_pip_conflict(self):
+        with self.assertRaises(ValueError):
+            ensurepip._main(["--altinstall", "--default-pip"])
+        self.assertFalse(self.run_pip.called)
+
+    def test_bootstrapping_with_all_options(self):
+        # The order of the options on the command line doesn't matter.
+        exit_code = ensurepip._main([
+            "-v", "--user", "--upgrade", "--root", "/foo/bar/",
+            "--altinstall", "-v",
+        ])
+
+        self.run_pip.assert_called_once_with(
+            [
+                "install", "--no-cache-dir", "--no-index", "--find-links",
+                unittest.mock.ANY, "--root", "/foo/bar/", "--upgrade",
+                "--user", "-vv", *COMPILE_OPT, "pip",
+            ],
+            unittest.mock.ANY,
+        )
+        self.assertEqual(self.os_environ["ENSUREPIP_OPTIONS"], "altinstall")
+        self.assertEqual(exit_code, 0)
+
+    def test_help(self):
+        with test.support.captured_stdout() as stdout:
+            with self.assertRaises(SystemExit) as cm:
+                ensurepip._main(["--help"])
+        self.assertEqual(cm.exception.code, 0)
+        help_text = stdout.getvalue()
+        for option in ("--version", "--verbose", "--upgrade", "--user",
+                       "--root", "--altinstall", "--default-pip"):
+            self.assertIn(option, help_text)
+        self.assertFalse(self.run_pip.called)
+
+    def test_unknown_option(self):
+        with test.support.captured_stderr() as stderr:
+            with self.assertRaises(SystemExit) as cm:
+                ensurepip._main(["--unknown"])
+        self.assertEqual(cm.exception.code, 2)
+        self.assertIn("unrecognized arguments: --unknown", stderr.getvalue())
+        self.assertFalse(self.run_pip.called)
+
 
 class TestUninstallationMainFunction(EnsurepipMixin, unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Tests/2026-09-08-02-05-00.gh-issue-131178.siIaKc.rst
+++ b/Misc/NEWS.d/next/Tests/2026-09-08-02-05-00.gh-issue-131178.siIaKc.rst
@@ -1,1 +1,0 @@
-Add tests for the :mod:`ensurepip` command-line interface.

--- a/Misc/NEWS.d/next/Tests/2026-09-08-02-05-00.gh-issue-131178.siIaKc.rst
+++ b/Misc/NEWS.d/next/Tests/2026-09-08-02-05-00.gh-issue-131178.siIaKc.rst
@@ -1,0 +1,1 @@
+Add tests for the :mod:`ensurepip` command-line interface.


### PR DESCRIPTION
The [documented command-line interface](https://docs.python.org/dev/library/ensurepip.html#command-line-interface) of `ensurepip` has six options, but `test_ensurepip.py` only called `_main()` with `--version` and with no arguments. The options themselves were covered only through `bootstrap()`, so a mistake in the argument parser or in how `_main()` forwards the parsed options would not have been caught.

This adds tests to the existing `TestBootstrappingMainFunction` class, one per documented option, in the same style as the `TestBootstrap` tests (pip is mocked, the arguments passed to pip and `ENSUREPIP_OPTIONS` are asserted):

- `--root`, `--user`, `--upgrade` and `-U`, `-v` / `--verbose` / `-vv` / repeated `-v`
- `--altinstall`, `--default-pip`, and the documented exception when both are given
- all options together, checking the order of the options does not matter
- `--help` lists every documented option and does not run pip
- an unknown option exits with status 2 and does not run pip

Tests-only; a NEWS entry is included in the Tests section like the earlier PRs in this series that shipped one.

Ran `test_ensurepip` (also with `-R 3:3`), `make patchcheck` and the pre-commit hooks on macOS.


<!-- gh-issue-number: gh-131178 -->
* Issue: gh-131178
<!-- /gh-issue-number -->
