### PR TITLE
gh-157157: Make test_taskgroup_cancel_keeps_outer_cancellation deterministic

### DIFF
--- a/Lib/test/test_asyncio/test_taskgroups.py
+++ b/Lib/test/test_asyncio/test_taskgroups.py
@@ -1200,11 +1200,17 @@ class BaseTestTaskGroup:
 
     async def test_taskgroup_cancel_keeps_outer_cancellation(self):
         # gh-155433: any cancellation from outside the group must propagate.
+        cancelling = asyncio.Event()
+        release = asyncio.Event()
+
         async def child():
             try:
                 await asyncio.sleep(10)
             finally:
-                await asyncio.sleep(0.1)
+                # The group is cancelling: it has cancelled its parent task
+                # and is waiting for this task to finish.
+                cancelling.set()
+                await release.wait()
 
         async def body():
             async with asyncio.TaskGroup() as tg:
@@ -1213,8 +1219,9 @@ class BaseTestTaskGroup:
                 tg.cancel()
 
         task = asyncio.create_task(body())
-        await asyncio.sleep(0.01)
+        await cancelling.wait()
         task.cancel('message')
+        release.set()
         with self.assertRaises(asyncio.CancelledError) as cm:
             await task
         self.assertEqual('message', cm.exception.args[0])

--- a/Misc/NEWS.d/next/Tests/2026-09-08-02-40-00.gh-issue-157157.5X2ypw.rst
+++ b/Misc/NEWS.d/next/Tests/2026-09-08-02-40-00.gh-issue-157157.5X2ypw.rst
@@ -1,2 +1,0 @@
-Fix a timing dependence in ``test_taskgroup_cancel_keeps_outer_cancellation``
-in ``test_asyncio``, which failed on slow builds.

--- a/Misc/NEWS.d/next/Tests/2026-09-08-02-40-00.gh-issue-157157.5X2ypw.rst
+++ b/Misc/NEWS.d/next/Tests/2026-09-08-02-40-00.gh-issue-157157.5X2ypw.rst
@@ -1,0 +1,2 @@
+Fix a timing dependence in ``test_taskgroup_cancel_keeps_outer_cancellation``
+in ``test_asyncio``, which failed on slow builds.


### PR DESCRIPTION
Fixes the timing dependence described in the issue: the test cancelled the parent task from outside after `await asyncio.sleep(0.01)`, and lost the cancellation message whenever the loop stalled for more than 10 ms before the body task first ran (the mechanism, and a reproducer that stalls the loop with `time.sleep()`, are in the issue).

The test now synchronizes on two events instead of sleeping. The child signals from its `finally` block that the group is cancelling, which by then has cancelled the parent task and is waiting for the child, and waits there until the test releases it. Only then does the test cancel the parent task from outside. The ordering is fixed by the callback queue, not by time, so it holds on any build speed and for both task implementations.

Checked:

- The rewritten test passes for `TestTaskGroup` and `TestEagerTaskTaskGroup`, 10 of 10 repeated runs, and the whole `test_asyncio.test_taskgroups` module passes.
- With the gh-155433 fix reverted locally, the rewritten test still fails in both classes (`CancelledError not raised`), so it keeps guarding the bug it was written for.
- The event-based ordering was also verified in a standalone harness with the same 20 ms loop stall that makes the current test fail.

Since the original test was added by the gh-155433 fix, this likely wants the same backports.


<!-- gh-issue-number: gh-157157 -->
* Issue: gh-157157
<!-- /gh-issue-number -->
