### PR TITLE
gh-157159: improve the tabnanny usage message

### DIFF
--- a/Lib/tabnanny.py
+++ b/Lib/tabnanny.py
@@ -47,7 +47,7 @@ def main():
         if o == '-v':
             verbose = verbose + 1
     if not args:
-        errprint("Usage:", sys.argv[0], "[-v] file_or_directory ...")
+        errprint(f"Usage: {sys.executable} -m tabnanny [-v] file_or_directory ...")
     for arg in args:
         check(arg)
 

--- a/Lib/test/test_tabnanny.py
+++ b/Lib/test/test_tabnanny.py
@@ -7,12 +7,12 @@ Glossary:
 from unittest import TestCase, main, mock
 import errno
 import os
+import sys
 import tabnanny
 import tokenize
 import tempfile
 import textwrap
-from test.support import (captured_stderr, captured_stdout, script_helper,
-                          findfile)
+from test.support import captured_stderr, captured_stdout, script_helper
 from test.support.os_helper import unlink
 
 
@@ -328,8 +328,7 @@ class TestCommandLine(TestCase):
 
     def test_command_usage(self):
         """Should display usage on no arguments."""
-        path = findfile('tabnanny.py')
-        stderr = f"Usage: {path} [-v] file_or_directory ..."
+        stderr = f"Usage: {sys.executable} -m tabnanny [-v] file_or_directory ..."
         self.validate_cmd(stderr=stderr, expect_failure=True)
 
     def test_quiet_flag(self):

--- a/Misc/NEWS.d/next/Library/2026-09-08-09-30-00.gh-issue-157159.tabNny.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-08-09-30-00.gh-issue-157159.tabNny.rst
@@ -1,0 +1,2 @@
+The usage message printed by ``python -m tabnanny`` when no arguments are
+given now suggests ``python -m`` instead of the source file.


### PR DESCRIPTION
The usage message embedded sys.argv[0], which under `python -m tabnanny` is the absolute path of tabnanny.py, and a meaningless virtual path when the standard library is in a zip archive or embedded in an executable. Print f"Usage: {sys.executable} -m tabnanny [-v] file_or_directory ..." instead, and make the test expect that form instead of a file that may not exist.

<!-- gh-issue-number: gh-157159 -->
* Issue: gh-157159
<!-- /gh-issue-number -->
