### PR TITLE
gh-157161: Fix test_rollover_based_on_st_birthtime_only on slow machines

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -6766,20 +6766,23 @@ class TimedRotatingFileHandlerTest(BaseFileTest):
         # At this point, the log file should be rotated if the rotation
         # is based on creation time but should be not if it's based on
         # modification time.  The rotated file is named after the creation
-        # time of the log file, so look back over the whole duration of the
-        # test, plus a margin: the file was created in setUp(), and the
-        # names have a resolution of one second.
-        found = False
+        # time of the log file, so search back over the whole time the test
+        # took rather than over a fixed number of seconds.
         now = datetime.datetime.now()
-        go_back = int((now - start).total_seconds()) + 2
-        for secs in range(go_back + 1):
+        test_duration = int((now - start).total_seconds())
+        # Two seconds of margin on top of that: the log file is created in
+        # setUp(), a moment before the test starts, and the name has a
+        # resolution of one second.
+        oldest = test_duration + 2
+        found = False
+        for secs in range(oldest + 1):   # inclusive of oldest
             prev = now - datetime.timedelta(seconds=secs)
             fn = self.fn + prev.strftime(".%Y-%m-%d_%H-%M-%S")
             found = os.path.exists(fn)
             if found:
                 self.rmfiles.append(fn)
                 break
-        msg = 'No rotated files found, went back %d seconds' % go_back
+        msg = 'No rotated files found, went back %d seconds' % oldest
         if not found:
             # print additional diagnostics
             dn, fn = os.path.split(self.fn)

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -6752,6 +6752,7 @@ class TimedRotatingFileHandlerTest(BaseFileTest):
             fh.emit(record)
             fh.close()
 
+        start = datetime.datetime.now()
         add_record('testing - initial')
         self.assertLogFile(self.fn)
         # Sleep a little over the half of rollover time - and this value
@@ -6764,18 +6765,21 @@ class TimedRotatingFileHandlerTest(BaseFileTest):
 
         # At this point, the log file should be rotated if the rotation
         # is based on creation time but should be not if it's based on
-        # modification time.
+        # modification time.  The rotated file is named after the creation
+        # time of the log file, so look back over the whole duration of the
+        # test, plus a margin: the file was created in setUp(), and the
+        # names have a resolution of one second.
         found = False
         now = datetime.datetime.now()
-        GO_BACK = 5 # seconds
-        for secs in range(GO_BACK + 1):
+        go_back = int((now - start).total_seconds()) + 2
+        for secs in range(go_back + 1):
             prev = now - datetime.timedelta(seconds=secs)
             fn = self.fn + prev.strftime(".%Y-%m-%d_%H-%M-%S")
             found = os.path.exists(fn)
             if found:
                 self.rmfiles.append(fn)
                 break
-        msg = 'No rotated files found, went back %d seconds' % GO_BACK
+        msg = 'No rotated files found, went back %d seconds' % go_back
         if not found:
             # print additional diagnostics
             dn, fn = os.path.split(self.fn)

--- a/Misc/NEWS.d/next/Tests/2026-09-08-03-20-00.gh-issue-157161.SGacVD.rst
+++ b/Misc/NEWS.d/next/Tests/2026-09-08-03-20-00.gh-issue-157161.SGacVD.rst
@@ -1,0 +1,3 @@
+Fix ``test_rollover_based_on_st_birthtime_only`` in ``test_logging`` on slow
+machines: search for the rotated file over the whole duration of the test
+instead of a fixed 5 seconds.

--- a/Misc/NEWS.d/next/Tests/2026-09-08-03-20-00.gh-issue-157161.SGacVD.rst
+++ b/Misc/NEWS.d/next/Tests/2026-09-08-03-20-00.gh-issue-157161.SGacVD.rst
@@ -1,3 +1,0 @@
-Fix ``test_rollover_based_on_st_birthtime_only`` in ``test_logging`` on slow
-machines: search for the rotated file over the whole duration of the test
-instead of a fixed 5 seconds.


### PR DESCRIPTION
The test looks for the rotated file by trying the timestamps of the last 5 seconds. The rotated file is named after the creation time of the log file (`rolloverAt - interval`, where `rolloverAt` was computed from the file's creation time), so it can only be found if the whole test took less than 5 seconds. Its nominal duration is 4.2 seconds of sleeps plus three handler set-ups, and on the failing CI job (diagnostics quoted in the issue) it took 6.07 seconds, so the file named after second 45 was never checked from second 51.

This derives the search window from the time the test actually took, plus two seconds: one because the log file is created in `setUp()`, slightly before the test starts, and one for the one-second resolution of the names.

Verified:

- With a 1.2 s slowdown injected into each `add_record()` (a 7.8 s test), the current test fails with exactly the CI message, `No rotated files found, went back 5 seconds`; with this change it passes.
- Without the slowdown it passes repeatedly, and the whole `test_logging` module passes with `-u walltime`.

The June change in GH-150954 widened the window by one timestamp; this makes it follow the actual duration so that no fixed value needs to be tuned again.


<!-- gh-issue-number: gh-157161 -->
* Issue: gh-157161
<!-- /gh-issue-number -->
