### PR TITLE
gh-157170: Restore use_env() after test_use_prescr_screen in test_curses

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -3459,6 +3459,10 @@ class ScreenTests(NewtermTestBase):
             with self.assertRaises(curses.error):
                 prescr.use(func)
         # Affecting the state before initscr() is what such a screen is for.
+        # use_env() sets a process-wide default rather than a property of the
+        # screen it is called on, so restore it: with it off, newterm() has no
+        # size for a terminfo entry without one (such as "linux") and fails.
+        self.addCleanup(curses.use_env, True)
         prescr.use(lambda scr: curses.use_env(False))
         # The current screen is unchanged.
         screen.stdscr.refresh()

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -3459,9 +3459,7 @@ class ScreenTests(NewtermTestBase):
             with self.assertRaises(curses.error):
                 prescr.use(func)
         # Affecting the state before initscr() is what such a screen is for.
-        # use_env() sets a process-wide default rather than a property of the
-        # screen it is called on, so restore it: with it off, newterm() has no
-        # size for a terminfo entry without one (such as "linux") and fails.
+        # use_env() is process-wide, not a property of this screen.
         self.addCleanup(curses.use_env, True)
         prescr.use(lambda scr: curses.use_env(False))
         # The current screen is unchanged.

--- a/Misc/NEWS.d/next/Tests/2026-09-08-12-30-00.gh-issue-157170.510IJX.rst
+++ b/Misc/NEWS.d/next/Tests/2026-09-08-12-30-00.gh-issue-157170.510IJX.rst
@@ -1,3 +1,0 @@
-Fix ``test_curses`` failing with 138 errors when ``TERM`` names a terminfo
-entry without a size, such as ``linux`` on the CI runners:
-``test_use_prescr_screen`` now restores :func:`curses.use_env`.

--- a/Misc/NEWS.d/next/Tests/2026-09-08-12-30-00.gh-issue-157170.510IJX.rst
+++ b/Misc/NEWS.d/next/Tests/2026-09-08-12-30-00.gh-issue-157170.510IJX.rst
@@ -1,0 +1,3 @@
+Fix ``test_curses`` failing with 138 errors when ``TERM`` names a terminfo
+entry without a size, such as ``linux`` on the CI runners:
+``test_use_prescr_screen`` now restores :func:`curses.use_env`.


### PR DESCRIPTION
`test_use_prescr_screen` turns `use_env` off to show that a `new_prescr()` screen can be used to affect state before `initscr()`, and never turns it back on. `curses.use_env()` calls ncurses' `use_env()`, which sets the process-wide default (`_nc_prescreen.use_env`) that every later screen copies, not a property of the screen that is current at the time. With it off, ncurses sizes a screen from the terminfo `lines`/`cols` capabilities alone, and the `linux` entry used by the CI runners has none, so every `newterm()` for the rest of the process returns NULL. That is the 138 errors `test_curses` reports in the parallel phase of every Ubuntu CI run (all 31 Ubuntu job runs in the last 8 successful runs on main); the sequential rerun passes only because it re-runs the failed tests by name and so never runs `ScreenTests` first. Details, including an ncurses trace of the failing `newterm()`, are in the issue.

This restores the setting with `addCleanup()`. Verified on Ubuntu 25.10 with ncurses 6.5 (the newterm-based `setUp()` needs ncurses 6.5 or newer):

- `TERM=linux ./python -m test test_curses -u curses`: 138 errors before, passes after (three consecutive runs).
- `TERM=linux ./python -m test --fast-ci test_curses`: no rerun needed after.
- `TERM=xterm` still passes.

On macOS the `ScreenTests` are skipped (ncurses 6.0), which is why this was invisible on developer machines.


<!-- gh-issue-number: gh-157170 -->
* Issue: gh-157170
<!-- /gh-issue-number -->
