### PR TITLE
gh-157174: Close the socket when HTTPConnection.connect() fails to set TCP_NODELAY

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1067,6 +1067,7 @@ class HTTPConnection:
             self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         except OSError as e:
             if e.errno != errno.ENOPROTOOPT:
+                self.close()
                 raise
 
         if self._tunnel_host:

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -2495,6 +2495,55 @@ class HTTPResponseTest(TestCase):
         header = self.resp.getheader('No-Such-Header',default=42)
         self.assertEqual(header, 42)
 
+class ConnectTests(TestCase):
+
+    class Socket(FakeSocket):
+        def __init__(self, setsockopt_error=None):
+            super().__init__(b'')
+            self.setsockopt_error = setsockopt_error
+            self.closed = False
+
+        def setsockopt(self, level, optname, value):
+            if self.setsockopt_error is not None:
+                raise self.setsockopt_error
+
+        def close(self):
+            self.closed = True
+
+    def make_connection(self, sock):
+        conn = client.HTTPConnection('example.com')
+        conn._create_connection = lambda *args, **kwargs: sock
+        return conn
+
+    def test_connect(self):
+        sock = self.Socket()
+        conn = self.make_connection(sock)
+        conn.connect()
+        self.assertIs(conn.sock, sock)
+        self.assertFalse(sock.closed)
+
+    def test_connect_tcp_nodelay_unsupported(self):
+        # An OS without TCP_NODELAY leaves the connection usable.
+        error = OSError(errno.ENOPROTOOPT, 'Protocol not available')
+        sock = self.Socket(setsockopt_error=error)
+        conn = self.make_connection(sock)
+        conn.connect()
+        self.assertIs(conn.sock, sock)
+        self.assertFalse(sock.closed)
+
+    def test_connect_tcp_nodelay_error_closes_socket(self):
+        # gh-157174: any other error setting TCP_NODELAY (macOS raises EINVAL
+        # once the peer has reset the connection) must not leak the socket.
+        error = OSError(errno.EINVAL, 'Invalid argument')
+        sock = self.Socket(setsockopt_error=error)
+        conn = self.make_connection(sock)
+        with self.assertRaises(OSError) as cm:
+            conn.connect()
+        self.assertIs(cm.exception, error)
+        self.assertIsNone(conn.sock)
+        self.assertTrue(sock.closed)
+
+
 class TunnelTests(TestCase):
     def setUp(self):
         response_text = (

--- a/Misc/NEWS.d/next/Library/2026-09-08-13-10-00.gh-issue-157174.7J6qt6.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-08-13-10-00.gh-issue-157174.7J6qt6.rst
@@ -1,0 +1,3 @@
+Fix :class:`http.client.HTTPConnection` leaking its socket when connecting
+fails at setting the ``TCP_NODELAY`` option, which happens on macOS when the
+server resets the connection right after accepting it.


### PR DESCRIPTION
`HTTPConnection.connect()` assigns the new socket to `self.sock` and then sets `TCP_NODELAY` on it. When that `setsockopt()` fails with anything other than `ENOPROTOOPT`, the error propagates while `self.sock` still holds the open socket, and a caller that drops the connection leaks it. `_tunnel()` handles its own connect-time failure by calling `self.close()` before raising; this does the same for `TCP_NODELAY`.

It is what is behind the `ResourceWarning` from `test_ssl.test_https_client_non_tls_response_ignored` on macOS CI (details in the issue): on macOS, `setsockopt(TCP_NODELAY)` raises `EINVAL` once the peer has reset the connection, that test's server resets on purpose, and on a slow runner the reset wins the race.

Verified on macOS 26:

- A harness with a server that accepts and resets at once, and a client whose `_create_connection` pauses 2 ms before returning (standing in for the client thread being preempted): 150 of 150 attempts raise `EINVAL` from `setsockopt()`; without this change all 150 sockets are reported unclosed, with it none.
- The new `test_connect_tcp_nodelay_error_closes_socket` fails before the change (`conn.sock` is not None) and passes after; `test_connect_tcp_nodelay_unsupported` checks that `ENOPROTOOPT` still leaves the connection usable.
- `test_httplib`, `test_urllib2`, `test_urllib2_localnet` and the `test_ssl` test in question pass.


<!-- gh-issue-number: gh-157174 -->
* Issue: gh-157174
<!-- /gh-issue-number -->
