### PR TITLE
gh-156002: Keep reading through third-party zipfile decompressors

### DIFF
--- a/Lib/_py_warnings.py
+++ b/Lib/_py_warnings.py
@@ -873,7 +873,8 @@ class deprecated:
 _DEPRECATED_MSG = "{name!r} is deprecated and slated for removal in Python {remove}"
 
 
-def _deprecated(name, message=_DEPRECATED_MSG, *, remove, _version=sys.version_info):
+def _deprecated(name, message=_DEPRECATED_MSG, *, remove, _version=sys.version_info,
+                stacklevel=3):
     """Warn that *name* is deprecated or should be removed.
 
     RuntimeError is raised if *remove* specifies a major/minor tuple older than
@@ -889,7 +890,7 @@ def _deprecated(name, message=_DEPRECATED_MSG, *, remove, _version=sys.version_i
         raise RuntimeError(msg)
     else:
         msg = message.format(name=name, remove=remove_formatted)
-        _wm.warn(msg, DeprecationWarning, stacklevel=3)
+        _wm.warn(msg, DeprecationWarning, stacklevel=stacklevel)
 
 
 # Private utility function called by _PyErr_WarnUnawaitedCoroutine

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -4970,8 +4970,12 @@ class ThirdPartyDecompressorTests(unittest.TestCase):
             self.assertEqual(zf.read("member"), data)
             with zf.open("member") as f:
                 self.assertEqual(f.read(100), data[:100])
+                self.assertEqual(f.read1(100), data[100:200])
                 f.seek(-100, os.SEEK_END)
                 self.assertEqual(f.read(), data[-100:])
+                # Rewinding past the read buffer re-creates the decompressor.
+                f.seek(0)
+                self.assertEqual(f.read(), data)
 
 
 class AbstractBadCrcTests:

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -4916,6 +4916,64 @@ class ZstdBoundedDecompressTests(AbstractBoundedDecompressTests,
     compression = zipfile.ZIP_ZSTANDARD
 
 
+class ThirdPartyDecompressorTests(unittest.TestCase):
+    # A decompressor installed by replacing _get_decompressor() may support
+    # neither decompress(data, max_length) nor needs_input.  ZipExtFile must
+    # still read through it (unbounded, as before bounded decompression).
+    COMPRESSION = 99
+
+    class Compressor:
+        def compress(self, data):
+            return data
+
+        def flush(self):
+            return b''
+
+    class Decompressor:
+        eof = False
+
+        def decompress(self, data):
+            return data
+
+    def setUp(self):
+        orig_check_compression = zipfile._check_compression
+        orig_get_compressor = zipfile._get_compressor
+        orig_get_decompressor = zipfile._get_decompressor
+
+        def check_compression(compression):
+            if compression != self.COMPRESSION:
+                orig_check_compression(compression)
+
+        def get_compressor(compress_type, compresslevel=None):
+            if compress_type == self.COMPRESSION:
+                return self.Compressor()
+            return orig_get_compressor(compress_type, compresslevel)
+
+        def get_decompressor(compress_type):
+            if compress_type == self.COMPRESSION:
+                return self.Decompressor()
+            return orig_get_decompressor(compress_type)
+
+        self.enterContext(mock.patch.object(
+            zipfile, '_check_compression', check_compression))
+        self.enterContext(mock.patch.object(
+            zipfile, '_get_compressor', get_compressor))
+        self.enterContext(mock.patch.object(
+            zipfile, '_get_decompressor', get_decompressor))
+
+    def test_read_through_third_party_decompressor(self):
+        data = bytes(range(256)) * 256
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", compression=self.COMPRESSION) as zf:
+            zf.writestr("member", data)
+        with zipfile.ZipFile(io.BytesIO(buf.getvalue())) as zf:
+            self.assertEqual(zf.read("member"), data)
+            with zf.open("member") as f:
+                self.assertEqual(f.read(100), data[:100])
+                f.seek(-100, os.SEEK_END)
+                self.assertEqual(f.read(), data[-100:])
+
+
 class AbstractBadCrcTests:
     def test_testzip_with_bad_crc(self):
         """Tests that files with bad CRCs return their name from testzip."""

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -4922,8 +4922,8 @@ class MonkeypatchedDecompressorTests(unittest.TestCase):
     # Some third-party projects monkey-patch _get_decompressor() to add
     # additional compression schemes. This can break at any time as the
     # internal compressor objects change.
-    # To protect users, we try to keep this case working (see ).
-    # See also: GH-156002 and GH-113756.
+    # To protect users, we try to keep this case working.
+    # See also: GH-156002 and GH-113767.
     COMPRESSION = 99
 
     class Compressor:
@@ -4935,7 +4935,7 @@ class MonkeypatchedDecompressorTests(unittest.TestCase):
             return b''
 
     class Decompressor:
-        """Decmpressor with only the 3.3+ BZ2Decompressor API"""
+        """Decompressor with only the 3.3+ BZ2Decompressor API"""
         eof = False
 
         def decompress(self, data):
@@ -4974,7 +4974,7 @@ class MonkeypatchedDecompressorTests(unittest.TestCase):
             zf.writestr("member", data)
         self.assertIn(data.swapcase(), buf.getvalue())
         with (ignore_warnings(category=DeprecationWarning,
-                              message='.*two argumentzs.*'),
+                              message='.*two arguments.*'),
               zipfile.ZipFile(io.BytesIO(buf.getvalue())) as zf):
             self.assertEqual(zf.read("member"), data)
             with zf.open("member") as f:

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -33,7 +33,9 @@ from test.support.os_helper import (
     with_source_date_epoch, without_source_date_epoch,
 )
 from test.support.import_helper import ensure_lazy_imports
-from test.support.warnings_helper import check_no_resource_warning
+from test.support.warnings_helper import (
+    check_no_resource_warning, ignore_warnings,
+)
 
 
 TESTFN2 = TESTFN + "2"
@@ -4920,8 +4922,7 @@ class MonkeypatchedDecompressorTests(unittest.TestCase):
     # Some third-party projects monkey-patch _get_decompressor() to add
     # additional compression schemes. This can break at any time as the
     # internal compressor objects change.
-    # To protect users, we try to keep this case working (until it becomes
-    # too big of a burden, or we make the API public).
+    # To protect users, we try to keep this case working (see ).
     # See also: GH-156002 and GH-113756.
     COMPRESSION = 99
 
@@ -4972,7 +4973,9 @@ class MonkeypatchedDecompressorTests(unittest.TestCase):
         with zipfile.ZipFile(buf, "w", compression=self.COMPRESSION) as zf:
             zf.writestr("member", data)
         self.assertIn(data.swapcase(), buf.getvalue())
-        with zipfile.ZipFile(io.BytesIO(buf.getvalue())) as zf:
+        with (ignore_warnings(category=DeprecationWarning,
+                              message='.*two argumentzs.*'),
+              zipfile.ZipFile(io.BytesIO(buf.getvalue())) as zf):
             self.assertEqual(zf.read("member"), data)
             with zf.open("member") as f:
                 self.assertEqual(f.read(100), data[:100])

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -4916,24 +4916,29 @@ class ZstdBoundedDecompressTests(AbstractBoundedDecompressTests,
     compression = zipfile.ZIP_ZSTANDARD
 
 
-class ThirdPartyDecompressorTests(unittest.TestCase):
-    # A decompressor installed by replacing _get_decompressor() may support
-    # neither decompress(data, max_length) nor needs_input.  ZipExtFile must
-    # still read through it (unbounded, as before bounded decompression).
+class MonkeypatchedDecompressorTests(unittest.TestCase):
+    # Some third-party projects monkey-patch _get_decompressor() to add
+    # additional compression schemes. This can break at any time as the
+    # internal compressor objects change.
+    # To protect users, we try to keep this case working (until it becomes
+    # too big of a burden, or we make the API public).
+    # See also: GH-156002 and GH-113756.
     COMPRESSION = 99
 
     class Compressor:
+        """Compressor with only the original BZ2Compressor API"""
         def compress(self, data):
-            return data
+            return data.swapcase()
 
         def flush(self):
             return b''
 
     class Decompressor:
+        """Decmpressor with only the 3.3+ BZ2Decompressor API"""
         eof = False
 
         def decompress(self, data):
-            return data
+            return data.swapcase()
 
     def setUp(self):
         orig_check_compression = zipfile._check_compression
@@ -4961,11 +4966,12 @@ class ThirdPartyDecompressorTests(unittest.TestCase):
         self.enterContext(mock.patch.object(
             zipfile, '_get_decompressor', get_decompressor))
 
-    def test_read_through_third_party_decompressor(self):
-        data = bytes(range(256)) * 256
+    def test_roundtrip_monkeypatched_decompressor(self):
+        data = bytes(range(256)) * 8
         buf = io.BytesIO()
         with zipfile.ZipFile(buf, "w", compression=self.COMPRESSION) as zf:
             zf.writestr("member", data)
+        self.assertIn(data.swapcase(), buf.getvalue())
         with zipfile.ZipFile(io.BytesIO(buf.getvalue())) as zf:
             self.assertEqual(zf.read("member"), data)
             with zf.open("member") as f:

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -1204,7 +1204,8 @@ class ZipExtFile(io.BufferedIOBase):
 
     def _set_decompressor(self):
         self._decompressor = _get_decompressor(self._compress_type)
-        self._decompress_bounded = _decompressor_bounds_output(self._decompressor)
+        self._decompress_bounded = _decompressor_bounds_output(
+            self._decompressor)
 
     def _read1(self, n):
         # Read up to n compressed bytes with at most one read() system call,
@@ -1245,7 +1246,8 @@ class ZipExtFile(io.BufferedIOBase):
             data = self._decompressor.decompress(data, max(n, self.MIN_READ_SIZE))
             self._eof = (self._decompressor.eof or
                          self._compress_left <= 0 and
-                         _decompressor_needs_input(self._decompressor, default=True))
+                         _decompressor_needs_input(self._decompressor,
+                                                   default=True))
         else:
             data = self._decompressor.decompress(data)
             self._eof = self._decompressor.eof or self._compress_left <= 0

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -802,7 +802,7 @@ class LZMADecompressor:
             return b''
 
     @property
-    def _needs_input(self):
+    def needs_input(self):
         # While the LZMA properties header is still being buffered, more input
         # is required; afterwards defer to the wrapped decompressor so a bounded
         # decompress() call can be drained across reads.
@@ -891,25 +891,6 @@ def _get_compressor(compress_type, compresslevel=None):
         return zstd.ZstdCompressor(level=compresslevel)
     else:
         return None
-
-
-def _decompressor_needs_input(decompressor, default):
-    # bz2/zstd expose the stdlib decompressor's public needs_input; the LZMA
-    # wrapper keeps it private (_needs_input) to avoid adding public API.
-    # A decompressor with neither attribute reports *default*.
-    needs_input = getattr(decompressor, "needs_input", None)
-    if needs_input is None:
-        needs_input = getattr(decompressor, "_needs_input", default)
-    return needs_input
-
-
-def _decompressor_bounds_output(decompressor):
-    # The stdlib bzip2/LZMA/Zstandard decompressors report needs_input and
-    # accept decompress(data, max_length).  A third-party decompressor
-    # installed by replacing _get_decompressor() may support neither; it is
-    # then read unbounded, as before the bounded-decompression fix.
-    return (hasattr(decompressor, "needs_input")
-            or hasattr(decompressor, "_needs_input"))
 
 
 def _get_decompressor(compress_type):
@@ -1019,7 +1000,7 @@ class ZipExtFile(io.BufferedIOBase):
         self._compress_left = zipinfo.compress_size
         self._left = zipinfo.file_size
 
-        self._set_decompressor()
+        self._decompressor = _get_decompressor(self._compress_type)
 
         self._eof = False
         self._readbuffer = b''
@@ -1202,11 +1183,6 @@ class ZipExtFile(io.BufferedIOBase):
                     break
         return buf
 
-    def _set_decompressor(self):
-        self._decompressor = _get_decompressor(self._compress_type)
-        self._decompress_bounded = _decompressor_bounds_output(
-            self._decompressor)
-
     def _read1(self, n):
         # Read up to n compressed bytes with at most one read() system call,
         # decrypt and decompress them.
@@ -1224,7 +1200,7 @@ class ZipExtFile(io.BufferedIOBase):
         else:
             # bzip2/lzma/zstd: a bounded decompress() call may leave input
             # buffered inside the decompressor; drain that before reading more.
-            if _decompressor_needs_input(self._decompressor, default=True):
+            if getattr(self._decompressor, "needs_input", True):
                 data = self._read2(n)
             else:
                 data = b''
@@ -1239,18 +1215,27 @@ class ZipExtFile(io.BufferedIOBase):
                          not self._decompressor.unconsumed_tail)
             if self._eof:
                 data += self._decompressor.flush()
-        elif self._decompress_bounded:
+        else:
             # Bound the output of a single decompress() call (mirroring the
             # DEFLATE path above) so that a small compressed member cannot
             # expand into one unbounded read.
-            data = self._decompressor.decompress(data, max(n, self.MIN_READ_SIZE))
+            try:
+                data = self._decompressor.decompress(data, max(n, self.MIN_READ_SIZE))
+            except TypeError:
+                # See MonkeypatchedDecompressorTests in test_core.py
+                warnings._deprecated(
+                    'one-argument decompress()',
+                    'The decompress() method of '
+                    + type(self._decompressor).__name__
+                    + ' should take two arguments, data and max_length.'
+                    + ' One-argument calls will stop working before'
+                    + ' Python 3.21.',
+                    remove=(3, 21),
+                    stacklevel=4)
+                data = self._decompressor.decompress(data)
             self._eof = (self._decompressor.eof or
                          self._compress_left <= 0 and
-                         _decompressor_needs_input(self._decompressor,
-                                                   default=True))
-        else:
-            data = self._decompressor.decompress(data)
-            self._eof = self._decompressor.eof or self._compress_left <= 0
+                         getattr(self._decompressor, "needs_input", True))
 
         data = data[:self._left]
         self._left -= len(data)
@@ -1339,7 +1324,7 @@ class ZipExtFile(io.BufferedIOBase):
             self._left = self._orig_file_size
             self._readbuffer = b''
             self._offset = 0
-            self._set_decompressor()
+            self._decompressor = _get_decompressor(self._compress_type)
             self._eof = False
             read_offset = new_pos
             if self._decrypter is not None:

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -893,11 +893,23 @@ def _get_compressor(compress_type, compresslevel=None):
         return None
 
 
-def _decompressor_needs_input(decompressor):
+def _decompressor_needs_input(decompressor, default):
     # bz2/zstd expose the stdlib decompressor's public needs_input; the LZMA
     # wrapper keeps it private (_needs_input) to avoid adding public API.
+    # A decompressor with neither attribute reports *default*.
     needs_input = getattr(decompressor, "needs_input", None)
-    return decompressor._needs_input if needs_input is None else needs_input
+    if needs_input is None:
+        needs_input = getattr(decompressor, "_needs_input", default)
+    return needs_input
+
+
+def _decompressor_bounds_output(decompressor):
+    # The stdlib bzip2/LZMA/Zstandard decompressors report needs_input and
+    # accept decompress(data, max_length).  A third-party decompressor
+    # installed by replacing _get_decompressor() may support neither; it is
+    # then read unbounded, as before the bounded-decompression fix.
+    return (hasattr(decompressor, "needs_input")
+            or hasattr(decompressor, "_needs_input"))
 
 
 def _get_decompressor(compress_type):
@@ -1007,7 +1019,7 @@ class ZipExtFile(io.BufferedIOBase):
         self._compress_left = zipinfo.compress_size
         self._left = zipinfo.file_size
 
-        self._decompressor = _get_decompressor(self._compress_type)
+        self._set_decompressor()
 
         self._eof = False
         self._readbuffer = b''
@@ -1190,6 +1202,10 @@ class ZipExtFile(io.BufferedIOBase):
                     break
         return buf
 
+    def _set_decompressor(self):
+        self._decompressor = _get_decompressor(self._compress_type)
+        self._decompress_bounded = _decompressor_bounds_output(self._decompressor)
+
     def _read1(self, n):
         # Read up to n compressed bytes with at most one read() system call,
         # decrypt and decompress them.
@@ -1207,7 +1223,7 @@ class ZipExtFile(io.BufferedIOBase):
         else:
             # bzip2/lzma/zstd: a bounded decompress() call may leave input
             # buffered inside the decompressor; drain that before reading more.
-            if _decompressor_needs_input(self._decompressor):
+            if _decompressor_needs_input(self._decompressor, default=True):
                 data = self._read2(n)
             else:
                 data = b''
@@ -1222,14 +1238,17 @@ class ZipExtFile(io.BufferedIOBase):
                          not self._decompressor.unconsumed_tail)
             if self._eof:
                 data += self._decompressor.flush()
-        else:
+        elif self._decompress_bounded:
             # Bound the output of a single decompress() call (mirroring the
             # DEFLATE path above) so that a small compressed member cannot
             # expand into one unbounded read.
             data = self._decompressor.decompress(data, max(n, self.MIN_READ_SIZE))
             self._eof = (self._decompressor.eof or
                          self._compress_left <= 0 and
-                         _decompressor_needs_input(self._decompressor))
+                         _decompressor_needs_input(self._decompressor, default=True))
+        else:
+            data = self._decompressor.decompress(data)
+            self._eof = self._decompressor.eof or self._compress_left <= 0
 
         data = data[:self._left]
         self._left -= len(data)
@@ -1318,7 +1337,7 @@ class ZipExtFile(io.BufferedIOBase):
             self._left = self._orig_file_size
             self._readbuffer = b''
             self._offset = 0
-            self._decompressor = _get_decompressor(self._compress_type)
+            self._set_decompressor()
             self._eof = False
             read_offset = new_pos
             if self._decrypter is not None:

--- a/Misc/NEWS.d/next/Library/2026-09-08-13-06-29.gh-issue-156002.vmOC8T.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-08-13-06-29.gh-issue-156002.vmOC8T.rst
@@ -1,0 +1,5 @@
+:mod:`zipfile` again reads members through a third-party decompressor
+installed by replacing ``_get_decompressor()``, unbounded as before the
+bounded-decompression fix, instead of raising :exc:`AttributeError`. The
+bound still applies to the standard library's bzip2, LZMA and Zstandard
+decompressors.

--- a/Misc/NEWS.d/next/Library/2026-09-08-13-06-29.gh-issue-156002.vmOC8T.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-08-13-06-29.gh-issue-156002.vmOC8T.rst
@@ -1,6 +1,6 @@
 :mod:`zipfile` again reads members through a third-party decompressor
 installed by monkey-patching the private ``_get_decompressor()`` to return an
 object that only implements old BZ2Decompressor API from Python 3.3.
-Calling to decompress() with one argument is deprecated.
+Calling decompress() with one argument is deprecated.
 Note that decompressors without ``needs_input`` and two-argument
 ``decompress()`` are vulnerable to :cve:`2026-15310`.

--- a/Misc/NEWS.d/next/Library/2026-09-08-13-06-29.gh-issue-156002.vmOC8T.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-08-13-06-29.gh-issue-156002.vmOC8T.rst
@@ -1,5 +1,6 @@
 :mod:`zipfile` again reads members through a third-party decompressor
-installed by replacing the private ``_get_decompressor()``, unbounded as
-before the bounded-decompression fix, instead of raising
-:exc:`AttributeError`. The bound still applies to the standard library's
-bzip2, LZMA and Zstandard decompressors.
+installed by monkey-patching the private ``_get_decompressor()`` to return an
+object that only implements old BZ2Decompressor API from Python 3.3.
+Calling to decompress() with one argument is deprecated.
+Note that decompressors without ``needs_input`` and two-argument
+``decompress()`` are vulnerable to :cve:`2026-15310`.

--- a/Misc/NEWS.d/next/Library/2026-09-08-13-06-29.gh-issue-156002.vmOC8T.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-08-13-06-29.gh-issue-156002.vmOC8T.rst
@@ -1,5 +1,5 @@
 :mod:`zipfile` again reads members through a third-party decompressor
-installed by replacing ``_get_decompressor()``, unbounded as before the
-bounded-decompression fix, instead of raising :exc:`AttributeError`. The
-bound still applies to the standard library's bzip2, LZMA and Zstandard
-decompressors.
+installed by replacing the private ``_get_decompressor()``, unbounded as
+before the bounded-decompression fix, instead of raising
+:exc:`AttributeError`. The bound still applies to the standard library's
+bzip2, LZMA and Zstandard decompressors.


### PR DESCRIPTION
Follow-up to GH-156003, as discussed in https://github.com/python/cpython/issues/156002#issuecomment-5585469860.

The change to bound decompression made `ZipExtFile._read1()` call `decompress(data, max_length)` on non-deflate decompressors and check `needs_input`. Many third-party decompressors (zipfile-zstd, zipfile-deflate64, and others) that are installed by replacing `_get_decompressor()` (zipfile-zstd, zipfile-deflate64, ...) do not support those, and end up failing with `AttributeError: ... has no attribute '_needs_input'`.

This PR:

- gives `_decompressor_needs_input()` a `default` argument for decompressors that report neither `needs_input` nor `_needs_input` (no three-state return);
- decides once per decompressor instance, when `ZipExtFile` creates it (construction and `seek()`), whether it takes the bounded path: only decompressors that report `needs_input` do, which is all of the stdlib ones. Anything else is read unbounded, exactly as before GH-156003;
- adds a test with a fake third-party compression method whose decompressor has a one-argument `decompress()` and no `needs_input`; it fails with the `AttributeError` above without the fix.

Verified with the real packages by applying the same three hunks to the 3.13 backport (#156738): a Deflate64 archive written by 7-Zip reads through zipfile-deflate64, and a Zstandard member reads through zipfile-zstd, on Python 3.13.15 where both currently fail. `test_zipfile`, `test_zstd`, `test_zipimport`, `test_zipapp` and `test_shutil` pass on a debug build of main with `_zstd` enabled; the `*BoundedDecompressTests` still pass for every stdlib method.

Should ride along with the open backports #156737–#156741.

Claude Fable 5.1 and GPT-6 Astra both reviewed and gave input, as well as drafted PR description and commit messages.

<!-- gh-issue-number: gh-156002 -->
* Issue: gh-156002
<!-- /gh-issue-number -->
