### PR TITLE
gh-157181: smtplib: add server_hostname to starttls() and SMTP_SSL

### DIFF
--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -81,7 +81,7 @@ Protocol) and :rfc:`1869` (SMTP Service Extensions).
       :class:`ValueError` to prevent the creation of a non-blocking socket.
 
 .. class:: SMTP_SSL(host='', port=0, local_hostname=None, * [, timeout], \
-                    context=None, source_address=None)
+                    context=None, source_address=None, server_hostname=None)
 
    An :class:`SMTP_SSL` instance behaves exactly the same as instances of
    :class:`SMTP`. :class:`SMTP_SSL` should be used for situations where SSL is
@@ -97,6 +97,12 @@ Protocol) and :rfc:`1869` (SMTP Service Extensions).
    can contain a :class:`~ssl.SSLContext` and allows configuring various
    aspects of the secure connection.  Please read :ref:`ssl-security` for
    best practices.
+
+   The optional keyword-only argument *server_hostname* overrides the
+   hostname used for *Server Name Indication* and certificate matching
+   against *host*.  This is useful when *host* is a pre-resolved IP address
+   or otherwise differs from the hostname the server's certificate should be
+   validated against.  If not given, it defaults to *host*.
 
    .. attribute:: SMTP_SSL.default_port
 
@@ -119,6 +125,9 @@ Protocol) and :rfc:`1869` (SMTP Service Extensions).
 
    .. versionchanged:: 3.12
       The deprecated *keyfile* and *certfile* parameters have been removed.
+
+   .. versionchanged:: 3.16
+      The *server_hostname* argument was added.
 
 .. class:: LMTP(host='', port=LMTP_PORT, local_hostname=None, \
                 source_address=None[, timeout])
@@ -409,7 +418,7 @@ An :class:`SMTP` instance has the following methods:
    .. versionadded:: 3.5
 
 
-.. method:: SMTP.starttls(*, context=None)
+.. method:: SMTP.starttls(*, context=None, server_hostname=None)
 
    Put the SMTP connection in TLS (Transport Layer Security) mode.  All SMTP
    commands that follow will be encrypted.  You should then call :meth:`ehlo`
@@ -421,6 +430,13 @@ An :class:`SMTP` instance has the following methods:
    Optional *context* parameter is an :class:`ssl.SSLContext` object; This is
    an alternative to using a keyfile and a certfile and if specified both
    *keyfile* and *certfile* should be ``None``.
+
+   Optional *server_hostname* parameter overrides the hostname used for
+   *Server Name Indication* and certificate matching.  This is useful when
+   the address given to :meth:`connect` differs from the hostname the
+   server's certificate should be validated against, for example when
+   connecting to a pre-resolved IP address.  If not given, it defaults to
+   the host used for the connection.
 
    If there has been no previous ``EHLO`` or ``HELO`` command this session,
    this method tries ESMTP ``EHLO`` first.
@@ -449,6 +465,9 @@ An :class:`SMTP` instance has the following methods:
       The error raised for lack of STARTTLS support is now the
       :exc:`SMTPNotSupportedError` subclass instead of the base
       :exc:`SMTPException`.
+
+   .. versionchanged:: 3.16
+      The *server_hostname* argument was added.
 
 
 .. method:: SMTP.sendmail(from_addr, to_addrs, msg, mail_options=(), rcpt_options=())

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -521,6 +521,16 @@ shlex
   (Contributed by Jay Berry in :gh:`148846`.)
 
 
+smtplib
+-------
+
+* :meth:`SMTP.starttls() <smtplib.SMTP.starttls>` and the
+  :class:`~smtplib.SMTP_SSL` constructor now accept a keyword-only
+  *server_hostname* parameter to override the hostname used for SNI and
+  certificate matching, independently of the address used to connect.
+  (Contributed by Yasser Ameur in :gh:`157181`.)
+
+
 socket
 ------
 

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -761,7 +761,7 @@ class SMTP:
         # We could not login successfully.  Return result of last attempt.
         raise last_exception
 
-    def starttls(self, *, context=None):
+    def starttls(self, *, context=None, server_hostname=None):
         """Puts the connection to the SMTP server into TLS mode.
 
         If there has been no previous EHLO or HELO command this session, this
@@ -772,6 +772,12 @@ class SMTP:
         the identity of the SMTP server and client can be checked. This,
         however, depends on whether the socket module really checks the
         certificates.
+
+        The server_hostname parameter can be used to override the hostname
+        used for SNI and certificate matching, in case it differs from the
+        address given to connect() (for example, when connecting to a
+        pre-resolved IP address). It defaults to the hostname stored from
+        connect().
 
         This method may raise the following exceptions:
 
@@ -788,8 +794,10 @@ class SMTP:
                 raise RuntimeError("No SSL support included in this Python")
             if context is None:
                 context = ssl._create_stdlib_context()
+            if server_hostname is None:
+                server_hostname = self._host
             self.sock = context.wrap_socket(self.sock,
-                                            server_hostname=self._host)
+                                            server_hostname=server_hostname)
             self.file = None
             # RFC 3207:
             # The client MUST discard any knowledge obtained from
@@ -1019,7 +1027,10 @@ if _have_ssl:
         host) is used. If port is omitted, the standard SMTP-over-SSL port
         (465) is used.  local_hostname and source_address have the same meaning
         as they do in the SMTP class.  context also optional, can contain a
-        SSLContext.
+        SSLContext.  The server_hostname parameter can be used to override the
+        hostname used for SNI and certificate matching, in case it differs
+        from host (for example, when host is a pre-resolved IP address); it
+        defaults to host.
 
         """
 
@@ -1027,10 +1038,12 @@ if _have_ssl:
 
         def __init__(self, host='', port=0, local_hostname=None,
                      *, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
-                     source_address=None, context=None):
+                     source_address=None, context=None,
+                     server_hostname=None):
             if context is None:
                 context = ssl._create_stdlib_context()
             self.context = context
+            self._server_hostname = server_hostname
             SMTP.__init__(self, host, port, local_hostname, timeout,
                           source_address)
 
@@ -1038,8 +1051,11 @@ if _have_ssl:
             if self.debuglevel > 0:
                 self._print_debug('connect:', (host, port))
             new_socket = super()._get_socket(host, port, timeout)
+            server_hostname = self._server_hostname
+            if server_hostname is None:
+                server_hostname = self._host
             new_socket = self.context.wrap_socket(new_socket,
-                                                  server_hostname=self._host)
+                                                  server_hostname=server_hostname)
             return new_socket
 
     __all__.append("SMTP_SSL")

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -723,6 +723,69 @@ class NonConnectingTests(unittest.TestCase):
             self.assertIsNone(smtp.sock)
 
 
+@unittest.skipUnless(smtplib._have_ssl, 'SSL not available')
+class StartTLSServerHostnameTests(unittest.TestCase):
+    # Verify that starttls() picks the hostname passed to wrap_socket()
+    # for SNI/certificate matching from the server_hostname keyword when
+    # given, and falls back to the connected host (self._host) otherwise.
+
+    def _make_smtp(self):
+        smtp = smtplib.SMTP()
+        smtp.sock = Mock()
+        smtp._host = 'connected.example.com'
+        smtp.ehlo_or_helo_if_needed = Mock()
+        smtp.has_extn = Mock(return_value=True)
+        smtp.docmd = Mock(return_value=(220, b'Go ahead'))
+        return smtp
+
+    def testStarttlsDefaultsToHost(self):
+        smtp = self._make_smtp()
+        original_sock = smtp.sock
+        mock_context = Mock()
+        smtp.starttls(context=mock_context)
+        mock_context.wrap_socket.assert_called_once_with(
+            original_sock, server_hostname='connected.example.com')
+
+    def testStarttlsExplicitServerHostname(self):
+        smtp = self._make_smtp()
+        original_sock = smtp.sock
+        mock_context = Mock()
+        smtp.starttls(context=mock_context,
+                       server_hostname='override.example.org')
+        mock_context.wrap_socket.assert_called_once_with(
+            original_sock, server_hostname='override.example.org')
+
+
+@unittest.skipUnless(smtplib._have_ssl, 'SSL not available')
+class SMTP_SSLServerHostnameTests(unittest.TestCase):
+    # Verify that SMTP_SSL._get_socket() picks the hostname passed to
+    # wrap_socket() from the server_hostname constructor keyword when
+    # given, and falls back to the connected host (self._host) otherwise.
+
+    def testGetSocketDefaultsToHost(self):
+        mock_context = Mock()
+        smtp = smtplib.SMTP_SSL(context=mock_context)
+        smtp._host = 'connected.example.com'
+        with mock.patch.object(smtplib.SMTP, '_get_socket',
+                                return_value=Mock()) as base_get_socket:
+            smtp._get_socket('connected.example.com', 465, 1)
+        mock_context.wrap_socket.assert_called_once_with(
+            base_get_socket.return_value,
+            server_hostname='connected.example.com')
+
+    def testGetSocketExplicitServerHostname(self):
+        mock_context = Mock()
+        smtp = smtplib.SMTP_SSL(context=mock_context,
+                                 server_hostname='override.example.org')
+        smtp._host = 'connected.example.com'
+        with mock.patch.object(smtplib.SMTP, '_get_socket',
+                                return_value=Mock()) as base_get_socket:
+            smtp._get_socket('connected.example.com', 465, 1)
+        mock_context.wrap_socket.assert_called_once_with(
+            base_get_socket.return_value,
+            server_hostname='override.example.org')
+
+
 class DefaultArgumentsTests(unittest.TestCase):
 
     def setUp(self):

--- a/Misc/NEWS.d/next/Library/2026-09-08-12-00-00.gh-issue-157181.aZ3kNp.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-08-12-00-00.gh-issue-157181.aZ3kNp.rst
@@ -1,0 +1,5 @@
+Add a keyword-only *server_hostname* parameter to
+:meth:`SMTP.starttls() <smtplib.SMTP.starttls>` and to the
+:class:`~smtplib.SMTP_SSL` constructor, so the hostname used for TLS SNI
+and certificate matching can be set independently of the address the
+client connected to. Patch by Yasser Ameur.


### PR DESCRIPTION
`SMTP.connect()` stores the address it connected to in `_host`, and both `SMTP.starttls()` and `SMTP_SSL._get_socket()` pass that value to `ssl.SSLContext.wrap_socket(server_hostname=...)`. A client that connects to a pre-resolved IP (SSRF pinning, a load balancer address) and needs the certificate verified against its configured hostname has no public way to say so today; the only workaround is writing the private `_host`.

This adds a keyword-only `server_hostname` parameter to `SMTP.starttls()` and to the `SMTP_SSL` constructor. When omitted, both keep using the host from `connect()`, so existing calls are unaffected. Plain `SMTP.__init__` is untouched because it never wraps a socket. The name matches the `wrap_socket` parameter it feeds.

Tests: `StartTLSServerHostnameTests` and `SMTP_SSLServerHostnameTests` in `Lib/test/test_smtplib.py` assert the hostname handed to `wrap_socket` in the default and explicit cases for both entry points, mirroring the file's existing mock-based tests, and skip when SSL is unavailable. Docs carry `versionchanged:: 3.16` on both, plus a whatsnew line and a NEWS entry.

The patch was prepared with AI assistance under my direction; I am responsible for it and have reviewed it.

* Issue: gh-157181
