### PR TITLE
gh-157184: Scale the join() alarm in the multiprocessing kill tests

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -9,6 +9,7 @@ import textwrap
 import time
 import io
 import itertools
+import math
 import sys
 import os
 import gc
@@ -624,11 +625,14 @@ class _TestProcess(BaseTestCase):
         if hasattr(signal, 'alarm'):
             # On the Gentoo buildbot waitpid() often seems to block forever.
             # We use alarm() to interrupt it if it blocks for too long.
+            # The timeout only has to catch a hang, so use LONG_TIMEOUT:
+            # a shorter one fires on a slow build where reaping the child
+            # legitimately takes a while.
             def handler(*args):
                 raise RuntimeError('join took too long: %s' % p)
             old_handler = signal.signal(signal.SIGALRM, handler)
             try:
-                signal.alarm(10)
+                signal.alarm(math.ceil(support.LONG_TIMEOUT))
                 self.assertEqual(join(), None)
             finally:
                 signal.alarm(0)

--- a/Misc/NEWS.d/next/Tests/2026-09-08-14-05-00.gh-issue-157184.nKPZhX.rst
+++ b/Misc/NEWS.d/next/Tests/2026-09-08-14-05-00.gh-issue-157184.nKPZhX.rst
@@ -1,5 +1,0 @@
-Fix the ``multiprocessing`` tests that kill a child process
-(``test_interrupt``, ``test_interrupt_no_handler``, ``test_terminate`` and
-``test_kill``) failing on slow builds: the alarm guarding the ``join()`` of
-the killed child used a fixed 10 second timeout, and now uses
-:data:`~test.support.LONG_TIMEOUT`, which regrtest scales.

--- a/Misc/NEWS.d/next/Tests/2026-09-08-14-05-00.gh-issue-157184.nKPZhX.rst
+++ b/Misc/NEWS.d/next/Tests/2026-09-08-14-05-00.gh-issue-157184.nKPZhX.rst
@@ -1,0 +1,5 @@
+Fix the ``multiprocessing`` tests that kill a child process
+(``test_interrupt``, ``test_interrupt_no_handler``, ``test_terminate`` and
+``test_kill``) failing on slow builds: the alarm guarding the ``join()`` of
+the killed child used a fixed 10 second timeout, and now uses
+:data:`~test.support.LONG_TIMEOUT`, which regrtest scales.


### PR DESCRIPTION
`_kill_process()` guards the `join()` of the killed child with a `SIGALRM` so that a blocked `waitpid()` becomes a readable error instead of a hang. The alarm has been a literal `10` seconds since it was added in 2013 (cc5c728513a), so on a build slow enough that reaping the child legitimately takes longer than that, it fires on a healthy run and fails the test. That is what happened on the UBSan job of 57594aae5e (traceback in the issue): the alarm interrupted `os.waitpid()` itself.

`test.support.LONG_TIMEOUT` is documented for this exact purpose, "Timeout in seconds to detect when a test hangs [...] It should not be used to mark a test as failed if the test takes 'too long'", and regrtest scales it from `--timeout` for slow workers. The `SHORT_TIMEOUT` docs point the same way: "If a test using `SHORT_TIMEOUT` starts to fail randomly on slow buildbots, use `LONG_TIMEOUT` instead." `_kill_process()` already uses `support.SHORT_TIMEOUT` a few lines above for its event wait. `math.ceil()` keeps the alarm from being cancelled outright if a very short `--timeout` scales the value below one second.

Four tests go through this helper, in every start-method variant: `test_interrupt`, `test_interrupt_no_handler`, `test_terminate` and `test_kill`.

Verified by making the child slow to die (a `SIGINT` handler that sleeps 12 seconds), which is what a loaded machine looks like from the parent's side, and running the real `test_interrupt`. On Linux with the fork start method, the configuration that failed on CI, and on macOS with spawn:

| | Linux, fork | macOS, spawn |
|---|---|---|
| `signal.alarm(10)` | `join took too long` — FAILURE | `join took too long` — FAILURE |
| this change | SUCCESS | SUCCESS |

Without the injected delay, `test_multiprocessing_spawn`, `test_multiprocessing_forkserver`, `test_multiprocessing_fork`, `test_multiprocessing_main_handling` and `test_concurrent_futures` pass (1427 tests).


<!-- gh-issue-number: gh-157184 -->
* Issue: gh-157184
<!-- /gh-issue-number -->
