### PR TITLE
gh-157194: Read the opcode atomically in the specializer

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-09-08-17-40-00.gh-issue-157194.17Ffhk.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-09-08-17-40-00.gh-issue-157194.17Ffhk.rst
@@ -1,0 +1,4 @@
+Fix a data race in the free-threaded build, reported by ThreadSanitizer,
+between the specializer reading an instruction opcode and another thread
+writing it. Only reachable when thread-local bytecode is disabled with
+``-X tlbc=0``, which makes threads share one copy of the bytecode.

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -2348,7 +2348,7 @@ _Py_Specialize_BinaryOp(_PyStackRef lhs_st, _PyStackRef rhs_st, _Py_CODEUNIT *in
     assert(_PyOpcode_Caches[BINARY_OP] == INLINE_CACHE_ENTRIES_BINARY_OP);
 
     _PyBinaryOpCache *cache = (_PyBinaryOpCache *)(instr + 1);
-    if (instr->op.code == BINARY_OP_EXTEND) {
+    if (FT_ATOMIC_LOAD_UINT8_RELAXED(instr->op.code) == BINARY_OP_EXTEND) {
         write_ptr(cache->external_cache, NULL);
     }
 
@@ -2954,7 +2954,8 @@ _Py_Specialize_GetIter(_PyStackRef iterable, _Py_CODEUNIT *instr)
 void
 _Py_Specialize_Resume(_Py_CODEUNIT *instr, PyThreadState *tstate, _PyInterpreterFrame *frame)
 {
-    if (tstate->tracing == 0 && instr->op.code == RESUME) {
+    if (tstate->tracing == 0 &&
+        FT_ATOMIC_LOAD_UINT8_RELAXED(instr->op.code) == RESUME) {
         if (tstate->interp->jit) {
             PyCodeObject *co = (PyCodeObject *)PyStackRef_AsPyObjectBorrow(frame->f_executable);
             if (co != NULL &&


### PR DESCRIPTION
`set_opcode()` writes `instr->op.code` with `_Py_atomic_compare_exchange_uint8()` and `unspecialize()` reads it with `FT_ATOMIC_LOAD_UINT8_RELAXED()`, the convention introduced with the (un)specialization helpers in gh-115999 (9ce4fa0719d). Two later comparisons read the same byte directly:

- `_Py_Specialize_Resume()`, added by 3d0824aef26 (gh-127958)
- `_Py_Specialize_BinaryOp()`, added by 3893a92d956 (gh-100239)

In a free-threaded build each thread normally gets its own copy of the bytecode, so specialization never races. With `-X tlbc=0` the copies are disabled and the bytecode is shared, and those plain reads race with the atomic write. ThreadSanitizer reported exactly that on the CI job for `test_thread_local_bytecode` (report quoted in the issue): a read at `specialize.c:2957` against a "previous atomic write" from `set_opcode()` via `unspecialize()`.

The change makes both reads use the same relaxed atomic load. The logic is unchanged, and on the default build `FT_ATOMIC_LOAD_UINT8_RELAXED` expands to the plain access, so only the free-threaded build is affected.

## Verification

On a `--disable-gil --with-thread-sanitizer --with-pydebug` build (clang 20, Linux aarch64), with a script that has several threads and the main thread call the same freshly created function repeatedly under `-X tlbc=0`:

| | data races reported |
|---|---|
| before | 3, every one of them `_Py_Specialize_Resume Python/specialize.c:2957:43` — the same file, line and column as the CI report |
| after | 0, in three consecutive runs |

`test_thread_local_bytecode` passes 10 out of 10 runs on that build, and `test_opcache`, `test_capi`, `test_code`, `test_monitoring`, `test_sys_settrace` and `test_generators` pass under TSan (2244 tests). On macOS, `test_thread_local_bytecode`, `test_opcache`, `test_monitoring` and `test_capi` pass on a free-threaded debug build, and `test_opcache`, `test_dis`, `test_monitoring`, `test_generators`, `test_sys_settrace` and `test_capi` pass on the default build.


<!-- gh-issue-number: gh-157194 -->
* Issue: gh-157194
<!-- /gh-issue-number -->
