### PR TITLE
[3.15] gh-156910: fix deadlock in type_set_abstractmethods under free-threading (#156948)

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-09-04-22-00-00.gh-issue-156910.aBcD3f.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-09-04-22-00-00.gh-issue-156910.aBcD3f.rst
@@ -1,0 +1,3 @@
+Fix a deadlock in the :term:`free threaded <free threading>` build when
+setting ``__abstractmethods__`` on a type while another thread holds the
+type lock.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1776,14 +1776,17 @@ type_set_abstractmethods(PyObject *tp, PyObject *value, void *Py_UNUSED(closure)
         return -1;
     }
 
+    pinned_mutexes_t pinned;
     BEGIN_TYPE_LOCK();
     type_modified_unlocked(type);
+    type_lock_prevent_release(&pinned);
     types_stop_world();
     if (abstract)
         type_add_flags(type, Py_TPFLAGS_IS_ABSTRACT);
     else
         type_clear_flags(type, Py_TPFLAGS_IS_ABSTRACT);
     types_start_world();
+    type_lock_allow_release(&pinned);
     ASSERT_TYPE_LOCK_HELD();
     END_TYPE_LOCK();
 


### PR DESCRIPTION


(cherry picked from commit 1ac3bfaacc424775438f5873fa178a93a53edef2)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156910 -->
* Issue: gh-156910
<!-- /gh-issue-number -->
