### PR TITLE
gh-157210: Attach a combining mark in the last curses Textbox cell

### DIFF
--- a/Lib/curses/textpad.py
+++ b/Lib/curses/textpad.py
@@ -2,6 +2,7 @@
 
 import curses
 import curses.ascii
+import unicodedata
 
 def rectangle(win, uly, ulx, lry, lrx):
     """Draw a rectangle with corners at the provided upper-left
@@ -98,7 +99,14 @@ class Textbox:
                 # the cursor out of the window (an error, and it scrolls a
                 # scrollable window).
                 if isinstance(ch, int):
-                    self.win.insch(self._decode(ch), ch & curses.A_ATTRIBUTES)
+                    ch, attr = self._decode(ch), ch & curses.A_ATTRIBUTES
+                else:
+                    attr = curses.A_NORMAL
+                if isinstance(ch, str) and unicodedata.combining(ch):
+                    cell = self.win.in_wch()
+                    ch = curses.complexchar(str(cell) + ch, cell.attr, cell.pair)
+                if isinstance(ch, str):
+                    self.win.insch(ch, attr)
                 else:
                     self.win.insch(ch)
                 break

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -2698,6 +2698,18 @@ class TestCurses(unittest.TestCase):
             self.assertEqual(box.gather(), text + ' ')
 
     @requires_wide_build
+    def test_textbox_combining_fill_last_cell(self):
+        # A combining mark typed into the lower-right cell, which is written
+        # with insch(), attaches to the character already there instead of
+        # taking a cell of its own.
+        text = 'abe\u0301'          # 'e' + COMBINING ACUTE ACCENT in the corner
+        if self._encodable(text):
+            box, win = self._make_textbox(1, 3, stripspaces=0)
+            for ch in text:
+                box.do_command(ch)
+            self.assertEqual(box.gather(), text)
+
+    @requires_wide_build
     def test_textbox_double_width(self):
         # A double-width (East Asian) character occupies two cells.  gather()
         # reads a whole line at a time so that the second cell, which holds


### PR DESCRIPTION
The lower-right cell of a `Textbox` is written with `insch()`, which gave a lone combining mark a cell of its own and pushed the character it belongs to off the window edge. The mark is now merged into the cell that is already there.

No `Misc/NEWS.d` entry: a combining mark reaches that cell only through the string keystroke path added for 3.16, which has not been released.


<!-- gh-issue-number: gh-157210 -->
* Issue: gh-157210
<!-- /gh-issue-number -->
