### PR TITLE
gh-72165: Add timeout to Executor.shutdown

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -93,7 +93,7 @@ Executor Objects
          The returned iterator is no longer automatically closed if a *fn*
          call raises an exception.
 
-   .. method:: shutdown(wait=True, *, cancel_futures=False)
+   .. method:: shutdown(wait=True, *, cancel_futures=False, timeout=None)
 
       Signal the executor that it should free any resources that it is using
       when the currently pending futures are done executing.  Calls to
@@ -112,6 +112,15 @@ Executor Objects
       futures that the executor has not started running. Any futures that
       are completed or running won't be cancelled, regardless of the value
       of *cancel_futures*.
+
+      If *timeout* is not ``None``, this method will wait at most the given
+      number of seconds for the executor to shut down. The timeout has no
+      effect when *wait* is false. If the timeout expires while waiting,
+      :exc:`TimeoutError` is raised. Running futures are not cancelled and may
+      continue executing after this method returns.
+
+      .. versionchanged:: next
+         Added the *timeout* parameter.
 
       If both *cancel_futures* and *wait* are ``True``, all futures that the
       executor has started running will be completed prior to this method

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -136,6 +136,12 @@ concurrent.futures
   Use method :meth:`!close` to explicitly close the iterator.
   (Contributed by xzmeng and Serhiy Storchaka in :gh:`108518`.)
 
+  * :meth:`concurrent.futures.Executor.shutdown` now accepts a *timeout*
+  parameter to limit how long it waits for the executor to shut down.
+  :exc:`TimeoutError` is raised if the executor does not shut down within
+  the specified time.
+  (Contributed by Ilham Al Rahm in :gh:`72165`.)
+
 
 csv
 ---

--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -688,7 +688,7 @@ class Executor(object):
                     future.cancel()
         return result_iterator()
 
-    def shutdown(self, wait=True, *, cancel_futures=False):
+    def shutdown(self, wait=True, *, cancel_futures=False, timeout=None):
         """Clean-up the resources associated with the Executor.
 
         It is safe to call this method several times. Otherwise, no other
@@ -701,6 +701,10 @@ class Executor(object):
             cancel_futures: If True then shutdown will cancel all pending
                 futures. Futures that are completed or running will not be
                 cancelled.
+            timeout: The maximum number of seconds to wait for the executor to
+                shut down. If the timeout expires before the executor shuts down,
+                TimeoutError is raised. Running futures are not cancelled and may
+                continue executing after this method returns.
         """
         pass
 

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -54,6 +54,7 @@ import multiprocessing as mp
 import multiprocessing.connection
 from multiprocessing.queues import Queue
 import threading
+import time
 import weakref
 from functools import partial
 import itertools
@@ -973,7 +974,7 @@ class ProcessPoolExecutor(_base.Executor):
                               buffersize=buffersize)
         return _base._MapResultIterator(_chain_from_iterable_of_lists(results))
 
-    def shutdown(self, wait=True, *, cancel_futures=False):
+    def shutdown(self, wait=True, *, cancel_futures=False, timeout=None):
         with self._shutdown_lock:
             self._cancel_pending_futures = cancel_futures
             self._shutdown_thread = True
@@ -982,7 +983,14 @@ class ProcessPoolExecutor(_base.Executor):
                 self._executor_manager_thread_wakeup.wakeup()
 
         if self._executor_manager_thread is not None and wait:
-            self._executor_manager_thread.join()
+            end_time = None if timeout is None else time.monotonic() + timeout
+            if end_time is None:
+                self._executor_manager_thread.join()
+            else:
+                self._executor_manager_thread.join(
+                    max(0, end_time - time.monotonic()))
+                if self._executor_manager_thread.is_alive():
+                    raise _base.TimeoutError()
         # To reduce the risk of opening too many files, remove references to
         # objects that use file descriptors.
         self._executor_manager_thread = None

--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -9,6 +9,7 @@ from concurrent.futures import _base
 import itertools
 import queue
 import threading
+import time
 import types
 import weakref
 import os
@@ -251,7 +252,7 @@ class ThreadPoolExecutor(_base.Executor):
                 if work_item is not None:
                     work_item.future.set_exception(self.BROKEN(self._broken))
 
-    def shutdown(self, wait=True, *, cancel_futures=False):
+    def shutdown(self, wait=True, *, cancel_futures=False, timeout=None):
         with self._shutdown_lock:
             self._shutdown = True
             if cancel_futures:
@@ -269,6 +270,12 @@ class ThreadPoolExecutor(_base.Executor):
             # _work_queue.get(block=True) from permanently blocking.
             self._work_queue.put(None)
         if wait:
+            end_time = None if timeout is None else time.monotonic() + timeout
             for t in self._threads:
-                t.join()
+                if end_time is None:
+                    t.join()
+                else:
+                    t.join(max(0, end_time - time.monotonic()))
+                    if t.is_alive():
+                        raise _base.TimeoutError()
     shutdown.__doc__ = _base.Executor.shutdown.__doc__

--- a/Lib/test/test_concurrent_futures/test_shutdown.py
+++ b/Lib/test/test_concurrent_futures/test_shutdown.py
@@ -110,6 +110,38 @@ class ExecutorShutdownTest:
         # one finished.
         self.assertGreater(len(others), 0)
 
+    def test_shutdown_timeout(self):
+        # A zero timeout raises while work is still running.
+        future = self.executor.submit(time.sleep, 0.1)
+        with self.assertRaises(futures.TimeoutError):
+            self.executor.shutdown(timeout=0)
+        self.assertFalse(future.done())
+
+        future.result(timeout=support.SHORT_TIMEOUT)
+
+    def test_shutdown_timeout_expires(self):
+        # A positive timeout raises when shutdown takes longer than allowed.
+        future = self.executor.submit(time.sleep, 0.1)
+        with self.assertRaises(futures.TimeoutError):
+            self.executor.shutdown(timeout=0.01)
+        self.assertFalse(future.done())
+
+        future.result(timeout=support.SHORT_TIMEOUT)
+
+    def test_shutdown_timeout_completed(self):
+        # Shutdown succeeds when all work finishes before the timeout.
+        future = self.executor.submit(pow, 2, 5)
+        future.result(timeout=support.SHORT_TIMEOUT)
+        self.executor.shutdown(timeout=support.SHORT_TIMEOUT)
+
+    def test_shutdown_timeout_wait_false(self):
+        # wait=False returns immediately without using the timeout.
+        future = self.executor.submit(time.sleep, 0.1)
+        self.executor.shutdown(wait=False, timeout=0)
+        self.assertFalse(future.done())
+
+        future.result(timeout=support.SHORT_TIMEOUT)
+
     def test_hang_gh83386(self):
         """shutdown(wait=False) doesn't hang at exit with running futures.
 

--- a/Misc/NEWS.d/next/Library/2026-09-09-17-04-55.gh-issue-72165.HXoGNA.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-09-17-04-55.gh-issue-72165.HXoGNA.rst
@@ -1,0 +1,2 @@
+Add a *timeout* parameter to :meth:`concurrent.futures.Executor.shutdown` to
+limit how long it waits for the executor to shut down.


### PR DESCRIPTION
Add a timeout parameter to concurrent.futures.Executor.shutdown().

The timeout limits how long shutdown() waits for the executor to
finish shutting down. If the timeout expires, TimeoutError is raised.

Running futures are not cancelled and may continue executing after
shutdown() raises.

gh-72165