### PR TITLE
gh-157216: Document that forkserver preload skips deferred imports

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1242,6 +1242,16 @@ Miscellaneous
    processes. This can be used as a performance enhancement to avoid repeated
    work in every process.
 
+   Only the modules named in *module_names* are imported, together with
+   whatever those modules import at module level. A module imported inside a
+   function body is not imported in the forkserver process, and is therefore
+   imported again in every child process, the first time that function runs
+   there. For example, preloading :mod:`datetime` does not cover
+   ``_strptime``, which :meth:`~datetime.datetime.strptime` imports on its
+   first call, so every child pays for that import privately. To share such
+   modules as well, call the function at the module level of a preloaded
+   module, so that the import happens in the forkserver process.
+
    For this to work, it must be called before the forkserver process has been
    launched (before creating a :class:`Pool` or starting a :class:`Process`).
 


### PR DESCRIPTION
The current `set_forkserver_preload()` entry says the named modules' "already imported state is inherited by forked processes", but doesn't say what happens to a module that a preloaded module imports inside a function body rather than at module level. Those are not imported in the forkserver process, so each child imports them privately on first use.

This adds a paragraph after the opening description: module-level imports are inherited (transitively), imports inside function bodies are not, with `datetime.strptime()` / `_strptime` as the example, and a note that calling such a function at the module level of a preloaded module puts the import in the forkserver.

Measurements, module counts and a reproducer are in gh-157216.

Docs-only, so no `Misc/NEWS.d` entry.