### PR TITLE
gh-156780: Emscripten: drop the trampoline's dependence on exports

### DIFF
--- a/Python/emscripten_trampoline.c
+++ b/Python/emscripten_trampoline.c
@@ -47,6 +47,19 @@ typedef PyObject* (*TrampolineFunc)(int* success,
                                     PyObject* args,
                                     PyObject* kw);
 
+// Lets JS reach _PyRuntime without it being in -sEXPORTED_FUNCTIONS.
+EMSCRIPTEN_KEEPALIVE _PyRuntimeState *const _PyEM_runtime = &_PyRuntime;
+
+// Its table slot is taken over by the wasm-gc trampoline, so the table
+// never grows.
+static PyObject*
+trampoline_placeholder(int* success, PyCFunctionWithKeywords func,
+                       PyObject* self, PyObject* args, PyObject* kw)
+{
+    Py_FatalError("Emscripten trampoline slot was not set up");
+}
+EMSCRIPTEN_KEEPALIVE const TrampolineFunc _PyEM_trampoline_slot = trampoline_placeholder;
+
 /**
  * Backwards compatible trampoline works with all JS runtimes
  */
@@ -79,7 +92,9 @@ function getPyEMTrampolinePtr() {
     const trampolineInstance = new WebAssembly.Instance(trampolineModule, {
         env: { __indirect_function_table: wasmTable, memory: wasmMemory },
     });
-    return addFunction(trampolineInstance.exports.trampoline_call);
+    const slot = HEAPU32[__PyEM_trampoline_slot / 4];
+    wasmTable.set(slot, trampolineInstance.exports.trampoline_call);
+    return slot;
 }
 // We have to be careful to work correctly with memory snapshots -- the value of
 // _PyRuntimeState.emscripten_trampoline needs to reflect whether wasm-gc is
@@ -90,12 +105,12 @@ function getPyEMTrampolinePtr() {
 addOnPreRun(function setEmscriptenTrampoline() {
     const ptr = getPyEMTrampolinePtr();
     const offset = HEAP32[__PyEM_EMSCRIPTEN_TRAMPOLINE_OFFSET / 4];
-    HEAP32[(__PyRuntime + offset) / 4] = ptr;
+    HEAP32[(HEAPU32[__PyEM_runtime / 4] + offset) / 4] = ptr;
 });
 );
 
 EM_JS_DEPS(_PyEM_TrampolineCall,
-           "$wasmTable,$wasmMemory,$addFunction,$addOnPreRun");
+           "$wasmTable,$wasmMemory,$addOnPreRun");
 
 PyObject*
 _PyEM_TrampolineCall(PyCFunctionWithKeywords func,

--- a/configure
+++ b/configure
@@ -9978,7 +9978,7 @@ fi
 
         as_fn_append LINKFORSHARED " -sFORCE_FILESYSTEM -lidbfs.js -lnodefs.js -lproxyfs.js -lworkerfs.js"
     as_fn_append LINKFORSHARED " -sEXPORTED_RUNTIME_METHODS=FS,callMain,ENV,HEAPU32,TTY,ERRNO_CODES"
-    as_fn_append LINKFORSHARED " -sEXPORTED_FUNCTIONS=_main,_Py_Version,__PyRuntime,_PyGILState_GetThisThreadState,__PyEM_EMSCRIPTEN_TRAMPOLINE_OFFSET"
+    as_fn_append LINKFORSHARED " -sEXPORTED_FUNCTIONS=_main,_Py_Version,_PyGILState_GetThisThreadState,__PyEM_EMSCRIPTEN_TRAMPOLINE_OFFSET"
     as_fn_append LINKFORSHARED " -sSTACK_SIZE=5MB"
         as_fn_append LINKFORSHARED " -sTEXTDECODER=2"
 

--- a/configure.ac
+++ b/configure.ac
@@ -2440,7 +2440,7 @@ AS_CASE([$ac_sys_system],
     dnl Include file system support
     AS_VAR_APPEND([LINKFORSHARED], [" -sFORCE_FILESYSTEM -lidbfs.js -lnodefs.js -lproxyfs.js -lworkerfs.js"])
     AS_VAR_APPEND([LINKFORSHARED], [" -sEXPORTED_RUNTIME_METHODS=FS,callMain,ENV,HEAPU32,TTY,ERRNO_CODES"])
-    AS_VAR_APPEND([LINKFORSHARED], [" -sEXPORTED_FUNCTIONS=_main,_Py_Version,__PyRuntime,_PyGILState_GetThisThreadState,__PyEM_EMSCRIPTEN_TRAMPOLINE_OFFSET"])
+    AS_VAR_APPEND([LINKFORSHARED], [" -sEXPORTED_FUNCTIONS=_main,_Py_Version,_PyGILState_GetThisThreadState,__PyEM_EMSCRIPTEN_TRAMPOLINE_OFFSET"])
     AS_VAR_APPEND([LINKFORSHARED], [" -sSTACK_SIZE=5MB"])
     dnl Avoid bugs in JS fallback string decoding path
     AS_VAR_APPEND([LINKFORSHARED], [" -sTEXTDECODER=2"])


### PR DESCRIPTION
Split out of #156781 as requested by @hoodmane.

The call trampoline exports `_PyRuntime`'s address itself and takes over a placeholder's function table slot instead of calling `addFunction()`, so it no longer needs `_PyRuntime` in `-sEXPORTED_FUNCTIONS` or `-sALLOW_TABLE_GROWTH`. `__PyRuntime` is dropped from the interpreter's export list.

Tested with the CI configuration: the wasm-gc trampoline is picked up and `test_capi`, `test_builtin`, `test_functools` pass.

<!-- gh-issue-number: gh-156780 -->
* Issue: gh-156780
<!-- /gh-issue-number -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
