### PR TITLE
Fix a stray newline in the `cell` type docstring

### DIFF
--- a/Objects/cellobject.c
+++ b/Objects/cellobject.c
@@ -29,7 +29,7 @@ PyDoc_STRVAR(cell_new_doc,
 "\n"
 "  contents\n"
 "    the contents of the cell. If not specified, the cell will be empty,\n"
-"    and \n further attempts to access its cell_contents attribute will\n"
+"    and further attempts to access its cell_contents attribute will\n"
 "    raise a ValueError.");
 
 


### PR DESCRIPTION
The `contents` documentation was split over multiple lines, but an extra newline meant that there was an (indented) line with just the word "and" followed by an unindented line with "further attempts...". Remove that newline to avoid having just a single word in the documentation and to fix the indentation.