### PR TITLE
gh-157244: Fix potential division by zero in turtle.py

### DIFF
--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -1095,6 +1095,8 @@ class TurtleScreen(TurtleScreenBase):
             self.mode("world")
         xspan = float(urx - llx)
         yspan = float(ury - lly)
+        if xspan == 0 or yspan == 0:
+            raise ValueError("Width and height must be greater than zero")
         wx, wy = self._window_size()
         self.screensize(wx-20, wy-20)
         oldxscale, oldyscale = self.xscale, self.yscale
@@ -2055,6 +2057,8 @@ class TNavigator(object):
         if steps is None:
             frac = abs(extent)/self._fullcircle
             steps = 1+int(min(11+abs(radius)/6.0, 59.0)*frac)
+        if steps == 0:
+            raise ValueError("steps must not be zero")
         w = 1.0 * extent / steps
         w2 = 0.5 * w
         l = 2.0 * radius * math.sin(math.radians(w2)*self._degreesPerAU)


### PR DESCRIPTION
Fixes #157244

This PR adds guard clauses to prevent potential ZeroDivisionError exceptions in the turtle module:

-Validates `xspan` and `yspan` in `setworldcoordinates` to prevent division by zero during coordinate scaling.
-Validates `steps` in `circle` before using it as a denominator.
(Backport request: to 3.13).

<!-- gh-issue-number: gh-157244 -->
* Issue: gh-157244
<!-- /gh-issue-number -->
