### PR TITLE
gh-157250: Remove superfluous symbol in inline assembly

### DIFF
--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -324,7 +324,7 @@ _Py_get_machine_stack_pointer(void) {
 #elif defined(__aarch64__)
     __asm__ ("mov %0, sp" : "=r" (result));
 #elif defined(__x86_64__)
-    __asm__("{movq %%rsp, %0" : "=r" (result));
+    __asm__("movq %%rsp, %0" : "=r" (result));
 #else
     char here;
     result = (uintptr_t)&here;


### PR DESCRIPTION
Remove an extra `{` in inline assembly that is likely typo.

<!-- gh-issue-number: gh-157250 -->
* Issue: gh-157250
<!-- /gh-issue-number -->
