### PR TITLE
gh-157212: Fix _Py_ThreadId() on Windows ARM64 with MinGW

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -523,7 +523,9 @@ _Py_ThreadId(void)
 #elif defined(__MINGW32__) && defined(_M_IX86)
     tid = __readfsdword(24);
 #elif defined(__MINGW32__) && defined(_M_ARM64)
-    tid = __getReg(18);
+    // Windows on ARM64 keeps the TEB in x18. The __getReg() intrinsic used by
+    // the MSVC branch above is not available for MinGW ARM64.
+    __asm__ ("mov %0, x18" : "=r" (tid));
 #elif defined(__i386__)
     __asm__("{movl %%gs:0, %0|mov %0, dword ptr gs:[0]}" : "=r" (tid));  // 32-bit always uses GS
 #elif defined(__MACH__) && defined(__x86_64__)

--- a/Misc/NEWS.d/next/Windows/2026-09-10-01-21-34.gh-issue-157212.2Zx7YD.rst
+++ b/Misc/NEWS.d/next/Windows/2026-09-10-01-21-34.gh-issue-157212.2Zx7YD.rst
@@ -1,0 +1,4 @@
+Fix compilation of free-threaded builds and extension modules on Windows
+ARM64 with MinGW toolchains. ``_Py_ThreadId()`` used ``__getReg()``, an
+intrinsic that is not available for MinGW ARM64; the thread environment
+block is now read from ``x18`` directly. Patch by Christian Aurich.


### PR DESCRIPTION


<!-- gh-issue-number: gh-157212 -->
* Issue: gh-157212
<!-- /gh-issue-number -->
