### PR TITLE
gh-157212: Fix _Py_ThreadId() on Windows ARM64 with MinGW

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -523,7 +523,8 @@ _Py_ThreadId(void)
 #elif defined(__MINGW32__) && defined(_M_IX86)
     tid = __readfsdword(24);
 #elif defined(__MINGW32__) && defined(_M_ARM64)
-    tid = __getReg(18);
+    // x18 is the Windows ARM64 platform register and points to the TEB.
+    __asm__ ("mov %0, x18" : "=r" (tid));
 #elif defined(__i386__)
     __asm__("{movl %%gs:0, %0|mov %0, dword ptr gs:[0]}" : "=r" (tid));  // 32-bit always uses GS
 #elif defined(__MACH__) && defined(__x86_64__)

--- a/Misc/NEWS.d/next/Windows/2026-09-10-02-00-00.gh-issue-157212.x18TEB.rst
+++ b/Misc/NEWS.d/next/Windows/2026-09-10-02-00-00.gh-issue-157212.x18TEB.rst
@@ -1,0 +1,3 @@
+Fix ``_Py_ThreadId()`` compilation on Windows ARM64 with MinGW toolchains,
+where ``__getReg()`` is unavailable. The TEB address is now read directly
+from ``x18``. Patch by Christian Aurich.


### PR DESCRIPTION
Fixes #157212

`_Py_ThreadId()` currently uses `__getReg(18)` for the MinGW ARM64 branch:

```c
#elif defined(__MINGW32__) && defined(_M_ARM64)
    tid = __getReg(18);
```

That intrinsic is not available for MinGW ARM64. For a `*-windows-gnu` target, Clang's `intrin.h` defers to mingw-w64's header, which declares `__getReg` only for Itanium. GCC does not provide a corresponding builtin either.

The branch is reached by AArch64 MinGW toolchains because mingw-w64 defines `_M_ARM64` when `__aarch64__` is defined.

Falling through to the generic `__aarch64__` implementation is not a valid alternative. The Windows ARM64 ABI reserves `x18` as the platform register pointing to the Thread Environment Block (TEB). In the system tested in gh-157212, `x18` also matched `NtCurrentTeb()` for each tested thread, while `tpidr_el0` was observed as zero.

This change therefore reads the TEB address directly from `x18` for MinGW
ARM64:

```c
__asm__ ("mov %0, x18" : "=r" (tid));
```

The MSVC branch is unchanged.

### Verification

I reproduced the original compile failure with `zig cc`/Clang targeting
`aarch64-windows-gnu`:

```text
error: call to undeclared function '__getReg'; ISO C99 and later do not
support implicit function declarations [-Wimplicit-function-declaration]
```

With this change, the same target compiles successfully and at `-O2` emits the expected register read:

```asm
mov     x0, x18
ret
```

The change is limited to the MinGW ARM64 branch.

AI tools were used to help organize and edit the wording of this PR description.