### PR TITLE
gh-149760: Improve exception tracebacks from TarFile.next()

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2951,12 +2951,12 @@ class TarFile(object):
             except Exception as e:
                 try:
                     import zlib
+                except ImportError:
+                    pass
+                else:
                     if isinstance(e, zlib.error):
                         raise ReadError(f'zlib error: {e}') from None
-                    else:
-                        raise e
-                except ImportError:
-                    raise e
+                raise
             break
 
         if tarinfo is not None:

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -877,6 +877,33 @@ class MiscReadTestBase(CommonReadTest):
             with self.assertRaises(tarfile.ReadError):
                 tarfile.open(self.tarname)
 
+    def test_next_preserves_exception_traceback(self):
+        class FailingFile(io.BytesIO):
+            def read(self, *args):
+                raise error
+
+        for error_type in (OSError, ImportError):
+            for missing_zlib in (False, True):
+                with self.subTest(error_type=error_type,
+                                  missing_zlib=missing_zlib):
+                    error = error_type("read failed")
+                    modules = {"zlib": None} if missing_zlib else {}
+                    with unittest.mock.patch.dict(sys.modules, modules):
+                        try:
+                            tarfile.open(fileobj=FailingFile(), mode="r:")
+                        except error_type as exc:
+                            self.assertIs(exc, error)
+                            next_frames = 0
+                            tb = exc.__traceback__
+                            while tb is not None:
+                                code = tb.tb_frame.f_code
+                                if code is tarfile.TarFile.next.__code__:
+                                    next_frames += 1
+                                tb = tb.tb_next
+                            self.assertEqual(next_frames, 1)
+                        else:
+                            self.fail(f"{error_type.__name__} not raised")
+
     def test_next_on_empty_tarfile(self):
         fd = io.BytesIO()
         tf = tarfile.open(fileobj=fd, mode="w")

--- a/Misc/NEWS.d/next/Library/2026-09-10-15-51-43.gh-issue-149760.Pwme-m.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-10-15-51-43.gh-issue-149760.Pwme-m.rst
@@ -1,0 +1,2 @@
+Preserve the original traceback when :meth:`tarfile.TarFile.next`
+reraises an exception.


### PR DESCRIPTION
Keep the original traceback when TarFile.next() reraises non-zlib exceptions, including when zlib is unavailable. Preserve the existing conversion of zlib.error to ReadError.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-149760 -->
* Issue: gh-149760
<!-- /gh-issue-number -->
