### PR TITLE
Skip optimisations to speedup `test_freeze` rebuild

### DIFF
--- a/Tools/freeze/test/freeze.py
+++ b/Tools/freeze/test/freeze.py
@@ -64,6 +64,16 @@ def find_opt(args, name):
     return -1
 
 
+def remove_opt(args: list[str], name: str) -> None:
+    opt = f'--{name}'
+    optstart = f'{opt}='
+    args[:] = [
+        arg
+        for arg in args
+        if arg != opt and not arg.startswith(optstart)
+    ]
+
+
 def ensure_opt(args, name, value):
     opt = f'--{name}'
     pos = find_opt(args, name)
@@ -128,6 +138,10 @@ def prepare(script=None, outdir=None):
     # Run configure.
     print(f'configuring python in {builddir}...')
     config_args = shlex.split(sysconfig.get_config_var('CONFIG_ARGS') or '')
+    # Optimisations such as LTO and PGO only slow down the build of this
+    # throwaway interpreter without affecting what the test checks.
+    remove_opt(config_args, 'enable-optimizations')
+    remove_opt(config_args, 'with-lto')
     cmd = [os.path.join(srcdir, 'configure'), *config_args]
     ensure_opt(cmd, 'cache-file', os.path.join(outdir, 'python-config.cache'))
     prefix = os.path.join(outdir, 'python-installation')


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

For LTO buildbots, `test_tools` from `test_freeze.py` accounts for the majority of the test runtime:

| Builder (build) | Test step | test_tools | % |
|---|---|---|---|
| PPC64LE CentOS9 LTO | [35m09s](https://buildbot.python.org/#/builders/868/builds/8227) | 31m09s | 89% |
| PPC64LE Fedora Stable LTO | [23m53s](https://buildbot.python.org/#/builders/541/builds/6852) | 17m51s | 75% |
| PPC64LE Fedora Rawhide LTO | [21m26s](https://buildbot.python.org/#/builders/448/builds/7941) | 20m57s | 98% |
| AMD64 CentOS9 LTO | [14m02s](https://buildbot.python.org/#/builders/831/builds/9377) | 13m59s | 100% |
| AMD64 Fedora Rawhide LTO | [13m24s](https://buildbot.python.org/#/builders/375/builds/9606) | 11m18s | 84% |
| aarch64 CentOS9 LTO | [11m19s](https://buildbot.python.org/#/builders/882/builds/10192) | 10m54s | 96% |
| AMD64 Fedora Stable LTO | [10m01s](https://buildbot.python.org/#/builders/271/builds/9491) | 7m14s | 72% |
| s390x RHEL9 LTO | [8m46s](https://buildbot.python.org/#/builders/1587/builds/5508) | 8m06s | 92% |
| aarch64 Fedora Rawhide LTO | [8m26s](https://buildbot.python.org/#/builders/307/builds/7326) | 7m10s | 85% |
| s390x Fedora Stable LTO | [8m08s](https://buildbot.python.org/#/builders/1654/builds/3300) | 7m37s | 94% |
| aarch64 CentOS10 LTO | [7m59s](https://buildbot.python.org/#/builders/2134/builds/538) | 6m26s | 81% |
| s390x Fedora Rawhide LTO | [7m44s](https://buildbot.python.org/#/builders/323/builds/7255) | 6m01s | 78% |
| aarch64 Fedora Stable LTO | [7m39s](https://buildbot.python.org/#/builders/336/builds/8454) | 6m47s | 89% |
| s390x CentOS10 LTO | [7m10s](https://buildbot.python.org/#/builders/2220/builds/317) | 6m22s | 89% |


Often the rest of the test suite had finished running, and we're just hanging on for this one to finish.

This is because it involves rebuilding the interpreter, and this includes the LTO flags, which results in a slow rebuild. The rebuild is to test the freezing machinery, and optimisation flags aren't needed here. 

See also https://github.com/python/cpython/issues/103053 which skipped the test on PGO, but not LTO. We could skip, but let's see if this improves things enough.
