### PR TITLE
gh-121647: Prefer decltype() for _Py_TYPEOF() on C++

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -352,7 +352,7 @@ PyAPI_FUNC(PyObject *) _PyObject_FunctionStr(PyObject *);
 #ifdef _Py_TYPEOF
 #define Py_SETREF(dst, src) \
     do { \
-        _Py_TYPEOF(dst)* _tmp_dst_ptr = &(dst); \
+        _Py_TYPEOF(&(dst)) _tmp_dst_ptr = &(dst); \
         _Py_TYPEOF(dst) _tmp_old_dst = (*_tmp_dst_ptr); \
         *_tmp_dst_ptr = (src); \
         Py_DECREF(_tmp_old_dst); \
@@ -374,7 +374,7 @@ PyAPI_FUNC(PyObject *) _PyObject_FunctionStr(PyObject *);
 #ifdef _Py_TYPEOF
 #define Py_XSETREF(dst, src) \
     do { \
-        _Py_TYPEOF(dst)* _tmp_dst_ptr = &(dst); \
+        _Py_TYPEOF(&(dst)) _tmp_dst_ptr = &(dst); \
         _Py_TYPEOF(dst) _tmp_old_dst = (*_tmp_dst_ptr); \
         *_tmp_dst_ptr = (src); \
         Py_XDECREF(_tmp_old_dst); \

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -545,9 +545,7 @@ extern "C" {
 // the /Zc:__cplusplus flag is used.
 #if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
 #  define _Py_TYPEOF(expr) typeof(expr)
-#elif defined(__cplusplus) && __cplusplus >= 201103L
-#  define _Py_TYPEOF(expr) decltype(expr)
-#elif defined(_MSVC_LANG) && _MSVC_LANG >= 201103L
+#elif defined(__cplusplus) && (__cplusplus >= 201103L ||  _MSVC_LANG >= 201103L)
 #  define _Py_TYPEOF(expr) decltype(expr)
 #elif defined(__GNUC__) || defined(__clang__) || \
     (defined(_MSC_VER) && _MSC_VER >= 1939)

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -538,15 +538,15 @@ extern "C" {
 //
 // Example: _Py_TYPEOF(x) x_copy = (x);
 //
-// On C23, use typeof(). Otherwise __typeof__() if on GCC, clang or
-// MSVC 17.9 and newer. Else if on C++11 or newer, decltype() is used.
+// On C23, use typeof(). On C++11, use decltype(). Otherwise, use __typeof__()
+// if on GCC, clang or MSVC 17.9 and newer.
 #if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
 #  define _Py_TYPEOF(expr) typeof(expr)
+#elif defined(__cplusplus) && __cplusplus >= 201103L
+#  define _Py_TYPEOF(expr) decltype(expr)
 #elif defined(__GNUC__) || defined(__clang__) || \
     (defined(_MSC_VER) && _MSC_VER >= 1939)
 #  define _Py_TYPEOF(expr) __typeof__(expr)
-#elif defined(__cplusplus) && __cplusplus >= 201103L
-#  define _Py_TYPEOF(expr) decltype(expr)
 #endif
 
 

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -540,9 +540,14 @@ extern "C" {
 //
 // On C23, use typeof(). On C++11, use decltype(). Otherwise, use __typeof__()
 // if on GCC, clang or MSVC 17.9 and newer.
+//
+// On MSVC, check also _MSVC_LANG since __cplusplus is 199711L unless
+// the /Zc:__cplusplus flag is used.
 #if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
 #  define _Py_TYPEOF(expr) typeof(expr)
 #elif defined(__cplusplus) && __cplusplus >= 201103L
+#  define _Py_TYPEOF(expr) decltype(expr)
+#elif defined(_MSVC_LANG) && _MSVC_LANG >= 201103L
 #  define _Py_TYPEOF(expr) decltype(expr)
 #elif defined(__GNUC__) || defined(__clang__) || \
     (defined(_MSC_VER) && _MSC_VER >= 1939)

--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -482,7 +482,7 @@ static inline Py_ALWAYS_INLINE void Py_DECREF(PyObject *op)
 #ifdef _Py_TYPEOF
 #define Py_CLEAR(op) \
     do { \
-        _Py_TYPEOF(op)* _tmp_op_ptr = &(op); \
+        _Py_TYPEOF(&(op)) _tmp_op_ptr = &(op); \
         _Py_TYPEOF(op) _tmp_old_op = (*_tmp_op_ptr); \
         if (_tmp_old_op != _Py_NULL) { \
             *_tmp_op_ptr = _Py_NULL; \


### PR DESCRIPTION
Using MSVC (on Windows), prefer decltype() over __typeof__() on C++.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121647 -->
* Issue: gh-121647
<!-- /gh-issue-number -->
