### PR TITLE
gh-156186: Fix PyREPL bracketed paste consuming the following newline

### DIFF
--- a/Lib/_pyrepl/commands.py
+++ b/Lib/_pyrepl/commands.py
@@ -504,15 +504,19 @@ class paste_mode(Command):
 
 class perform_bracketed_paste(Command):
     def do(self) -> None:
-        done = "\x1b[201~"
-        data = ""
+        done = b"\x1b[201~"
+        data = b""
         start = time.time()
         while done not in data:
             ev = self.reader.console.getpending()
-            data += ev.data
+            data += ev.raw
         trace(
-            "bracketed pasting of {l} chars done in {s:.2f}s",
+            "bracketed pasting of {l} bytes done in {s:.2f}s",
             l=len(data),
             s=time.time() - start,
         )
-        self.reader.insert(data.replace(done, ""))
+        pasted, _, rest = data.partition(done)
+        self.reader.insert(pasted.decode(self.reader.console.encoding, "replace"))
+
+        for byte in rest:
+            self.reader.console.push_char(byte)

--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -627,7 +627,8 @@ class WindowsConsole(Console):
         """
         Push a character to the console event queue.
         """
-        raise NotImplementedError("push_char not supported on Windows")
+        trace("push char {char!r}", char=char)
+        self.event_queue.push(char)
 
     def beep(self) -> None:
         self.__write("\x07")
@@ -671,6 +672,7 @@ class WindowsConsole(Console):
             e2 = self.event_queue.get()
             if e2:
                 e.data += e2.data
+                e.raw += e2.raw
 
         recs, rec_count = self._read_input_bulk(1024)
         for i in range(rec_count):
@@ -689,6 +691,7 @@ class WindowsConsole(Console):
                 if ch == "\r":
                     ch = "\n"
                 e.data += ch
+                e.raw += ch.encode(self.event_queue.encoding, "replace")
         return e
 
     def wait_for_event(self, timeout: float | None) -> bool:

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -2202,6 +2202,20 @@ class TestMain(ReplTestCase):
         self.assertNotIn("Exception", output)
         self.assertNotIn("Traceback", output)
 
+    def test_bracketed_paste_newline_after_end_marker(self):
+        # A newline arriving in the same read as the closing marker must
+        # execute the pasted block instead of being inserted as text.
+        # See #156186.
+        env = os.environ.copy()
+        commands = ("\x1b[200~x = 1\nprint(f'^{x=}')\n\x1b[201~"
+                    "\n"
+                    "exit()\n")
+        output, exit_code = self.run_repl(commands, env=env, skip=True)
+        self.assertEqual(exit_code, 0)
+        self.assertIn("^x=1", output)
+        self.assertNotIn("Exception", output)
+        self.assertNotIn("Traceback", output)
+
     @force_not_colorized
     def test_no_pyrepl_source_in_exc(self):
         # Avoid using _pyrepl/__main__.py in traceback reports

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -2205,7 +2205,7 @@ class TestMain(ReplTestCase):
     def test_bracketed_paste_newline_after_end_marker(self):
         # A newline arriving in the same read as the closing marker must
         # execute the pasted block instead of being inserted as text.
-        # See #156186.
+        # See gh-156186.
         env = os.environ.copy()
         commands = ("\x1b[200~x = 1\nprint(f'^{x=}')\n\x1b[201~"
                     "\n"

--- a/Misc/NEWS.d/next/Library/2026-09-10-09-43-11.gh-issue-156186.yeOh4o.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-10-09-43-11.gh-issue-156186.yeOh4o.rst
@@ -1,0 +1,2 @@
+Fix PyREPL so that a newline sent right after a pasted block runs the block,
+instead of being added to the pasted text.


### PR DESCRIPTION
A newline sent right after a bracketed paste was inserted into the buffer instead of running the block, because `perform_bracketed_paste` drains all pending input and inserts everything, including what follows the closing marker.

PR implements the fix proposed by @pablogsal in the issue:
`perform_bracketed_paste` now accumulates `event.raw`, splits at the first closing marker, inserts the prefix, pushes the suffix back through the console.

Windows needed two changes to make it work:
`getpending()` now fills `raw`, and `push_char()` is implemented on the event queue  so the suffix path works there too.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156186 -->
* Issue: gh-156186
<!-- /gh-issue-number -->
