### PR TITLE
gh-156680 - Update IPv4Network and IPv6Network docstring.

### DIFF
--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -519,10 +519,10 @@ dictionaries.
       The interpretation is similar to an integer *address*.
 
    4. A two-tuple of an address description and a netmask, where the address
-      description is either a string, a 32-bits integer, a 4-bytes packed
-      integer, or an existing :class:`IPv4Address` object; and the netmask is either
-      an integer representing the prefix length (e.g. ``24``) or a string
-      representing the prefix mask (e.g. ``255.255.255.0``).
+      description is either a string, a 32-bit integer, a 4-byte packed
+      integer, or an existing :class:`IPv4Address` object; and the netmask is
+      either an integer representing the prefix length (e.g. ``24``) or a
+      string representing the prefix mask (e.g. ``255.255.255.0``).
 
    An :exc:`AddressValueError` is raised if *address* is not a valid IPv4
    address.  A :exc:`NetmaskValueError` is raised if the mask is not valid for
@@ -769,9 +769,9 @@ dictionaries.
       The interpretation is similar to an integer *address*.
 
    4. A two-tuple of an address description and a netmask, where the address
-      description is either a string, a 128-bits integer, a 16-bytes packed
-      integer, or an existing :class:`IPv6Address` object; and the netmask is an
-      integer representing the prefix length.
+      description is either a string, a 128-bit integer, a 16-byte packed
+      integer, or an existing :class:`IPv6Address` object; and the netmask is
+      an integer representing the prefix length.
 
    An :exc:`AddressValueError` is raised if *address* is not a valid IPv6
    address.  A :exc:`NetmaskValueError` is raised if the mask is not valid for

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1569,7 +1569,7 @@ class IPv4Network(_BaseV4, _BaseNetwork):
 
               The address can also be a two-tuple of an address description
               and a netmask, where the address description is either a
-              string, a 32-bits integer, a 4-bytes packed integer, or an
+              string, a 32-bit integer, a 4-byte packed integer, or an
               existing IPv4Address object; and the netmask is either an
               integer representing the prefix length (e.g. 24) or a string
               representing the prefix mask (e.g. '255.255.255.0').

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1567,6 +1567,13 @@ class IPv4Network(_BaseV4, _BaseNetwork):
               IPv4Interface(int(IPv4Interface('192.0.2.1'))) ==
                 IPv4Interface('192.0.2.1')
 
+              The address can also be a two-tuple of an address description
+              and a netmask, where the address description is either a
+              string, a 32-bits integer, a 4-bytes packed integer, or an
+              existing IPv4Address object; and the netmask is either an
+              integer representing the prefix length (e.g. 24) or a string
+              representing the prefix mask (e.g. '255.255.255.0').
+
         Raises:
             AddressValueError: If ipaddress isn't a valid IPv4 address.
             NetmaskValueError: If the netmask isn't valid for
@@ -2357,6 +2364,12 @@ class IPv6Network(_BaseV6, _BaseNetwork):
               or, more generally
               IPv6Network(int(IPv6Network('2001:db8::'))) ==
                 IPv6Network('2001:db8::')
+
+              The address can also be a two-tuple of an address description
+              and a netmask, where the address description is either a
+              string, a 128-bits integer, a 16-bytes packed integer, or an
+              existing IPv6Address object; and the netmask is an integer
+              representing the prefix length.
 
             strict: A boolean. If true, ensure that we have been passed
               A true network address, eg, 2001:db8::1000/124 and not an

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1574,6 +1574,10 @@ class IPv4Network(_BaseV4, _BaseNetwork):
               integer representing the prefix length (e.g. 24) or a string
               representing the prefix mask (e.g. '255.255.255.0').
 
+            strict: A boolean. If true, ensure that we have been passed
+              a true network address, eg, 192.0.2.0/24 and not an
+              IP address on a network, eg, 192.0.2.1/24.
+
         Raises:
             AddressValueError: If ipaddress isn't a valid IPv4 address.
             NetmaskValueError: If the netmask isn't valid for
@@ -2365,14 +2369,14 @@ class IPv6Network(_BaseV6, _BaseNetwork):
               IPv6Network(int(IPv6Network('2001:db8::'))) ==
                 IPv6Network('2001:db8::')
 
-              The address can also be a two-tuple of an address description
-              and a netmask, where the address description is either a
-              string, a 128-bits integer, a 16-bytes packed integer, or an
-              existing IPv6Address object; and the netmask is an integer
-              representing the prefix length.
+              The address can also be a two-tuple of an address description and
+              a netmask, where the address description is either a string, a
+              128-bit integer, a 16-byte packed integer, or an existing
+              IPv6Address object; and the netmask is an integer representing
+              the prefix length.
 
             strict: A boolean. If true, ensure that we have been passed
-              A true network address, eg, 2001:db8::1000/124 and not an
+              a true network address, eg, 2001:db8::1000/124 and not an
               IP address on a network, eg, 2001:db8::1/124.
 
         Raises:


### PR DESCRIPTION
Mention that the address argument can be a two-tuple representing address description and a netmask.

It is a follow-up to this comment

https://github.com/python/cpython/pull/156681#discussion_r3974142230 

<!-- gh-issue-number: gh-156680 -->
* Issue: gh-156680
<!-- /gh-issue-number -->
