### PR TITLE
gh-156544: fix free-threading race in UserDict with __missing__ or default 

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -1187,7 +1187,10 @@ class UserDict(_collections_abc.MutableMapping):
 
     def __getitem__(self, key):
         if key in self.data:
-            return self.data[key]
+            try:
+                return self.data[key]
+            except KeyError:
+                pass
         if hasattr(self.__class__, "__missing__"):
             return self.__class__.__missing__(self, key)
         raise KeyError(key)
@@ -1208,7 +1211,10 @@ class UserDict(_collections_abc.MutableMapping):
 
     def get(self, key, default=None):
         if key in self:
-            return self[key]
+            try:
+                return self[key]
+            except KeyError:
+                pass
         return default
 
 

--- a/Lib/test/test_userdict.py
+++ b/Lib/test/test_userdict.py
@@ -307,6 +307,66 @@ class UserDictTest(mapping_tests.TestHashMappingProtocol):
         self.assertIs(type(u), UserDictSubclass)
         self.assertIs(u, u2)
 
+    def test_matches_dict(self):
+        key, value, missing = object(), object(), object()
+        class Missing:
+            def __missing__(self, key):
+                return missing
+        class _Dict(dict, Missing): pass
+        class _UserDict(UserDict, Missing): pass
+        _dict = _Dict({key: value})
+        _user_dict = _UserDict({key: value})
+        self.assertIs(_dict[key], _user_dict[key])
+        self.assertIs(_dict.get(key), _user_dict.get(key))
+        self.assertIs(_dict.get(missing), _user_dict.get(missing))
+        self.assertIs(_dict[missing], _user_dict[missing])
+
+    def test_data_delegation(self):
+        class Dict(dict):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.calls = []
+            def __contains__(self, *args, **kwargs):
+                self.calls.append('__contains__')
+                return super().__contains__(*args, **kwargs)
+            def __getitem__(self, *args, **kwargs):
+                self.calls.append('__getitem__')
+                return super().__getitem__(*args, **kwargs)
+            def __missing__(self, *args, **kwargs):
+                self.calls.append('__missing__')
+                if hasattr(self.data, '__missing__'):
+                    return super().__missing__(*args, **kwargs)
+            def get(self, *args, **kwargs):
+                self.calls.append('get')
+                return super().get(*args, **kwargs)
+        class _UserDict(UserDict):
+            def __init__(self, **kwargs):
+                super().__init__()
+                self.data = Dict(**kwargs)
+            def __missing__(self, key):
+                return 'missing'
+
+        # get with value
+        _dict = _UserDict(key='value')
+        self.assertEqual('value', _dict.get('key'))
+        self.assertEqual(['__contains__', '__contains__', '__getitem__'], # LH ??? why two contains
+                         _dict.data.calls)
+
+        # get without value
+        _dict = _UserDict()
+        self.assertEqual(None, _dict.get('key'))
+        self.assertEqual(['__contains__'], _dict.data.calls)
+
+        # getitem with value
+        _dict = _UserDict(key='value')
+        self.assertEqual('value', _dict['key'])
+        self.assertEqual(['__contains__', '__getitem__'], _dict.data.calls)
+
+        # getitem without value
+        _dict = _UserDict()
+        self.assertEqual('missing', _dict['key'])
+        self.assertEqual(['__contains__'], _dict.data.calls)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2026-09-10-20-48-42.gh-issue-156544.YGR1Ig.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-10-20-48-42.gh-issue-156544.YGR1Ig.rst
@@ -1,0 +1,1 @@
+Fix free-threading race in which UserDict.__getitem__ may not call __missing__ and UserDict.get() may not return the default.


### PR DESCRIPTION
This fixes race conditions with `UserDict.__getitem__()` and `.get()`. When the key is removed concurrently `__missing__` may not be called or the default not returned, instead KeyError is raised.
This occurs because the initial containment check can see the item as existing, it is then concurrently removed, and the subsequent subscript lookup raises KeyError. I have reproduced these races on free-threading builds but *not* GIL-enabled builds. @markshannon says this is because the bytecodes emitted by the compiler are such that the GIL will not be released during the execution of `__getitem__` or `get`.

I considered several alternatives to resolving this and settled on catching the KeyError when the race occurs because it preserves existing semantics with respect to the wrapped dict. I do not believe it introduces performance degradation because the added try/except only incurs material costs when the exception occurs which is the case this fix addresses. I considered using `self.data.get(key, MISSING)` as well as removing the check an relying solely on KeyError from the subscripting,  but both of these approaches that alter the semantics.

This PR includes two changesets. The first adds tests to ensure the fix does not change the semantics of how UserDict interacts with the dict it wraps. I have it as a separate commit to show that the fix to UserDict does not alter the semantics. I can squash them into a single commit if that is preferable, please let me know if this is preferable.


<!-- gh-issue-number: gh-156544 -->
* Issue: gh-156544
<!-- /gh-issue-number -->
