### PR TITLE
gh-157290: datetime: strftime %Nf microsecond format

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2695,9 +2695,15 @@ convenience.
 +-----------+--------------------------------+------------------------+-------+
 | Directive | Meaning                        | Example                | Notes |
 +===========+================================+========================+=======+
-|  ``%f``   | Microsecond as a decimal       | 000000, 000001, ...,   | \(5)  |
+|  ``%f``   | Microseconds as a decimal      | 000000, 000001, ...,   | \(5)  |
 |           | number, zero-padded to 6       | 999999                 |       |
 |           | digits.                        |                        |       |
++-----------+--------------------------------+------------------------+-------+
+|  ``%Nf``  | Microseconds as a decimal      | 0, ..., 9 (``%1f``);   | \(5)  |
+|           | fraction of a second (without  | 000, ..., 999          |       |
+|           | the point), rounded down to N  | (``%3f``);             |       |
+|           | digits (``1 <= N <= 6``).      | 000000, ..., 999999;   |       |
+|           |                                | (``%6f``)              |       |
 +-----------+--------------------------------+------------------------+-------+
 | ``%:z``   | UTC offset in the form         | (empty), +00:00,       | \(6)  |
 |           | ``±HH:MM[:SS[.ffffff]]``       | -04:00, +10:30,        |       |
@@ -2719,6 +2725,10 @@ differences between platforms in handling of unsupported format specifiers.
 
 .. versionadded:: 3.15
    ``%D``, ``%F``, ``%n``, ``%t``, and ``%:z`` were added for
+   :meth:`~.datetime.strptime`.
+
+.. versionadded:: 3.16
+   ``%Nf`` was added for :meth:`~.datetime.strftime` and
    :meth:`~.datetime.strptime`.
 
 
@@ -2825,11 +2835,19 @@ Notes:
    leap seconds.
 
 (5)
+   The ``%f`` directive formats the microsecond part zero-padded to 6 digits.
+   The ``%Nf`` directive (where ``1 <= N <= 6``) formats or parses the microsecond
+   part to *N* decimal places (e.g. ``%3f`` for milliseconds).
    When used with the :meth:`~.datetime.strptime` method, the ``%f`` directive
-   accepts from one to six digits and zero pads on the right. ``%f`` is
-   an extension to the set of format characters in the C standard (but
+   accepts from one to six digits and zero pads on the right, whereas the
+   ``%Nf`` directive requires an exact match of *N* digits. Both ``%f`` and
+   ``%Nf`` are extensions to the set of format characters in the C standard (but
    implemented separately in datetime objects, and therefore always
    available).
+
+   .. versionchanged:: 3.16
+      Added the ``%Nf`` format code for :meth:`~.datetime.strftime` and
+      :meth:`~.datetime.strptime`.
 
 (6)
    For a naive object, the ``%z``, ``%:z`` and ``%Z`` format codes are replaced

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -216,7 +216,7 @@ def _need_normalize_century():
 # Correctly substitute for %z and %Z escapes in strftime formats.
 def _wrap_strftime(object, format, timetuple):
     # Don't call utcoffset() or tzname() unless actually needed.
-    freplace = None  # the string to use for %f
+    freplace = {}  # the strings to use for %f and %Nf 1 <= N <= 6
     zreplace = None  # the string to use for %z
     colonzreplace = None  # the string to use for %:z
     Zreplace = None  # the string to use for %Z
@@ -232,11 +232,28 @@ def _wrap_strftime(object, format, timetuple):
             if i < n:
                 ch = format[i]
                 i += 1
-                if ch == 'f':
-                    if freplace is None:
-                        freplace = '%06d' % getattr(object,
-                                                    'microsecond', 0)
-                    newformat.append(freplace)
+
+                # Handle "%f" and "%Nf" where 1 <= N <= 6
+                if ch == "f" or (
+                    "0" <= ch <= "9" and i < n and format[i] == "f"
+                ):
+                    if ch == "f":
+                        frepl_len = 6
+                    else:
+                        frepl_len = int(ch)
+
+                        if frepl_len == 0 or frepl_len > 6:
+                            raise ValueError(f"%Nf format code requires 1 <= N <= 6, got {frepl_len}")
+
+                        i += 1
+
+                    microseconds = freplace.get(frepl_len)
+                    if microseconds is None:
+                        microseconds = '%06d' % getattr(object, 'microsecond', 0)
+                        microseconds = microseconds[:frepl_len]
+                        freplace[frepl_len] = microseconds
+
+                    newformat.append(microseconds)
                 elif ch == 'z':
                     if zreplace is None:
                         if hasattr(object, "utcoffset"):

--- a/Lib/_strptime.py
+++ b/Lib/_strptime.py
@@ -354,6 +354,7 @@ class TimeRE(dict):
         mapping = {
             # The " [1-9]" part of the regex is to make %c from ANSI C work
             'd': r"(?P<d>3[0-1]|[1-2]\d|0[1-9]|[1-9]| [1-9])",
+            # This is for "%f". "%Nf" format for 1 <= N <= 6 added in a loop below
             'f': r"(?P<f>[0-9]{1,6})",
             'H': r"(?P<H>2[0-3]|[0-1]\d|\d| \d)",
             'k': r"(?P<H>2[0-3]|[0-1]\d|\d| \d)",
@@ -386,6 +387,9 @@ class TimeRE(dict):
             't': r'\s*',
             '%': '%',
         }
+        for n in range(1, 7):
+            mapping[f"{n}f"] = rf"(?P<f>[0-9]{{{n}}})"
+
         if self.locale_time.LC_alt_digits is None:
             for d in 'dmyCHIMS':
                 mapping['O' + d] = r'(?P<%s>\d\d|\d| \d)' % d

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -507,6 +507,123 @@ class HarmlessMixedComparison:
         self.assertRaises(TypeError, lambda: () > me)
         self.assertRaises(TypeError, lambda: () >= me)
 
+
+#############################################################################
+# Common tests for types containing time
+
+def check_strftime_Nf_invalid(self: unittest.TestCase, t: datetime | time) -> None:
+    """Test %Nf codes with invalid N parameters."""
+    for fmt, expected_exc_message in [
+        ("%0f", "%Nf format code requires 1 <= N <= 6, got 0"),
+        ("%7f", "%Nf format code requires 1 <= N <= 6, got 7"),
+        ("%8f", "%Nf format code requires 1 <= N <= 6, got 8"),
+        ("%9f", "%Nf format code requires 1 <= N <= 6, got 9"),
+    ]:
+        with self.subTest(fmt=fmt):
+            with self.assertRaisesRegex(ValueError, re.escape(expected_exc_message)):
+                t.strftime(fmt)
+
+    # "%NNf", "%NNNf", etc fall through to libc and therefore remain undefined
+
+class TimeTestMixin:
+
+    # datetime and time have incompatible constructor args
+    def make_instance(self):
+        raise NotImplementedError
+
+    def test_strftime_Nf_valid(self):
+        """Test the "%Nf" formatting code, where N ∈ {'','1','2','3','4','5','6'}."""
+        t = self.make_instance()
+
+        all_usec_formats = "%f: %1f %2f %3f %4f %5f %6f"
+        for fmt, expected in [
+            ("%f", "123456"),
+            ("%1f", "1"),
+            ("%2f", "12"),
+            ("%3f", "123"),
+            ("%4f", "1234"),
+            ("%5f", "12345"),
+            ("%6f", "123456"),
+            ("TIME: %T.%f%Z", "TIME: 06:22:33.123456UTC"),
+            ("TIME: %T.%3f%Z", "TIME: 06:22:33.123UTC"),
+            (all_usec_formats, "123456: 1 12 123 1234 12345 123456"),
+            ("%ff", "123456f"),
+            ("%1ff", "1f"),
+            ("%2ff", "12f"),
+        ]:
+            with self.subTest(fmt=fmt):
+                self.assertEqual(t.strftime(fmt), expected)
+
+        t_6_usec = t.replace(microsecond=6)
+        self.assertEqual(t_6_usec.microsecond, 6)
+        self.assertEqual(t_6_usec.strftime(all_usec_formats), "000006: 0 00 000 0000 00000 000006")
+
+        t_0_usec = t.replace(microsecond=0)
+        self.assertEqual(t_0_usec.microsecond, 0)
+        self.assertEqual(t_0_usec.strftime(all_usec_formats), "000000: 0 00 000 0000 00000 000000")
+
+    def test_strftime_Nf_invalid(self):
+        """Test the "%Nf" formatting code, where N ∉ {'','1','2','3','4','5','6'}."""
+        t = self.make_instance()
+        check_strftime_Nf_invalid(self, t)
+
+    def test_strptime_Nf_format_valid(self):
+        """Ensure that the "%Nf" format works with strptime."""
+        Nf_cases = [
+            ("%T.%1f", "06:22:33.1", 100000),
+            ("%T.%2f", "06:22:33.12", 120000),
+            ("%T.%3f", "06:22:33.123", 123000),
+            ("%T.%4f", "06:22:33.1234", 123400),
+            ("%T.%5f", "06:22:33.12345", 123450),
+            ("%T.%6f", "06:22:33.123456", 123456),
+        ]
+        for fmt, time_str, expected_microsec in [
+            ("%T.%f", "06:22:33.123456", 123456),
+            *Nf_cases,
+        ]:
+            with self.subTest(fmt):
+                expected = self.make_instance().replace(microsecond=expected_microsec)
+                actual = self.theclass.strptime(time_str, fmt)
+
+                self.assertEqual(
+                    (actual.hour, actual.minute, actual.second, actual.microsecond),
+                    (expected.hour, expected.minute, expected.second, expected.microsecond),
+                )
+
+            # Too many digits should raise
+            with self.subTest(f"{fmt}_extra_digits"):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    re.escape("unconverted data remains: 0"),
+                ):
+                    self.theclass.strptime(time_str + "0", fmt)
+
+        # Too few digits should raise (unless %f is used)
+        for fmt, time_str, expected_microsec in Nf_cases:
+            with self.subTest(f"{fmt}_missing_digits"):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    re.escape("does not match format"),
+                ):
+                    self.theclass.strptime(time_str[:-1], fmt)
+
+    def test_strptime_Nf_format_invalid(self):
+        """Ensure the "%Nf" is rejected for unhandled Ns."""
+        for fmt, exc_msg in [
+            ("%T.%0f", "'0f' is a bad directive in format '%T.%0f'"),
+            ("%T.%-0f", "'-0f' is a bad directive in format '%T.%-0f'"),
+            ("%T.%-1f", "'-1f' is a bad directive in format '%T.%-1f'"),
+            ("%T.%-2f", "'-2f' is a bad directive in format '%T.%-2f'"),
+            ("%T.%7f", "'7f' is a bad directive in format '%T.%7f'"),
+            ("%T.%8f", "'8f' is a bad directive in format '%T.%8f'"),
+            ("%T.%10f", "'10f' is a bad directive in format '%T.%10f'"),
+            ("%T.%Nf", "'N' is a bad directive in format '%T.%Nf'"),
+        ]:
+            with self.subTest(fmt):
+                with self.assertRaisesRegex(ValueError, re.escape(exc_msg)):
+                    (self.theclass.strptime("", fmt),)
+
+
 #############################################################################
 # timedelta tests
 
@@ -1171,6 +1288,11 @@ class TestDateOnly(unittest.TestCase):
             # Variations on ISO 8601 format
             (date(2023, 9, 25), '2023-W39-1', '%G-W%V-%u'),  # ISO week date (Week 39, Monday)
             (date(2023, 9, 25), '2023-268', '%Y-%j'),  # Year and day of the year (Julian)
+
+            # Time discarded
+            (date(2004, 12, 2), '2004-12-02 11:33:44.123456', '%F %T.%f'),
+            (date(2004, 12, 2), '2004-12-02 11:33:44.123', '%F %T.%3f'),
+            (date(2004, 12, 2), '2004-12-02 11:33:44.1', '%F %T.%1f'),
         ]
         for expected, string, format in inputs:
             with self.subTest(string=string, format=format):
@@ -1630,9 +1752,29 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
 
         #check that this standard extension works
         t.strftime("%f")
+        t.strftime("%3f")
 
         # bpo-41260: The parameter was named "fmt" in the pure python impl.
         t.strftime(format="%f")
+
+    def test_strftime_Nf_zeros(self):
+        t = self.theclass(2005, 3, 2)
+
+        for fmt, expected in [
+            ("%f", "000000"),
+            ("%1f", "0"),
+            ("%2f", "00"),
+            ("%3f", "000"),
+            ("%4f", "0000"),
+            ("%5f", "00000"),
+            ("%6f", "000000"),
+        ]:
+            with self.subTest(fmt):
+                self.assertEqual(t.strftime(fmt), expected)
+
+    def test_strftime_Nf_invalid(self):
+        t = self.theclass(2005, 3, 2)
+        check_strftime_Nf_invalid(self, t)
 
     def test_strftime_trailing_percent(self):
         # bpo-35066: Make sure trailing '%' doesn't cause datetime's strftime to
@@ -2245,9 +2387,12 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
 class SubclassDatetime(datetime):
     sub_var = 1
 
-class TestDateTime(TestDate):
+class TestDateTime(TestDate, TimeTestMixin):
 
     theclass = datetime
+
+    def make_instance(self) -> datetime:
+        return self.theclass(2004, 12, 31, 6, 22, 33, 123456, tzinfo=timezone.utc)
 
     def test_basic_attributes(self):
         dt = self.theclass(2002, 3, 1, 12, 0)
@@ -3222,6 +3367,12 @@ class TestDateTime(TestDate):
         self.assertEqual(t.strftime('\0%c\0%B'), f'\0{s1}\0{s2}')
         self.assertEqual(t.strftime('%c\0%B\0'), f'{s1}\0{s2}\0')
 
+    def test_strftime_Nf_datetime(self):
+        """Test datetime.strftime with the date and %f/%Nf codes formatting."""
+        t = self.make_instance()
+        self.assertEqual(t.strftime("%FT%T.%f%Z"), "2004-12-31T06:22:33.123456UTC")
+        self.assertEqual(t.strftime("%FT%T.%3f%Z"),  "2004-12-31T06:22:33.123UTC")
+
     def test_extract(self):
         dt = self.theclass(2002, 3, 4, 18, 45, 3, 1234)
         self.assertEqual(dt.date(), date(2002, 3, 4))
@@ -3878,7 +4029,6 @@ class TestDateTime(TestDate):
             self.theclass.strptime(test_time, "%H:%M:%S")
         )
 
-
 class TestSubclassDateTime(TestDateTime):
     theclass = SubclassDatetime
     # Override tests not designed for subclass
@@ -3889,9 +4039,12 @@ class TestSubclassDateTime(TestDateTime):
 class SubclassTime(time):
     sub_var = 1
 
-class TestTime(HarmlessMixedComparison, unittest.TestCase):
+class TestTime(HarmlessMixedComparison, TimeTestMixin, unittest.TestCase):
 
     theclass = time
+
+    def make_instance(self) -> time:
+        return self.theclass(6, 22, 33, 123456, tzinfo=timezone.utc)
 
     def test_basic_attributes(self):
         t = self.theclass(12, 0)
@@ -4145,6 +4298,14 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
                                     ('%C', '19'), ('%F', '1900-01-01')):
             with self.subTest(directive=directive):
                 self.assertEqual(t.strftime(directive), expected)
+
+    def test_strftime_Nf_time(self):
+        """Test time.strftime with the date and %f/%Nf codes.
+
+        The date should be default 1900-01-01."""
+        t = self.make_instance()
+        self.assertEqual(t.strftime("%FT%T.%f%Z"), "1900-01-01T06:22:33.123456UTC")
+        self.assertEqual(t.strftime("%FT%T.%3f%Z"),  "1900-01-01T06:22:33.123UTC")
 
     def test_format(self):
         t = self.theclass(1, 2, 3, 4)

--- a/Misc/NEWS.d/next/Library/2026-09-10-12-00-00.gh-issue-157290.NfFmt.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-10-12-00-00.gh-issue-157290.NfFmt.rst
@@ -1,0 +1,4 @@
+Add ``%Nf`` format code support (where ``1 <= N <= 6``) to
+:meth:`datetime.datetime.strftime`, :meth:`datetime.time.strftime`,
+:meth:`datetime.date.strftime`, and :meth:`datetime.datetime.strptime` for
+formatting and parsing subsecond/microsecond precision.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -117,6 +117,7 @@ typedef struct {
 #define CONST_SEC_PER_DAY(st) st->seconds_per_day
 #define CONST_EPOCH(st) st->epoch
 #define CONST_UTC(st) ((PyObject *)&utc_timezone)
+#define STRFTIME_NF_DIGITS 6
 
 static datetime_state *
 get_module_state(PyObject *module)
@@ -1861,15 +1862,20 @@ make_Zreplacement(PyObject *object, PyObject *tzinfoarg)
 }
 
 static PyObject *
-make_freplacement(PyObject *object)
+make_freplacement(PyObject *object, size_t digits)
 {
     char freplacement[64];
+
+    assert(digits <= 6);
+
     if (PyTime_Check(object))
         sprintf(freplacement, "%06d", TIME_GET_MICROSECOND(object));
     else if (PyDateTime_Check(object))
         sprintf(freplacement, "%06d", DATE_GET_MICROSECOND(object));
     else
         sprintf(freplacement, "%06d", 0);
+
+    freplacement[digits] = '\0';
 
     return PyUnicode_FromString(freplacement);
 }
@@ -1890,7 +1896,8 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     PyObject *zreplacement = NULL;      /* py string, replacement for %z */
     PyObject *colonzreplacement = NULL; /* py string, replacement for %:z */
     PyObject *Zreplacement = NULL;      /* py string, replacement for %Z */
-    PyObject *freplacement = NULL;      /* py string, replacement for %f */
+    /* py string, replacements for "%Nf" where 1 <= N <= 6 */
+    PyObject *freplacements[STRFTIME_NF_DIGITS] = {NULL};
 
     assert(object && format && timetuple);
     assert(PyUnicode_Check(format));
@@ -1960,12 +1967,41 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
             }
             replacement = Zreplacement;
         }
-        else if (ch == 'f') {
-            /* format microseconds */
+        else if (ch == 'f' ||
+                (ch >= '0' && ch <= '9' && i < flen && PyUnicode_READ_CHAR(format, i) == 'f')
+        ) {
+            /* format microseconds ("%f" or "%Nf" where 1 <= N <= 6) */
+            size_t microsec_digits = 6;
+            if (ch != 'f') {
+                /* ch denotes N */
+                assert(ch >= '0' && ch <= '9');
+                microsec_digits = (size_t)(ch - '0');
+
+                /* prevent unsupported lengths from falling through and hitting libc where they
+                 * will become "optional minimum field widths". With Glibc, even though 'f' isn't supported,
+                 * an input of "%7f" produces a result of "    %7f".
+                 *
+                 * Note: a code with 2- or more digit-long "minimum field width" will still fall through.
+                 * This is "ok" because N is defined as a digit, not a number.
+                 */
+                if (microsec_digits == 0 || microsec_digits > 6) {
+                    PyErr_Format(PyExc_ValueError,
+                                 "%%Nf format code requires 1 <= N <= 6, got %zu",
+                                 microsec_digits);
+                    goto Error;
+                }
+
+                i++;
+            }
+
+            assert(microsec_digits >= 1 && microsec_digits <= 6);
+
+            PyObject *freplacement = freplacements[microsec_digits - 1];
             if (freplacement == NULL) {
-                freplacement = make_freplacement(object);
+                freplacement = make_freplacement(object, microsec_digits);
                 if (freplacement == NULL)
                     goto Error;
+                freplacements[microsec_digits - 1] = freplacement;
             }
             replacement = freplacement;
         }
@@ -2056,7 +2092,9 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     Py_DECREF(newformat);
 
  Done:
-    Py_XDECREF(freplacement);
+    for (size_t i = 0; i < STRFTIME_NF_DIGITS; ++i) {
+        Py_XDECREF(freplacements[i]);
+    }
     Py_XDECREF(zreplacement);
     Py_XDECREF(colonzreplacement);
     Py_XDECREF(Zreplacement);


### PR DESCRIPTION
Includes a change to `strftime` and a corresponding `strptime` change for 1 <= N <= 6.

`ValueError` will be raised from `strftime` if N ∈ {0, 7, 8, 9}.

`strptime` requires an exact match of the microsecond field length ("%3f" will accept "111" but not "11" or "1111").


GitHub issue: https://github.com/python/cpython/issues/157290

<!-- gh-issue-number: gh-157290 -->
* Issue: gh-157290
<!-- /gh-issue-number -->
