### PR TITLE
gh-156995: Add caution around API behavior change

### DIFF
--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -808,6 +808,13 @@ Object Protocol
    that this function doesn't call into the Python interpreter. This function
    cannot fail.
 
+   .. caution::
+
+      For objects where :c:expr:`Py_REFCNT(op) == 1` is always true this
+      function will return false when checked in a different thread than the
+      allocation. This can lead to subtle behavior change bugs between the
+      free-threaded and GIL-enabled builds (:gh:`156995`).
+
    .. versionadded:: 3.14
 
 .. c:function:: int PyUnstable_SetImmortal(PyObject *op)

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -812,8 +812,7 @@ Object Protocol
 
       For objects where :c:expr:`Py_REFCNT(op) == 1` is always true this
       function will return false when checked in a different thread than the
-      allocation. This can lead to subtle behavior change bugs between the
-      free-threaded and GIL-enabled builds (:gh:`156995`).
+      allocation.
 
    .. versionadded:: 3.14
 


### PR DESCRIPTION
The subtle change between free-threading and GIL-enabled builds resulted in the `Py_REFCNT(op) == 1` `bytes` object inside `bytearray` was considered non-unique during `_PyBytes_Resize`. That led to it being substituted for an immortal global rather than keeping the allocation only in free-threaded builds.

The behavior has been fixed in `_PyBytes_Resize` but the hazard exists and was a part of a release blocking bug so urge caution around that case when porting.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156995 -->
* Issue: gh-156995
<!-- /gh-issue-number -->
