### PR TITLE
gh-140971: Document pathlib.PurePath("") meaning and bool value

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -131,10 +131,14 @@ we also call *flavours*:
       >>> PurePath(Path('foo'), Path('bar'))
       PurePosixPath('foo/bar')
 
-   When *pathsegments* is empty, the current directory is assumed::
+   When *pathsegments* is empty or a single empty string,
+   the current directory is assumed::
 
-      >>> PurePath()
-      PurePosixPath('.')
+      >>> PurePath(), PurePath('')
+      (PurePosixPath('.'), PurePosixPath('.'))
+
+   The boolean value of either expression is True.
+   This differs from ``os.path.exists("")``, which returns ``False``.
 
    If a segment is an absolute path, all previous segments are ignored
    (like :func:`os.path.join`)::


### PR DESCRIPTION
pathlib.PurePath() and pathlib.PurePath('') both mean the current working directory and both have boolean value True.

Patch implements suggestion in
https://github.com/python/cpython/pull/140993#discussion_r2490858118.
 ---
Co-authored-by: LiuQhahah <liuqiang9596@gmail.com>



<!-- gh-issue-number: gh-140971 -->
* Issue: gh-140971
<!-- /gh-issue-number -->
