### PR TITLE
gh-115426: Fix the socket object close() cross-references

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1497,7 +1497,7 @@ Socket Objects
    of :meth:`socket.getpeername` but not the actual OS resource.  Unlike
    :func:`socket.fromfd`, *fileno* will return the same socket and not a
    duplicate. This may help close a detached socket using
-   :meth:`socket.close`.
+   :meth:`~socket.socket.close`.
 
    The newly created socket is :ref:`non-inheritable <fd_inheritance>`.
 
@@ -1544,7 +1544,7 @@ Socket Objects
 
    .. versionchanged:: 3.2
       Support for the :term:`context manager` protocol was added.  Exiting the
-      context manager is equivalent to calling :meth:`~socket.close`.
+      context manager is equivalent to calling :meth:`~socket.socket.close`.
 
 
    .. method:: accept()
@@ -1769,7 +1769,7 @@ Socket Objects
 
       Closing the file object returned by :meth:`makefile` won't close the
       original socket unless all other file objects have been closed and
-      :meth:`socket.close` has been called on the socket object.
+      :meth:`~socket.socket.close` has been called on the socket object.
 
       .. note::
 


### PR DESCRIPTION
The socket object's `close()` is documented as a method, but the three
cross-references to it resolved to the module-level `socket.close(fd)`
function instead, so clicking any of them landed on the wrong object.

`close` is the only name that is both a module-level function (added in 3.7)
and a socket method, and the Python domain matches `<module>.<target>` before
the class-scoped name, so `:meth:`socket.close`` hit the function and won.
Every other method reference on the page has no module-level homonym and
resolves correctly, which is probably why this went unnoticed. Qualifying the
target as `socket.socket.close` matches the neighbouring
`:meth:`~socket.socket.ioctl`` and `:meth:`~socket.socket.shutdown``.

Two of the three now render as `close()` rather than `socket.close()`. That
seemed right rather than incidental, since `socket.close()` is literally the
name of the fd function and `close()` is how every other socket method renders
on the page. The bare `:meth:`close`` references inside `close()`'s own
description are left alone: Sphinx drops the link on a self-reference, which I
checked is independent of this bug.

@zevisert diagnosed this correctly when filing the issue in 2024. I built the
docs to confirm the link targets before and after, with no change to the
nitpick warning count for `socket.rst`.

Drafted with AI assistance, reviewed and verified locally before opening.


<!-- gh-issue-number: gh-115426 -->
* Issue: gh-115426
<!-- /gh-issue-number -->
