### PR TITLE
gh-156909: Fix crash in repr() of AST nodes without _fields

### DIFF
--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -1165,6 +1165,20 @@ class AST_Tests(unittest.TestCase):
                                     r"Exceeds the limit \(\d+ digits\)"):
             repr(ast.Constant(value=eval(source)))
 
+    def test_repr_missing_fields_crash(self):
+        class FieldsMissingMeta(type):
+            def __getattribute__(self, name):
+                if name == "_fields":
+                    raise AttributeError
+                return super().__getattribute__(name)
+
+        class FieldsMissing(ast.AST, metaclass=FieldsMissingMeta):
+            def __init__(self):
+                pass
+
+        node = FieldsMissing()
+        self.assertEqual(repr(node), "FieldsMissing()")
+
     def test_tstring(self):
         # Test AST structure for simple t-string
         tree = ast.parse('t"Hello"')

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-09-11-11-34-02.gh-issue-156909.2Hgszb.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-09-11-11-34-02.gh-issue-156909.2Hgszb.rst
@@ -1,0 +1,2 @@
+Fix a crash in :func:`repr` of AST nodes when the AST node's type lacks the
+``_fields`` attribute. Patched by Shamil Abdulaev.

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -1498,6 +1498,11 @@ ast_repr_max_depth(AST_object *self, int depth)
         return NULL;
     }
 
+    if (fields == NULL) {
+        Py_ReprLeave((PyObject *)self);
+        return PyUnicode_FromFormat("%s()", Py_TYPE(self)->tp_name);
+    }
+
     Py_ssize_t numfields = PySequence_Size(fields);
     if (numfields < 0) {
         Py_ReprLeave((PyObject *)self);

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -5810,6 +5810,11 @@ ast_repr_max_depth(AST_object *self, int depth)
         return NULL;
     }
 
+    if (fields == NULL) {
+        Py_ReprLeave((PyObject *)self);
+        return PyUnicode_FromFormat("%s()", Py_TYPE(self)->tp_name);
+    }
+
     Py_ssize_t numfields = PySequence_Size(fields);
     if (numfields < 0) {
         Py_ReprLeave((PyObject *)self);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-156909 -->
* Issue: gh-156909
<!-- /gh-issue-number -->
