### PR TITLE
In Doc/library/re.rst rename variables from `match` to `m`

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -1483,8 +1483,8 @@ Since :meth:`~Pattern.match` and :meth:`~Pattern.search` return ``None``
 when there is no match, you can test whether there was a match with a simple
 ``if`` statement::
 
-   if match := re.search(pattern, string):
-       process(match)
+   if m := re.search(pattern, string):
+       process(m)
 
 .. class:: Match
 
@@ -1707,10 +1707,10 @@ Checking for a pair
 In this example, we'll use the following helper function to display match
 objects a little more gracefully::
 
-   def displaymatch(match):
-       if match is None:
+   def displaymatch(m):
+       if m is None:
            return None
-       return '<Match: %r, groups=%r>' % (match.group(), match.groups())
+       return '<Match: %r, groups=%r>' % (m.group(), m.groups())
 
 Suppose you are writing a poker program where a player's hand is represented as
 a 5-character string with each character representing a card, "a" for ace, "k"


### PR DESCRIPTION
`match` has been a soft keyword since version 3.10, so examples ought to not use it as the name of a variable.

https://docs.python.org/3/reference/lexical_analysis.html#soft-keywords

The new name, `m`, is used for match objects in other examples in re.rst.