### PR TITLE
base64: optimize b16decode

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -301,14 +301,11 @@ def b16decode(s, casefold=False, *, ignorechars=b''):
         s = _bytes_from_decode_data(s)
         if not isinstance(ignorechars, bytes):
             ignorechars = bytes(memoryview(ignorechars))
+        for b in b'abcdef':
+            if b in s and b not in ignorechars:
+                raise binascii.Error('Non-base16 digit found')
         if ignorechars:
-            for b in b'abcdef':
-                if b in s and b not in ignorechars:
-                    raise binascii.Error('Non-base16 digit found')
-        translated = s.translate(None, delete=b'abcdef')
-        if not ignorechars and len(translated) != len(s):
-            raise binascii.Error('Non-base16 digit found')
-        s = translated
+            s = s.translate(None, delete=b'abcdef')
     return binascii.unhexlify(s, ignorechars=ignorechars)
 
 #

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -301,10 +301,14 @@ def b16decode(s, casefold=False, *, ignorechars=b''):
         s = _bytes_from_decode_data(s)
         if not isinstance(ignorechars, bytes):
             ignorechars = bytes(memoryview(ignorechars))
-        for b in b'abcdef':
-            if b in s and b not in ignorechars:
-                raise binascii.Error('Non-base16 digit found')
-        s = s.translate(None, delete=b'abcdef')
+        if ignorechars:
+            for b in b'abcdef':
+                if b in s and b not in ignorechars:
+                    raise binascii.Error('Non-base16 digit found')
+        translated = s.translate(None, delete=b'abcdef')
+        if not ignorechars and len(translated) != len(s):
+            raise binascii.Error('Non-base16 digit found')
+        s = translated
     return binascii.unhexlify(s, ignorechars=ignorechars)
 
 #

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -886,6 +886,27 @@ class BaseXYTestCase(unittest.TestCase):
         # Incorrect "padding"
         self.assertRaises(binascii.Error, base64.b16decode, '010')
 
+    def test_b16decode_empty_ignorechars(self):
+        for ignorechars in (b'', bytearray(), memoryview(b'')):
+            with self.subTest(ignorechars=ignorechars):
+                self.assertEqual(base64.b16decode(b'', ignorechars=ignorechars),
+                                 b'')
+                self.assertEqual(base64.b16decode(b'00AF', ignorechars=ignorechars),
+                                 b'\x00\xaf')
+                # Deleting a lowercase digit must not turn invalid input
+                # into valid input, including an empty string.
+                for digit in b'abcdef':
+                    lower = bytes([digit])
+                    for data in (lower, lower * 2, lower + b'00',
+                                 b'0' + lower + b'0', b'00' + lower):
+                        for s in (data, data.decode('ascii'),
+                                  bytearray(data), memoryview(data)):
+                            with self.subTest(s=s):
+                                with self.assertRaisesRegex(
+                                    binascii.Error, '^Non-base16 digit found$'
+                                ):
+                                    base64.b16decode(s, ignorechars=ignorechars)
+
     def test_b16decode_ignorechars(self):
         self._common_test_ignorechars(base64.b16decode)
         eq = self.assertEqual

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -886,27 +886,6 @@ class BaseXYTestCase(unittest.TestCase):
         # Incorrect "padding"
         self.assertRaises(binascii.Error, base64.b16decode, '010')
 
-    def test_b16decode_empty_ignorechars(self):
-        for ignorechars in (b'', bytearray(), memoryview(b'')):
-            with self.subTest(ignorechars=ignorechars):
-                self.assertEqual(base64.b16decode(b'', ignorechars=ignorechars),
-                                 b'')
-                self.assertEqual(base64.b16decode(b'00AF', ignorechars=ignorechars),
-                                 b'\x00\xaf')
-                # Deleting a lowercase digit must not turn invalid input
-                # into valid input, including an empty string.
-                for digit in b'abcdef':
-                    lower = bytes([digit])
-                    for data in (lower, lower * 2, lower + b'00',
-                                 b'0' + lower + b'0', b'00' + lower):
-                        for s in (data, data.decode('ascii'),
-                                  bytearray(data), memoryview(data)):
-                            with self.subTest(s=s):
-                                with self.assertRaisesRegex(
-                                    binascii.Error, '^Non-base16 digit found$'
-                                ):
-                                    base64.b16decode(s, ignorechars=ignorechars)
-
     def test_b16decode_ignorechars(self):
         self._common_test_ignorechars(base64.b16decode)
         eq = self.assertEqual


### PR DESCRIPTION
When `ignorechars` is empty, we already know that `[a-f]` is not present in the byte string, so we skip the call to `str.translate()`. Even when `str.translate()` does not modify the string at all, it internally creates a temporary bytes object, so this saves a small amount of time.