### PR TITLE
gh-150167: Prevent successful import of `bz2` under lazy_imports=all if `_bz2` is unavailable

### DIFF
--- a/Lib/bz2.py
+++ b/Lib/bz2.py
@@ -14,6 +14,7 @@ from compression._common import _streams
 import io
 import os
 
+import _bz2; _bz2  # Force the eager import of _bz2
 from _bz2 import BZ2Compressor, BZ2Decompressor
 
 

--- a/Lib/test/test_bz2.py
+++ b/Lib/test/test_bz2.py
@@ -1222,6 +1222,20 @@ class OpenTest(BaseTest):
             self.assertEqual(f.readlines(), [text])
 
 
+class TestMissingModuleImport(unittest.TestCase):
+    # Test that module import fails if _bz2 is not available
+    # See: https://github.com/python/cpython/issues/150167
+    @support.thread_unsafe("Modifies global import state")
+    def test_under_lazy_all(self):
+        import_state = sys.get_lazy_imports()
+        try:
+            sys.set_lazy_imports("all")
+            with self.assertRaises(ImportError):
+                import_helper.import_fresh_module("bz2", blocked=("_bz2",))
+        finally:
+            sys.set_lazy_imports(import_state)
+
+
 def tearDownModule():
     support.reap_children()
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Adds `import _bz2; _bz2` to bz2.py which has the effect of making the import eager even under the 'all' lazy imports mode. 

The import-ability of `bz2` is used in some places to detect if the format is supported. The other compression formats all already use the relevant internal module at module level but `bz2` does not.

<!-- gh-issue-number: gh-150167 -->
* Issue: gh-150167
<!-- /gh-issue-number -->
