### PR TITLE
gh-157265: Adjust test for Windows

### DIFF
--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -4621,15 +4621,15 @@ class TestExtractionFilters(unittest.TestCase):
         for filter in 'tar', 'fully_trusted':
             with self.subTest(filter), self.check_context(arc.open(), filter):
                 if not os_helper.can_symlink():
-                    if filter == 'tar':
+                    if filter == 'fully_trusted' or sys.platform == "win32":
+                        self.expect_file("a/t/dummy")
+                        self.expect_file("b/")
+                        self.expect_file("c/")
+                    else:
                         self.expect_exception(
                             tarfile.LinkFallbackError,
                             "link 'boom' would be extracted as a copy of "
                             + "'c/escape', which was rejected")
-                    else:
-                        self.expect_file("a/t/dummy")
-                        self.expect_file("b/")
-                        self.expect_file("c/")
                 else:
                     self.expect_file("a/t/dummy")
                     self.expect_file("b/")


### PR DESCRIPTION
On my Windows box (without developer mode), the behaviour is the same as without the fix in GH-157266:
- a/t/dummy is extracted
- b/ is extracted
- c/ is *not* created (the target, a/t, is not in the archive)
- c/escape: c/ is created; escape is skipped (target, c/../../link_here, is not in archive)
- c is not recreated as a directory
- boom is not created (target is c/escape, which falls back to ../../link_here, which does not exist in archive)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-157265 -->
* Issue: gh-157265
<!-- /gh-issue-number -->
