### PR TITLE
gh-136722: Document TurtleGraphicsError

### DIFF
--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -2571,6 +2571,16 @@ Public classes
    * ``a.rotate(angle)`` rotation
 
 
+Exceptions
+==========
+
+.. exception:: TurtleGraphicsError
+
+   Raised when an invalid turtle graphics operation is requested, such as
+   using an unsupported shape or an invalid color value.
+   This exception inherits from :exc:`Exception`.
+
+
 .. _turtle-explanation:
 
 Explanation


### PR DESCRIPTION
## Summary

Document `turtle.TurtleGraphicsError` in a dedicated Exceptions section, including its base class and examples of invalid operations that raise it.

This adds the missing API reference entry without changing runtime behavior.

## Validation

- `make -C Doc html SPHINXOPTS="-W --keep-going"` — passed
- `Doc/venv/bin/python -m pre_commit run sphinx-lint --files Doc/library/turtle.rst` — passed
- `git diff --check` — passed

Fixes #136722.


<!-- gh-issue-number: gh-136722 -->
* Issue: gh-136722
<!-- /gh-issue-number -->
