### PR TITLE
gh-157242: Do not close io.BytesIO on MemoryError

### DIFF
--- a/Lib/test/test_io/test_memoryio.py
+++ b/Lib/test/test_io/test_memoryio.py
@@ -5,6 +5,7 @@ BytesIO -- for bytes
 
 import unittest
 from test import support
+from test.support import import_helper
 
 import gc
 import io
@@ -752,6 +753,35 @@ class PyBytesIOTest(MemoryTestMixin, MemorySeekTestMixin, unittest.TestCase):
         self.assertEqual(n, 3)
         self.assertEqual(memio.getvalue(), b"01AAA56789")
         self.assertEqual(memio.tell(), 5)
+
+    def test_memory_error(self):
+        # gh-157242: io.BytesIO() must not close the file on MemoryError
+        _testcapi = import_helper.import_module('_testcapi')
+
+        # write()
+        stream = self.ioclass()
+        stream.write(self.buftype('abc'))
+        with self.assertRaises(MemoryError):
+            try:
+                data = self.buftype('def')
+                _testcapi.set_nomemory(0)
+                stream.write(data)
+            finally:
+                _testcapi.remove_mem_hooks()
+        stream.write(self.buftype('123'))
+        self.assertEqual(stream.getvalue(), self.buftype('abc123'))
+
+        # truncate()
+        data = self.buftype('x' * 100)
+        stream = self.ioclass()
+        stream.write(data)
+        with self.assertRaises(MemoryError):
+            try:
+                _testcapi.set_nomemory(0)
+                stream.truncate(5)
+            finally:
+                _testcapi.remove_mem_hooks()
+        self.assertEqual(stream.getvalue(), data)
 
 
 class TextIOTestMixin:

--- a/Misc/NEWS.d/next/Library/2026-09-12-03-14-57.gh-issue-157242.ycbtjC.rst
+++ b/Misc/NEWS.d/next/Library/2026-09-12-03-14-57.gh-issue-157242.ycbtjC.rst
@@ -1,0 +1,2 @@
+:class:`io.BytesIO` is no longer closed on ``write()`` and ``truncate()``
+failure (:exc:`MemoryError`). Patch by Victor Stinner.

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -1,4 +1,5 @@
 #include "Python.h"
+#include "pycore_bytesobject.h"       // _PyBytes_ResizeKeepOnError()
 #include "pycore_critical_section.h"  // Py_BEGIN_CRITICAL_SECTION()
 #include "pycore_object.h"
 #include "pycore_pyatomic_ft_wrappers.h"
@@ -108,7 +109,7 @@ resize_unshared_buffer_lock_held(bytesio *self, Py_ssize_t size)
        Callers must detach first. */
     assert(!self->buf_shared);
 #endif
-    int ret = _PyBytes_Resize(&self->buf, size);
+    int ret = _PyBytes_ResizeKeepOnError(&self->buf, size);
     if (ret == 0) {
         clear_shared_buf(self);
     }
@@ -758,9 +759,10 @@ _io_BytesIO_truncate_impl(bytesio *self, PyObject *size)
     }
 
     if (new_size < self->string_size) {
-        self->string_size = new_size;
-        if (resize_buffer_lock_held(self, new_size) < 0)
+        if (resize_buffer_lock_held(self, new_size) < 0) {
             return NULL;
+        }
+        self->string_size = new_size;
     }
 
     return PyLong_FromSsize_t(new_size);

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -759,10 +759,12 @@ _io_BytesIO_truncate_impl(bytesio *self, PyObject *size)
     }
 
     if (new_size < self->string_size) {
+        Py_ssize_t old_string_size = self->string_size;
+        self->string_size = new_size;
         if (resize_buffer_lock_held(self, new_size) < 0) {
+            self->string_size = old_string_size;
             return NULL;
         }
-        self->string_size = new_size;
     }
 
     return PyLong_FromSsize_t(new_size);


### PR DESCRIPTION
Replace _PyBytes_Resize() with _PyBytes_ResizeKeepOnError().

Fix truncate(): only set string_size on resize success.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-157242 -->
* Issue: gh-157242
<!-- /gh-issue-number -->
