### PR TITLE
gh-157242: Fix test_capi on Py_TRACE_REFS build

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -1569,6 +1569,7 @@ class ByteArrayTest(BaseBytesTest, unittest.TestCase):
         self.assertRaises(MemoryError, bytearray().resize, sys.maxsize)
         self.assertRaises(MemoryError, bytearray(1000).resize, sys.maxsize)
 
+    @support.nomemtest
     def test_resize_error(self):
         # gh-157242: If bytearray.resize() fails (MemoryError),
         # the bytearray must be left unchanged.
@@ -1662,6 +1663,7 @@ class ByteArrayTest(BaseBytesTest, unittest.TestCase):
         self.assertEqual(ba, bytearray(b'A'))
         self.assertEqual(ord(b'c'), ord('c'))
 
+    @support.nomemtest
     def test_take_bytes_error(self):
         # gh-157242: If bytearray.take_bytes() fails (MemoryError),
         # the bytearray must be left unchanged.

--- a/Lib/test/test_capi/test_bytes.py
+++ b/Lib/test/test_capi/test_bytes.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+from test import support
 from test.support import import_helper
 
 _testlimitedcapi = import_helper.import_module('_testlimitedcapi')
@@ -389,6 +390,7 @@ class BaseWriterTest:
         writer.resize(len(b'number=123456'), b'456')
         self.assertEqual(writer.finish(), self.result_type(b'number=123456'))
 
+    @support.nomemtest
     def test_resize_error(self):
         small_buffer = _testcapi.PyBytesWriter_small_buffer
         init = b'x' * (small_buffer * 2)
@@ -463,6 +465,10 @@ class BytesWriterTest(BaseWriterTest, unittest.TestCase):
 
     def test_example_highlevel(self):
         self.assertEqual(_testcapi.byteswriter_highlevel(), b'Hello World!')
+
+    @support.nomemtest
+    def test_bytes_resize_tracer(self):
+        _testcapi._test_bytes_resize_tracer()
 
 
 class ByteArrayWriterTest(BaseWriterTest, unittest.TestCase):

--- a/Modules/_testcapi/mem.c
+++ b/Modules/_testcapi/mem.c
@@ -943,7 +943,7 @@ error:
 
 
 static PyObject*
-test_bytes_resize_tracer(PyObject *self, PyObject *Py_UNUSED(ignored))
+_test_bytes_resize_tracer(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     if (check_bytes_resize_tracer(0) < 0) {
         return NULL;
@@ -972,7 +972,7 @@ static PyMethodDef test_methods[] = {
 #if TARGET_OS_OSX || defined(__FreeBSD__)
     {"get_process_memory_usage",      get_process_memory_usage,      METH_VARARGS},
 #endif
-    {"test_bytes_resize_tracer",      test_bytes_resize_tracer,      METH_NOARGS},
+    {"_test_bytes_resize_tracer",      _test_bytes_resize_tracer,      METH_NOARGS},
 
     // Tracemalloc tests
     {"tracemalloc_track",             tracemalloc_track,             METH_VARARGS},


### PR DESCRIPTION
Mark tests using set_nomemory() with @support.nomemtest to skip these tests on a Py_TRACE_REFS build.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-157242 -->
* Issue: gh-157242
<!-- /gh-issue-number -->
