### PR TITLE
gh-132509: Speed up bytes iteration in FOR_ITER_VIRTUAL

### DIFF
--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -2094,6 +2094,18 @@ class TestSpecializer(TestBase):
         self.assert_specialized(for_iter_tuple, "FOR_ITER_TUPLE")
         self.assert_no_opcode(for_iter_tuple, "FOR_ITER")
 
+        b = b"\x00\x7f\x80\xff" * 3
+        result = []
+        def for_iter_bytes():
+            result.clear()
+            for i in b:
+                result.append(i)
+
+        for_iter_bytes()
+        self.assertEqual(result, list(b))
+        self.assert_specialized(for_iter_bytes, "FOR_ITER_VIRTUAL")
+        self.assert_no_opcode(for_iter_bytes, "FOR_ITER")
+
         s = "abcdefghij"
         def for_iter_str():
             for i in s:

--- a/Misc/NEWS.d/next/Core_and_Builtins/2026-09-12-12-14-00.gh-issue-132509.bytes-iter.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2026-09-12-12-14-00.gh-issue-132509.bytes-iter.rst
@@ -1,0 +1,2 @@
+Speed up iteration over exact :class:`bytes` objects by inlining item
+retrieval in the bytecode interpreter.

--- a/Modules/_testinternalcapi/test_cases.c.h
+++ b/Modules/_testinternalcapi/test_cases.c.h
@@ -6674,10 +6674,33 @@
                 iter = stack_pointer[-2];
                 PyObject *iter_o = PyStackRef_AsPyObjectBorrow(iter);
                 Py_ssize_t index = PyStackRef_UntagInt(null_or_index);
-                _PyFrame_SetStackPointer(frame, stack_pointer);
-                _PyFrame_StackPointerValidate(frame);
-                _PyObjectIndexPair next_index = Py_TYPE(iter_o)->_tp_iteritem(iter_o, index);
-                _PyFrame_StackPointerInvalidate(frame);
+                _PyObjectIndexPair next_index;
+                if (PyBytes_CheckExact(iter_o)) {
+                    if ((size_t)index >= (size_t)PyBytes_GET_SIZE(iter_o)) {
+                        next_index = (_PyObjectIndexPair) {
+                            .object = NULL,
+                            .index = index,
+                        };
+                    }
+                    else {
+                        _PyFrame_SetStackPointer(frame, stack_pointer);
+                        _PyFrame_StackPointerValidate(frame);
+                        unsigned char value = (unsigned char)
+                        ((PyBytesObject *)iter_o)->ob_sval[index];
+                        _PyFrame_StackPointerInvalidate(frame);
+                        next_index = (_PyObjectIndexPair) {
+                            .object = (PyObject *)&_PyLong_SMALL_INTS[
+                            _PY_NSMALLNEGINTS + value],
+                            .index = index + 1,
+                        };
+                    }
+                }
+                else {
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    _PyFrame_StackPointerValidate(frame);
+                    next_index = Py_TYPE(iter_o)->_tp_iteritem(iter_o, index);
+                    _PyFrame_StackPointerInvalidate(frame);
+                }
                 PyObject *next_o = next_index.object;
                 index = next_index.index;
                 if (next_o == NULL) {

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -3883,7 +3883,27 @@ dummy_func(
         replaced op(_FOR_ITER_VIRTUAL, (iter, null_or_index -- iter, null_or_index, next)) {
             PyObject *iter_o = PyStackRef_AsPyObjectBorrow(iter);
             Py_ssize_t index = PyStackRef_UntagInt(null_or_index);
-            _PyObjectIndexPair next_index = Py_TYPE(iter_o)->_tp_iteritem(iter_o, index);
+            _PyObjectIndexPair next_index;
+            if (PyBytes_CheckExact(iter_o)) {
+                if ((size_t)index >= (size_t)PyBytes_GET_SIZE(iter_o)) {
+                    next_index = (_PyObjectIndexPair) {
+                        .object = NULL,
+                        .index = index,
+                    };
+                }
+                else {
+                    unsigned char value = (unsigned char)
+                        ((PyBytesObject *)iter_o)->ob_sval[index];
+                    next_index = (_PyObjectIndexPair) {
+                        .object = (PyObject *)&_PyLong_SMALL_INTS[
+                            _PY_NSMALLNEGINTS + value],
+                        .index = index + 1,
+                    };
+                }
+            }
+            else {
+                next_index = Py_TYPE(iter_o)->_tp_iteritem(iter_o, index);
+            }
             PyObject *next_o = next_index.object;
             index = next_index.index;
             if (next_o == NULL) {

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -6674,10 +6674,33 @@
                 iter = stack_pointer[-2];
                 PyObject *iter_o = PyStackRef_AsPyObjectBorrow(iter);
                 Py_ssize_t index = PyStackRef_UntagInt(null_or_index);
-                _PyFrame_SetStackPointer(frame, stack_pointer);
-                _PyFrame_StackPointerValidate(frame);
-                _PyObjectIndexPair next_index = Py_TYPE(iter_o)->_tp_iteritem(iter_o, index);
-                _PyFrame_StackPointerInvalidate(frame);
+                _PyObjectIndexPair next_index;
+                if (PyBytes_CheckExact(iter_o)) {
+                    if ((size_t)index >= (size_t)PyBytes_GET_SIZE(iter_o)) {
+                        next_index = (_PyObjectIndexPair) {
+                            .object = NULL,
+                            .index = index,
+                        };
+                    }
+                    else {
+                        _PyFrame_SetStackPointer(frame, stack_pointer);
+                        _PyFrame_StackPointerValidate(frame);
+                        unsigned char value = (unsigned char)
+                        ((PyBytesObject *)iter_o)->ob_sval[index];
+                        _PyFrame_StackPointerInvalidate(frame);
+                        next_index = (_PyObjectIndexPair) {
+                            .object = (PyObject *)&_PyLong_SMALL_INTS[
+                            _PY_NSMALLNEGINTS + value],
+                            .index = index + 1,
+                        };
+                    }
+                }
+                else {
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    _PyFrame_StackPointerValidate(frame);
+                    next_index = Py_TYPE(iter_o)->_tp_iteritem(iter_o, index);
+                    _PyFrame_StackPointerInvalidate(frame);
+                }
                 PyObject *next_o = next_index.object;
                 index = next_index.index;
                 if (next_o == NULL) {


### PR DESCRIPTION

Benchmark | Main| PR| Throughput improvement
-- | -- | -- | --
Empty loop | 13.858 ns/item | 11.850 ns/item | 16.9% faster
XOR accumulation | 28.195 ns/item | 25.409 ns/item | 11.0% faster
Conditional count | 28.649 ns/item | 24.721 ns/item | 15.9% faster

<details> test script

```python
import statistics
import timeit

DATA = bytes(range(256)) * 4096  # 1 MiB
NUMBER = 10
REPEAT = 11


def loop_pass():
    for byte in DATA:
        pass


def loop_xor():
    result = 0
    for byte in DATA:
        result ^= byte
    return result


def loop_count():
    result = 0
    for byte in DATA:
        if byte == 255:
            result += 1
    return result


BENCHMARKS = (
    ("empty loop", loop_pass),
    ("xor accumulation", loop_xor),
    ("conditional count", loop_count),
)

# Warm up adaptive specialization.
for _, benchmark in BENCHMARKS:
    for _ in range(10):
        benchmark()

print("| Benchmark | Median | Minimum | Median ns/item |")
print("|---|---:|---:|---:|")

for name, benchmark in BENCHMARKS:
    samples = timeit.repeat(
        benchmark,
        number=NUMBER,
        repeat=REPEAT,
    )
    median = statistics.median(samples)
    minimum = min(samples)
    ns_per_item = median * 1e9 / (NUMBER * len(DATA))
    print(
        f"| {name} | {median:.9f} s | "
        f"{minimum:.9f} s | {ns_per_item:.3f} |"
    )
```
</details>

<!-- gh-issue-number: gh-132509 -->
* Issue: gh-132509
<!-- /gh-issue-number -->
