### PR TITLE
ci: Reduce CI for draft pull requests

### DIFF
--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -1,6 +1,7 @@
 name: JIT
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     paths: &paths
       - '**jit**'
       - 'Python/bytecodes.c'
@@ -47,6 +48,7 @@ jobs:
           ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
   windows:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: ${{ matrix.target }} (${{ matrix.debug && 'Debug' || 'Release' }})
 
     runs-on: ${{ matrix.runner }}
@@ -87,6 +89,7 @@ jobs:
           ./PCbuild/rt.bat ${{ matrix.debug && '-d' || '' }} -p ${{ matrix.architecture }} -q --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
   macos:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: ${{ matrix.target }} (${{ matrix.debug && 'Debug' || 'Release' }})
 
     runs-on: ${{ matrix.runner }}
@@ -130,6 +133,7 @@ jobs:
           ./python.exe -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
   linux:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: ${{ matrix.target }} (${{ matrix.debug && 'Debug' || 'Release' }})
 
     runs-on: ${{ matrix.runner }}
@@ -168,6 +172,7 @@ jobs:
           ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
   linux-extras:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: ${{ matrix.name }}
 
     runs-on: ubuntu-26.04

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -1,7 +1,7 @@
 name: JIT
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths: &paths
       - '**jit**'
       - 'Python/bytecodes.c'

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - ".github/workflows/mypy.yml"
       - "Lib/_colorize.py"
@@ -48,6 +49,7 @@ concurrency:
 
 jobs:
   mypy:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Run mypy on ${{ matrix.target }}
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ready-for-review.yml
+++ b/.github/workflows/ready-for-review.yml
@@ -1,0 +1,20 @@
+name: Full tests when ready for review
+
+on:
+  pull_request:
+    types: [ready_for_review]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch-tests:
+    name: Dispatch full test matrix
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Tests workflow on the PR branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: gh workflow run build.yml --ref "$HEAD_REF"

--- a/.github/workflows/reusable-context.yml
+++ b/.github/workflows/reusable-context.yml
@@ -60,17 +60,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      run-android: ${{ steps.changes.outputs.run-android }}
-      run-ci-fuzz: ${{ steps.changes.outputs.run-ci-fuzz }}
-      run-ci-fuzz-stdlib: ${{ steps.changes.outputs.run-ci-fuzz-stdlib }}
-      run-docs: ${{ steps.changes.outputs.run-docs }}
-      run-ios: ${{ steps.changes.outputs.run-ios }}
-      run-macos: ${{ steps.changes.outputs.run-macos }}
-      run-tests: ${{ steps.changes.outputs.run-tests }}
-      run-ubuntu: ${{ steps.changes.outputs.run-ubuntu }}
-      run-emscripten: ${{ steps.changes.outputs.run-emscripten }}
-      run-wasi: ${{ steps.changes.outputs.run-wasi }}
-      run-windows-tests: ${{ steps.changes.outputs.run-windows-tests }}
+      run-android: ${{ steps.filtered.outputs.run-android }}
+      run-ci-fuzz: ${{ steps.filtered.outputs.run-ci-fuzz }}
+      run-ci-fuzz-stdlib: ${{ steps.filtered.outputs.run-ci-fuzz-stdlib }}
+      run-docs: ${{ steps.filtered.outputs.run-docs }}
+      run-ios: ${{ steps.filtered.outputs.run-ios }}
+      run-macos: ${{ steps.filtered.outputs.run-macos }}
+      run-tests: ${{ steps.filtered.outputs.run-tests }}
+      run-ubuntu: ${{ steps.filtered.outputs.run-ubuntu }}
+      run-emscripten: ${{ steps.filtered.outputs.run-emscripten }}
+      run-wasi: ${{ steps.filtered.outputs.run-wasi }}
+      run-windows-tests: ${{ steps.filtered.outputs.run-windows-tests }}
     steps:
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -123,3 +123,51 @@ jobs:
         GITHUB_EVENT_NAME: ${{ github.event_name }}
         CCF_TARGET_REF: ${{ github.base_ref || github.event.repository.default_branch }}
         CCF_HEAD_REF: ${{ github.event.pull_request.head.sha || github.sha }}
+
+    # Draft PRs are still useful for early feedback, but running the complete
+    # platform matrix on every incremental push is unnecessarily expensive.
+    # Dedicated lightweight workflows (for example lint and JIT's interpreter
+    # build) can continue to run while these outputs suppress the full matrix.
+    - name: Filter draft PRs
+      id: filtered
+      shell: bash
+      run: |
+        if [[ "${DRAFT_PR}" == "true" ]]; then
+          value=false
+          echo "run-android=${value}" >> "$GITHUB_OUTPUT"
+          echo "run-ci-fuzz=${value}" >> "$GITHUB_OUTPUT"
+          echo "run-ci-fuzz-stdlib=${value}" >> "$GITHUB_OUTPUT"
+          echo "run-docs=${value}" >> "$GITHUB_OUTPUT"
+          echo "run-ios=${value}" >> "$GITHUB_OUTPUT"
+          echo "run-macos=${value}" >> "$GITHUB_OUTPUT"
+          echo "run-tests=${value}" >> "$GITHUB_OUTPUT"
+          echo "run-ubuntu=${value}" >> "$GITHUB_OUTPUT"
+          echo "run-emscripten=${value}" >> "$GITHUB_OUTPUT"
+          echo "run-wasi=${value}" >> "$GITHUB_OUTPUT"
+          echo "run-windows-tests=${value}" >> "$GITHUB_OUTPUT"
+        else
+          echo "run-android=${RUN_ANDROID}" >> "$GITHUB_OUTPUT"
+          echo "run-ci-fuzz=${RUN_CI_FUZZ}" >> "$GITHUB_OUTPUT"
+          echo "run-ci-fuzz-stdlib=${RUN_CI_FUZZ_STDLIB}" >> "$GITHUB_OUTPUT"
+          echo "run-docs=${RUN_DOCS}" >> "$GITHUB_OUTPUT"
+          echo "run-ios=${RUN_IOS}" >> "$GITHUB_OUTPUT"
+          echo "run-macos=${RUN_MACOS}" >> "$GITHUB_OUTPUT"
+          echo "run-tests=${RUN_TESTS}" >> "$GITHUB_OUTPUT"
+          echo "run-ubuntu=${RUN_UBUNTU}" >> "$GITHUB_OUTPUT"
+          echo "run-emscripten=${RUN_EMSCRIPTEN}" >> "$GITHUB_OUTPUT"
+          echo "run-wasi=${RUN_WASI}" >> "$GITHUB_OUTPUT"
+          echo "run-windows-tests=${RUN_WINDOWS_TESTS}" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        DRAFT_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft }}
+        RUN_ANDROID: ${{ steps.changes.outputs.run-android }}
+        RUN_CI_FUZZ: ${{ steps.changes.outputs.run-ci-fuzz }}
+        RUN_CI_FUZZ_STDLIB: ${{ steps.changes.outputs.run-ci-fuzz-stdlib }}
+        RUN_DOCS: ${{ steps.changes.outputs.run-docs }}
+        RUN_IOS: ${{ steps.changes.outputs.run-ios }}
+        RUN_MACOS: ${{ steps.changes.outputs.run-macos }}
+        RUN_TESTS: ${{ steps.changes.outputs.run-tests }}
+        RUN_UBUNTU: ${{ steps.changes.outputs.run-ubuntu }}
+        RUN_EMSCRIPTEN: ${{ steps.changes.outputs.run-emscripten }}
+        RUN_WASI: ${{ steps.changes.outputs.run-wasi }}
+        RUN_WINDOWS_TESTS: ${{ steps.changes.outputs.run-windows-tests }}

--- a/.github/workflows/tail-call.yml
+++ b/.github/workflows/tail-call.yml
@@ -1,6 +1,7 @@
 name: Tail calling interpreter
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths: &paths
       - '.github/workflows/tail-call.yml'
       - 'Python/bytecodes.c'
@@ -24,6 +25,7 @@ env:
 
 jobs:
   macos:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
@@ -58,6 +60,7 @@ jobs:
           ./python.exe -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
   linux:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60


### PR DESCRIPTION
### Summary

Reduce GitHub Actions load while a pull request is still a draft.

- The main `Tests` workflow still computes the changed-file context, but draft PRs suppress the expensive platform/test outputs.
- `Lint` remains unchanged and continues to run on draft PRs.
- The JIT workflow keeps only its Ubuntu interpreter/debug job for draft PRs; Windows, macOS, Linux matrix, and JIT extras wait until the PR is ready for review.
- `mypy` and tail-call matrices are skipped for draft PRs.
- Marking the PR ready for review re-enables the JIT/mypy/tail-call workflows via `ready_for_review`, and a small dispatcher starts the full `Tests` workflow on the PR branch.

### Motivation

Large experimental changes often get many incremental pushes while they are still under development. Running the complete CPython CI matrix for each of those pushes consumes substantial runner capacity while providing relatively little additional signal. Draft PRs already communicate that the change is not ready for full review, so they are a useful boundary for lightweight vs. full CI.

This keeps early feedback (lint plus a representative JIT build/test when JIT-related files change) while deferring the expensive cross-platform matrices until the author explicitly marks the PR ready.

### Behavior

Draft PR push:
- change detection
- lint
- JIT interpreter/debug build+test when relevant
- full Tests/JIT/mypy/tail-call matrices skipped

Ready for review:
- full Tests workflow is dispatched on the PR branch
- JIT/mypy/tail-call workflows run normally when their path filters match

Pushes to `main`, manual workflow dispatches, and non-draft PRs keep the existing behavior.